### PR TITLE
17 prepare epc reweighting

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -22,3 +22,19 @@ usecols:
     - NUMBER_HABITABLE_ROOMS
     - HEATING_SYSTEM
     - HEATING_FUEL
+mapping:
+  pre_post_1930_epc:
+    "England and Wales: before 1900": "pre_1930"
+    "Scotland: before 1919": "pre_1930"
+    "1900-1929": "pre_1930"
+    "1930-1949": "post_1930"
+    "1950-1966": "post_1930"
+    "1965-1975": "post_1930"
+    "1976-1983": "post_1930"
+    "1983-1991": "post_1930"
+    "1991-1998": "post_1930"
+    "1996-2002": "post_1930"
+    "2003-2007": "post_1930"
+    "2007 onwards": "post_1930"
+    "unknown": "unknown"
+    "UNKNOWN": "unknown"

--- a/asf_heat_pump_suitability/pipeline/enhance_epc/run_script.py
+++ b/asf_heat_pump_suitability/pipeline/enhance_epc/run_script.py
@@ -32,7 +32,7 @@ def run():
     main(**vars(args))
 
 
-def main(epc_path: str, save_output: Optional[str]) -> pl.DataFrame:
+def main(epc_path: str, save_output: Optional[str] = None) -> pl.DataFrame:
     """
     Enhance EPC dataset with additional features: LSOA; MSOA.
 

--- a/asf_heat_pump_suitability/pipeline/enhance_epc/run_script.py
+++ b/asf_heat_pump_suitability/pipeline/enhance_epc/run_script.py
@@ -6,6 +6,7 @@ from typing import Optional
 from argparse import ArgumentParser
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.pipeline.enhance_epc import enhance_epc
+from asf_heat_pump_suitability.pipeline.reweight_epc import reweight_epc
 
 
 def run():
@@ -53,6 +54,8 @@ def main(epc_path: str, save_output: Optional[str]) -> pl.DataFrame:
 
     # Join ONSPD LSOA col
     enhanced_epc_df = enhance_epc.join_df_additional_features(epc_df)
+    # Prepare EPC df for reweighting
+    enhanced_epc_df = reweight_epc.add_cols_weighting_features(enhanced_epc_df)
 
     # Save to S3
     if save_output:

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
@@ -2,6 +2,21 @@ import polars as pl
 from asf_heat_pump_suitability import config
 
 
+def add_cols_weighting_features(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Add standardised feature columns to be used for weighting, to EPC dataset.
+
+    Args:
+        df (pl.DataFrame): EPC dataset
+
+    Returns:
+        pl.DataFrame: EPC dataset with standardised feature columns
+    """
+    df = add_col_property_type(df)
+    df = add_col_nrooms(df)
+    return add_col_build_year_1930(df)
+
+
 def add_col_property_type(df: pl.DataFrame) -> pl.DataFrame:
     """
     Add `property_type` column to EPC dataset with property type categories corresponding to those from the census.
@@ -58,7 +73,7 @@ def add_col_nrooms(df: pl.DataFrame) -> pl.DataFrame:
     return df.with_columns(
         pl.col("NUMBER_HABITABLE_ROOMS")
         .map_elements(lambda x: 9 if x > 9 else x, return_dtype=pl.Float32)
-        .cast(pl.Int16)
+        .cast(pl.Int8)
         .alias("number_of_rooms")
     )
 

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
@@ -73,16 +73,8 @@ def add_col_build_year_1930(df: pl.DataFrame) -> pl.DataFrame:
     Returns:
         pl.DataFrame: EPC dataset with `build_year` column
     """
-    pre = config["mapping"]["build_year_pre_cols_epc"]
-    post = config["mapping"]["build_year_post_cols_epc"]
-
-    df = df.with_columns(
-        pl.when(pl.col("CONSTRUCTION_AGE_BAND").is_in(pre))
-        .then(pl.lit("pre_1930"))
-        .when(pl.col("CONSTRUCTION_AGE_BAND").is_in(post))
-        .then(pl.lit("post_1930"))
-        .otherwise(pl.lit("unknown"))
+    return df.with_columns(
+        pl.col("CONSTRUCTION_AGE_BAND")
+        .map_dict(config["mapping"]["pre_post_1930_epc"])
         .alias("build_year")
     )
-
-    return df

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
@@ -52,7 +52,7 @@ def add_col_property_type(df: pl.DataFrame) -> pl.DataFrame:
         .then(pl.lit("Terraced (including end-terrace) whole house or bungalow"))
         .when(pl.col("PROPERTY_TYPE").is_in(["Flat", "Maisonette"]))
         .then(pl.lit("Flat, maisonette or apartment"))
-        .when(pl.col("PROPERTY_TYPE").is_in(["Park Home"]))
+        .when(pl.col("PROPERTY_TYPE").is_in(["Park home"]))
         .then(pl.lit("A caravan or other mobile or temporary structure"))
         .alias("property_type")
     )

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
@@ -1,0 +1,88 @@
+import polars as pl
+from asf_heat_pump_suitability import config
+
+
+def add_col_property_type(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Add `property_type` column to EPC dataset with property type categories corresponding to those from the census.
+
+    Args:
+        df (pl.DataFrame): EPC dataset
+
+    Returns:
+        pl.DataFrame: EPC dataset with `property_type` column
+    """
+    terraced = [
+        "Mid-Terrace",
+        "End-Terrace",
+        "Enclosed Mid-Terrace",
+        "Enclosed End-Terrace",
+    ]
+
+    df = df.with_columns(
+        pl.when(
+            pl.col("PROPERTY_TYPE").is_in(["House", "Bungalow"]),
+            pl.col("BUILT_FORM") == "Detached",
+        )
+        .then(pl.lit("Detached whole house or bungalow"))
+        .when(
+            pl.col("PROPERTY_TYPE").is_in(["House", "Bungalow"]),
+            pl.col("BUILT_FORM") == "Semi-Detached",
+        )
+        .then(pl.lit("Semi-detached whole house or bungalow"))
+        .when(
+            pl.col("PROPERTY_TYPE").is_in(["House", "Bungalow"]),
+            pl.col("BUILT_FORM").is_in(terraced),
+        )
+        .then(pl.lit("Terraced (including end-terrace) whole house or bungalow"))
+        .when(pl.col("PROPERTY_TYPE").is_in(["Flat", "Maisonette"]))
+        .then(pl.lit("Flat, maisonette or apartment"))
+        .when(pl.col("PROPERTY_TYPE").is_in(["Park Home"]))
+        .then(pl.lit("A caravan or other mobile or temporary structure"))
+        .alias("property_type")
+    )
+
+    return df
+
+
+def add_col_nrooms(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Add `number_of_rooms` column to EPC dataset with categories corresponding to those from the census.
+
+    Args:
+        df (pl.DataFrame): EPC dataset
+
+    Returns:
+        pl.DataFrame: EPC dataset with `number_of_rooms` column
+    """
+    return df.with_columns(
+        pl.col("NUMBER_HABITABLE_ROOMS")
+        .map_elements(lambda x: 9 if x > 9 else x, return_dtype=pl.Float32)
+        .cast(pl.Int16)
+        .alias("number_of_rooms")
+    )
+
+
+def add_col_build_year_1930(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Add `build_year` column to EPC dataset indicating whether property construction year is pre- or post-1930 (or unknown).
+
+    Args:
+        df (pl.DataFrame): EPC dataset
+
+    Returns:
+        pl.DataFrame: EPC dataset with `build_year` column
+    """
+    pre = config["mapping"]["build_year_pre_cols_epc"]
+    post = config["mapping"]["build_year_post_cols_epc"]
+
+    df = df.with_columns(
+        pl.when(pl.col("CONSTRUCTION_AGE_BAND").is_in(pre))
+        .then(pl.lit("pre_1930"))
+        .when(pl.col("CONSTRUCTION_AGE_BAND").is_in(post))
+        .then(pl.lit("post_1930"))
+        .otherwise(pl.lit("unknown"))
+        .alias("build_year")
+    )
+
+    return df


### PR DESCRIPTION
Fixes #17 

# Description

Changes:
- add `pipeline/reweight_epc/reweight_epc.py` with functions to prepare EPC columns for reweighting. Preparation involves standardising columns so that they match the categories of data in the census/CDRC. This is not required for `tenure` feature because the census data has been collapsed to match the EPC categories in the pipeline.
- update `config/base.yaml` with mapping for functions above
- add sample preparation function to `pipeline/enhance_epc/run_script.py`
- fix `save_output` param in `run_script.main` to be optional rather than required

# Instructions for Reviewer

Please could you:
- check for bugs and mistakes
- check the recategorisation of EPC data is correct for each feature
- check columns are added as expected when running code. New columns should be added: [`property_type`, `number_of_rooms`, `build_year`] with the appropriate categories. To run the code (e.g. in a notebook), run the following after pulling the branch (note this df will only contain a sample of LSOAs from EPC, not the whole dataset - this is for speed purposes in testing):
```
from asf_heat_pump_suitability.pipeline.enhance_epc import run_script
df = run_script.main(epc_path="s3://asf-heat-pump-suitability/outputs/epc_sample_lsoa.parquet")
df.head()
```


# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
