### PR TITLE
20 prepare target reweighting

### DIFF
--- a/asf_heat_pump_suitability/pipeline/reweight_epc/prepare_target.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/prepare_target.py
@@ -21,7 +21,9 @@ def generate_balance_target_population(
     """
     target = {k: v[lsoa] for k, v in target_marginals.items()}
     df = rake.prepare_marginal_dist_for_raking(target)
-    return balance.Sample.from_frame(df)
+    df["weight"] = 1
+    df = balance.Sample.from_frame(df, id_column="id", weight_column="weight")
+    return df
 
 
 def get_dict_target_marginals() -> Dict[str, pl.DataFrame]:

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/prepare_target.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/prepare_target.py
@@ -1,0 +1,94 @@
+import balance
+from balance.weighting_methods import rake
+import polars as pl
+import polars.selectors as cs
+from typing import Dict
+from asf_heat_pump_suitability.getters import get_target
+
+
+def generate_balance_target_population(
+    target_marginals: Dict[str, dict], lsoa: str
+) -> balance.sample_class.Sample:
+    """
+    Generate balance Sample object from target proportions for each feature category for the specified LSOA.
+
+    Args:
+        target_marginals (Dict[str, dict]): dict of dicts containing target proportions for each feature category by LSOA
+        lsoa (str): LSOA to generate target population for
+
+    Returns:
+        balance.sample_class.Sample: artificial target population object generated from given marginals
+    """
+    target = {k: v[lsoa] for k, v in target_marginals.items()}
+    df = rake.prepare_marginal_dist_for_raking(target)
+    return balance.Sample.from_frame(df)
+
+
+def get_dict_target_marginals() -> Dict[str, pl.DataFrame]:
+    """
+    Get dict of dicts containing target proportions of each feature category per LSOA. Dictionary keys are
+    feature names.
+
+    Returns:
+        Dict[str, dict]: dict of dicts containing target proportions for each feature category per LSOA
+    """
+    target_features = get_dict_dfs_counts()
+
+    target_proportions = {
+        k: convert_df_proportions(v) for k, v in target_features.items()
+    }
+
+    return {k: to_dict_feature_marginals(v) for k, v in target_proportions.items()}
+
+
+def get_dict_dfs_counts() -> Dict[str, pl.DataFrame]:
+    """
+    Get dict of dataframes containing counts of each feature category per LSOA in the target datasets. Dictionary
+    keys are feature names.
+
+    Returns:
+        Dict[str, pl.DataFrame]: dict of dataframes containing counts of each feature category per LSOA in the target
+        datasets
+    """
+    return {
+        "tenure": get_target.get_df_target_tenure(),
+        "property_type": get_target.get_df_target_property_type(),
+        # TODO: adding nrooms feature causes crash when running `generate_balance_target_population`
+        # "nrooms": get_target.get_df_target_nrooms(),
+        "build_year": get_target.get_df_target_build_year(),
+    }
+
+
+def convert_df_proportions(df: pl.DataFrame) -> Dict[str, pl.DataFrame]:
+    """
+    Convert dataframe of counts to target proportions for each feature category per LSOA.
+
+    Args:
+        pl.DataFrame: dataframe containing counts of each feature category per LSOA
+
+    Returns:
+        Dict[str, pl.DataFrame]: dataframe of target proportions for each feature category per LSOA
+    """
+    cols = df.select(cs.integer()).columns
+    df = df.with_columns(pl.sum_horizontal(df.select(cols)).alias("total"))
+    df = df.with_columns(
+        [(pl.col(col) / pl.col("total")).alias(col) for col in cols]
+    ).drop(columns=["total"])
+
+    return df
+
+
+def to_dict_feature_marginals(df: pl.DataFrame) -> Dict[str, dict]:
+    """
+    Convert dataframe with target marginals to dict where keys are LSOA codes
+
+    Args:
+        df (pl.DataFrame): dataframe with target marginals category per LSOA
+
+    Returns:
+        Dict[str, dict]: dict with target proportions for each feature category where keys are LSOA codes
+    """
+    lsoas = df["lsoa"].to_list()
+    marginals = df.select(pl.exclude("lsoa")).to_dicts()
+
+    return dict(zip(lsoas, marginals))

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/prepare_target.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/prepare_target.py
@@ -53,8 +53,8 @@ def get_dict_dfs_counts() -> Dict[str, pl.DataFrame]:
     return {
         "tenure": get_target.get_df_target_tenure(),
         "property_type": get_target.get_df_target_property_type(),
-        # TODO: adding nrooms feature causes crash when running `generate_balance_target_population`
-        # "nrooms": get_target.get_df_target_nrooms(),
+        # TODO: potentially collapse nrooms categories to increase speed
+        "nrooms": get_target.get_df_target_nrooms(),
         "build_year": get_target.get_df_target_build_year(),
     }
 
@@ -71,8 +71,9 @@ def convert_df_proportions(df: pl.DataFrame) -> Dict[str, pl.DataFrame]:
     """
     cols = df.select(cs.integer()).columns
     df = df.with_columns(pl.sum_horizontal(df.select(cols)).alias("total"))
+    # Rounding the proportions cuts the run time to generate target population down
     df = df.with_columns(
-        [(pl.col(col) / pl.col("total")).alias(col) for col in cols]
+        [(pl.col(col) / pl.col("total")).round(3).alias(col) for col in cols]
     ).drop(columns=["total"])
 
     return df


### PR DESCRIPTION
Fixes #20 

# Description

Changes:
- add new `pipeline/reweight_epc/prepare_target.py` file with functions to prepare target marginals for reweighting with [balance](https://github.com/facebookresearch/balance)

Note: the functions will be added into the `enhance_epc` pipeline in a separate PR when all reweighting functions are completed.

# Instructions for Reviewer

Please could you:
- check for bugs and mistakes
- check the docstrings are clear and make sense to you. Same with function names
- test the code works for you (e.g. in a notebook). Snippet below will import the target datasets and prepare marginals for specified LSOA. `marginal_lsoa` should be a `balance.sample_class.Sample` object. `marginals` should be a dict that contains proportions for each feature for each LSOA in the census data.
```
from asf_heat_pump_suitability.pipeline.reweight_epc import prepare_target
marginals = prepare_target.get_dict_target_marginals()
print(marginals)
lsoa = "E01000001"  # choose any lsoa of your choice
marginal_lsoa = prepare_target.generate_balance_target_population(marginals, lsoa)
marginal_lsoa
```

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
