### PR TITLE
adding the property density feature to the EPC dataset

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -5,6 +5,8 @@ data_source:
   EW_census_housing_characteristics: "s3://asf-heat-pump-suitability/source_data/2021census_Mar2023update_housing_characteristics_E_W.xlsx" # 2021 census, Mar 2023 update
   EW_census_tenure: "s3://asf-heat-pump-suitability/source_data/2021census_2023Mar_tenure_E_W.csv"
   EW_census_number_of_rooms: "s3://asf-heat-pump-suitability/source_data/2021census_Mar2023_number_of_rooms_E_W.csv"
+  EW_census_number_of_households: "s3://asf-heat-pump-suitability/source_data/2021_vMar2023_census_numberofhouseholds_EW.csv"
+  EW_census_land_area: "s3://asf-heat-pump-suitability/source_data/2021_vDec2021_census_landareaKM_EW.csv"
   EW_cdrc_dwelling_age: "s3://asf-heat-pump-suitability/source_data/2015cdrc_dwelling_ages_E_W.csv"
   GB_ons_garden_space_access: "s3://asf-heat-pump-suitability/source_data/ONS_Apr2020_access_to_garden_space.xlsx"
   GB_osopen_uprn_latlon: "s3://asf-heat-pump-suitability/source_data/osopenuprn_202405_csv.zip"

--- a/asf_heat_pump_suitability/getters/get_datasets.py
+++ b/asf_heat_pump_suitability/getters/get_datasets.py
@@ -1,6 +1,7 @@
 import polars as pl
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.getters import base_getters, schemas
+from io import StringIO
 
 
 def get_df_ons_pd(**kwargs) -> pl.DataFrame:
@@ -62,4 +63,57 @@ def get_df_osopen_uprn_latlon(**kwargs) -> pl.DataFrame:
         **kwargs,
     )
 
+    return df
+
+
+def get_df_ons_number_of_households() -> pl.DataFrame:
+    """
+    Get raw ONS 'Number of households' dataset.
+
+    Args:
+        **kwargs for pl.read_excel
+
+    Returns:
+        pl.DataFrame: raw ONS 'Number of households' dataset
+    """
+    content = base_getters.get_content_from_s3_path(
+        config["data_source"]["EW_census_number_of_households"],
+    )
+    content_str = content.decode("utf-8")  # convert bytes to string
+    content_file = StringIO(content_str)  # convert string to file-like object
+    df = pl.read_csv(content_file, skip_rows=6, has_header=True)
+    # Preprocessing steps due to white space
+    # Remove the last eight rows
+    df = df.slice(0, len(df) - 9)
+    # Remove the first row
+    df = df.slice(1, len(df) - 1)
+    return df
+
+
+def get_df_ons_land_area() -> pl.DataFrame:
+    """
+    Get raw ONS 'land area' dataset.
+
+    Returns:
+        pl.DataFrame: raw ONS 'land area' dataset
+    """
+    content = base_getters.get_content_from_s3_path(
+        config["data_source"]["EW_census_land_area"],
+    )
+    content_str = content.decode("utf-8")  # convert bytes to string
+    content_file = StringIO(content_str)  # convert string to file-like object
+
+    # dtypes specificed as polars read csv wa inferring wrong data types and throwing error
+    dtypes = {
+        "LSOA21CD": pl.Utf8,
+        "LSOA21NM": pl.Utf8,
+        "Extent of the Realm (Area in KM2)": pl.Float64,
+        "Clipped to the Coastline (Area in KM2)": pl.Float64,
+        "Area of Inland Water (KM2)": pl.Float64,
+        "Land Count (Area in KM2)": pl.Float64,
+        "LTLA22CD": pl.Utf8,
+        "LTLA22NM": pl.Utf8,
+        "LTLA22NMW": pl.Utf8,
+    }
+    df = pl.read_csv(content_file, dtypes=dtypes, has_header=True)
     return df

--- a/asf_heat_pump_suitability/pipeline/prepare_features/land_area.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/land_area.py
@@ -1,0 +1,37 @@
+import polars as pl
+from asf_heat_pump_suitability.getters import get_datasets
+
+
+def prepare_df_land_area_ons() -> pl.DataFrame:
+    """
+    Process and clean ONS land area dataset
+
+    Args
+
+    Returns
+        pl.DataFrame: processed ONS land area
+    """
+    df = get_datasets.get_df_ons_land_area()
+    df = preprocess_df_land_area(df)
+    return df
+
+
+def preprocess_df_land_area(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Preprocess
+
+    Args
+        df (pl.DataFrame): dataset of land areas
+        pcd_col (str): name of column containing land areas
+
+    Returns
+        pl.DataFrame: dataset with renamed LSOA column
+    """
+    # Rename columns
+    df = df.rename(
+        {
+            "LSOA21CD": "lsoa21",
+        }
+    )
+
+    return df

--- a/asf_heat_pump_suitability/pipeline/prepare_features/number_of_households.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/number_of_households.py
@@ -1,0 +1,41 @@
+import polars as pl
+from asf_heat_pump_suitability.getters import get_datasets
+
+
+def prepare_df_num_of_households_ons() -> pl.DataFrame:
+    """
+    Process and clean ONS number of households dataset
+
+    Args
+
+    Returns
+        pl.DataFrame: processed ONS number of households
+    """
+    df = get_datasets.get_df_ons_number_of_households()
+    df = preprocess_df_num_of_households(df)
+    return df
+
+
+def preprocess_df_num_of_households(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Preprocess
+
+    Args
+        df (pl.DataFrame): dataset containing number of households
+        pcd_col (str): name of column containing postcodes
+
+    Returns
+        pl.DataFrame: dataset with standardised postcode column
+    """
+    # Rename columns
+    df = df.rename(
+        {
+            "mnemonic": "lsoa21",
+            "2021": "Number of households 2021",
+        }
+    )
+
+    return df
+
+
+prepare_df_num_of_households_ons()

--- a/asf_heat_pump_suitability/pipeline/prepare_features/property_density.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/property_density.py
@@ -1,0 +1,63 @@
+# Add property density feature to EPC dataset
+import polars as pl
+
+
+def extend_df_with_property_density(enhanced_epc_df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Add property density feature to the EPC dataset
+    Args:
+        enhanced_epc_df (pl.DataFrame): EPC dataset with additional features
+    Returns:
+        pl.DataFrame: EPC dataset with property density feature
+    """
+    # Fill None values with a default value (e.g., 0)
+    enhanced_epc_df = enhanced_epc_df.with_columns(
+        [
+            pl.col("Number of households 2021")
+            .fill_null(0)
+            .alias("Number of households 2021"),
+            pl.col("Land Count (Area in KM2)")
+            .fill_null(0)
+            .alias("Land Count (Area in KM2)"),  # Fill with 1 to avoid division by zero
+        ]
+    )
+    # Calculate and add the new column with the property density, handling division by zero
+    enhanced_epc_df = enhanced_epc_df.with_columns(
+        (
+            pl.when(pl.col("Land Count (Area in KM2)") != 0)
+            .then(
+                pl.col("Number of households 2021") / pl.col("Land Count (Area in KM2)")
+            )
+            .otherwise(None)
+        ).alias("Property density (households per KM2)")
+    )
+    # Changes 0 values back to None
+    enhanced_epc_df = replace_zeros_with_none_df(
+        enhanced_epc_df, "Number of households 2021"
+    )
+    enhanced_epc_df = replace_zeros_with_none_df(
+        enhanced_epc_df, "Land Count (Area in KM2)"
+    )
+
+    return enhanced_epc_df
+
+
+def replace_zeros_with_none_df(df: pl.Dataframe, column_name: str) -> pl.DataFrame:
+    """
+    This function replaces 0 values in the specified column of a DataFrame with None.
+
+    Parameters:
+    df (pl.DataFrame): The DataFrame to modify.
+    column_name (str): The name of the column in which to replace 0 values.
+
+    Returns:
+    pl.DataFrame: The modified DataFrame.
+    """
+    df = df.with_columns(
+        pl.when(pl.col(column_name) == 0)
+        .then(None)
+        .otherwise(pl.col(column_name))
+        .alias(column_name)
+    )
+
+    return df

--- a/asf_heat_pump_suitability/pipeline/prepare_features/property_density.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/property_density.py
@@ -42,7 +42,7 @@ def extend_df_with_property_density(enhanced_epc_df: pl.DataFrame) -> pl.DataFra
     return enhanced_epc_df
 
 
-def replace_zeros_with_none_df(df: pl.Dataframe, column_name: str) -> pl.DataFrame:
+def replace_zeros_with_none_df(df: pl.DataFrame, column_name: str) -> pl.DataFrame:
     """
     This function replaces 0 values in the specified column of a DataFrame with None.
 

--- a/asf_heat_pump_suitability/pipeline/run_scripts/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run_scripts/add_features.py
@@ -6,6 +6,9 @@ from argparse import ArgumentParser
 from asf_heat_pump_suitability.pipeline.prepare_features import (
     garden_space_avg,
     lat_lon,
+    number_of_households,
+    land_area,
+    property_density,
 )
 from asf_heat_pump_suitability.pipeline.enhance_epc import prepare_epc
 
@@ -69,6 +72,28 @@ def main(epc_path: str, save_output: Optional[str] = None) -> pl.DataFrame:
 
     # Join enhanced datasets together
     enhanced_epc_df = enhanced_epc_df.join(uprn_latlon_df, how="left", on="UPRN")
+
+    logging.info("Adding number of households data to EPC")
+    lsoa_number_of_households_df = (
+        number_of_households.prepare_df_num_of_households_ons()
+    )
+    epc_lsoa_number_of_households_df = lsoa_number_of_households_df.select(
+        ["lsoa21", "Number of households 2021"]
+    )
+    print(enhanced_epc_df.columns)
+    enhanced_epc_df = enhanced_epc_df.join(
+        epc_lsoa_number_of_households_df, how="left", on="lsoa21"
+    )
+    logging.info("Adding land area to EPC")
+    lsoa_land_area_df = land_area.prepare_df_land_area_ons()
+    epc_lsoa_land_area_df = lsoa_land_area_df.select(
+        ["lsoa21", "Land Count (Area in KM2)"]
+    )
+    enhanced_epc_df = enhanced_epc_df.join(
+        epc_lsoa_land_area_df, how="left", on="lsoa21"
+    )
+    logging.info("Adding property density to EPC")
+    enhanced_epc_df = property_density.extend_df_with_property_density(enhanced_epc_df)
 
     # Save to S3
     fs = s3fs.S3FileSystem()


### PR DESCRIPTION
---

# Description
This is a PR which adds the number of households, the land area and the property density per LSOA as features for England and Wales to the EPC dataset

Fixes #42 

# Instructions for Reviewer
I've made changes to / added the following files (if you could quickly go through them and check to see if everything seems OK):
- `pipeline/run_scripts/add_features.py`
- `pipeline/prepare_features/number_of_households.py`
- `pipeline/prepare_features/property_density.py`
- `pipeline/prepare_features/output_areas.py`
- `getters/get_datasets.py`
- `config/base.yaml`

In order to test the code in this PR you need to run the following:
`python pipeline/run_scripts/add_features.py --epc_path "s3://asf-heat-pump-suitability/outputs/2023_Q2_EPC_enhanced_weights_sample_10k.parquet" --save_output "s3://asf-heat-pump-suitability/outputs/2023_Q2_EPC_enhanced_weights_property_density_sample_test_10k.parquet"`


Please pay special attention to any bugs, sense test the functions and please think of any efficiencies that can be made and sense check the outputs!

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [X] I have checked the code runs
- [ ] I have tested the code
- [X] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [X] I have documented the code
  - [X] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [X] I have explained this PR above
- [X] I have requested a code review
