### PR TITLE
96 Scottish anchor properties

### DIFF
--- a/asf_heat_pump_suitability/getters/get_datasets.py
+++ b/asf_heat_pump_suitability/getters/get_datasets.py
@@ -269,14 +269,20 @@ def load_gdf_listed_buildings(nation: str, **kwargs) -> gpd.GeoDataFrame:
     return gdf
 
 
-def load_gdf_scotgov_data_zone_bounds() -> gpd.GeoDataFrame:
+def load_gdf_scotgov_data_zone_bounds(**kwargs) -> gpd.GeoDataFrame:
     """
-    Load raw 2011 Data Zone geospatial boundary polygons and area data for Scotland from the Scottish Government.
+    Load raw 2011 Data Zone geospatial boundary polygons and area data for Scotland from the Scottish Government. CRS
+    British National Grid (EPSG:27700).
+
+    Args:
+        **kwargs for geopandas.read_file()
 
     Returns:
         gpd.GeoDataFrame: boundary polygons and area data for 2011 Scottish Data Zones
     """
-    return gpd.read_file(config["data_source"]["S_scottish_gov_DZ2011_boundaries"])
+    return gpd.read_file(
+        config["data_source"]["S_scottish_gov_DZ2011_boundaries"], **kwargs
+    )
 
 
 def load_df_nrs_dwellings() -> pl.DataFrame:

--- a/asf_heat_pump_suitability/pipeline/prepare_features/anchor_properties.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/anchor_properties.py
@@ -103,13 +103,13 @@ def load_gdf_and_process_poi() -> gpd.GeoDataFrame:
 
 def identify_anchor_properties_gdf() -> gpd.GeoDataFrame:
     """
-    Identify and analyze anchor properties within LSOAs.
+    Identify and analyze anchor properties within LSOAs/DataZones.
 
     Returns:
-        gpd.GeoDataFrame: Summary of anchor properties by LSOA containing columns:
-            - lsoa: Unique identifier for the LSOA
-            - lsoa_name: Name of the LSOA
-            - anchor_count: Number of anchor properties in the LSOA
+        gpd.GeoDataFrame: Summary of anchor properties by LSOA/DataZone, containing columns:
+            - lsoa: Unique identifier for the LSOA/DataZone
+            - lsoa_name: Name of the LSOA/DataZone
+            - anchor_count: Number of anchor properties in the LSOA/DataZone
             - building_categories: List of main categories present
             - building_subcategories: List of subcategories present
             - has_anchor_property: Boolean indicating presence of anchor properties

--- a/asf_heat_pump_suitability/pipeline/prepare_features/anchor_properties.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/anchor_properties.py
@@ -6,14 +6,13 @@ This script can be run independentally and will output a CSV file with a list of
 # TODO implement building footprint data for improved identification accuracy
 
 import logging
-from typing import Set
 from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
 
-from asf_heat_pump_suitability.getters.s3_getters import load_s3_data
 from asf_heat_pump_suitability import config
+from asf_heat_pump_suitability.getters import get_datasets
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -81,14 +80,13 @@ def load_gdf_and_process_poi() -> gpd.GeoDataFrame:
         "geometry",
     ]
     poi = gpd.read_file(
-        config["data_source"]["UK_poi_locations"], columns=required_columns
+        config["data_source"]["UK_poi_locations"],
+        columns=required_columns,
+        layer="poi_uk",
     ).to_crs(INPUT_CRS)
 
     # Filter and process
-    poi = poi[poi.country == '"GB"'].copy()
-    poi["main_category"] = poi["main_category"].apply(
-        lambda x: str.strip(x, '"') if pd.notna(x) else None
-    )
+    poi = poi[poi.country == "GB"].copy()
 
     # Filter anchor properties and reproject
     anchor_properties = poi[poi.main_category.isin(ANCHOR_PROPERTIES)].to_crs(
@@ -119,13 +117,27 @@ def identify_anchor_properties_gdf() -> gpd.GeoDataFrame:
     try:
         logger.info("Starting anchor property analysis...")
 
-        # Load required data
+        # Load and process LSOA and DZ boundary data
         logger.info("Loading LSOA boundaries...")
-        # Load and process LSOA boundary data
-        lsoa_gdf = gpd.read_file(
-            config["data_source"]["EW_lsoa_bounds"],
-            columns=["LSOA21CD", "LSOA21NM", "geometry"],
-        ).to_crs(PROCESSING_CRS)
+        lsoa_gdf = (
+            gpd.read_file(
+                config["data_source"]["EW_lsoa_bounds"],
+                columns=["LSOA21CD", "LSOA21NM", "geometry"],
+            )
+            .rename(columns={"LSOA21CD": "lsoa", "LSOA21NM": "lsoa_name"})
+            .to_crs(PROCESSING_CRS)
+        )
+
+        dz_gdf = (
+            get_datasets.load_gdf_scotgov_data_zone_bounds(
+                columns=["DataZone", "Name", "geometry"]
+            )
+            .rename(columns={"DataZone": "lsoa", "Name": "lsoa_name"})
+            .to_crs(PROCESSING_CRS)
+        )
+
+        lsoa_gdf = pd.concat([lsoa_gdf, dz_gdf])
+
         anchor_properties = load_gdf_and_process_poi()
 
         lsoa_with_anchors = gpd.sjoin(
@@ -133,10 +145,10 @@ def identify_anchor_properties_gdf() -> gpd.GeoDataFrame:
         )
 
         lsoa_anchor_summary = (
-            lsoa_with_anchors.groupby("LSOA21CD")
+            lsoa_with_anchors.groupby("lsoa")
             .agg(
                 {
-                    "LSOA21NM": "first",
+                    "lsoa_name": "first",
                     "id": "count",
                     "main_category": _safe_join_str_categories,
                     "alternate_category": _safe_join_str_categories,


### PR DESCRIPTION
Fixes #96 

# Description

Update `anchor_properties.py` to identify anchor properties for Scotland as well as England and Wales. As the anchor properties POI dataset already has UK coverage, I just needed to add a new geodataframe with Scottish Data Zone boundaries and concatenate that to the existing boundaries for England and Wales. The spatial join with the POI dataset then proceeds as before.

# Instructions for Reviewer

To create dataframe of anchor properties, run:
`python -i asf_heat_pump_suitability/pipeline/prepare_features/anchor_properties.py`

NB: there is a bug in `run_add_features.py` in the lines to add anchor properties. This bug is fixed in PR 86 `update run scripts`: https://github.com/nestauk/asf_heat_pump_suitability/pull/93 . The PR has been approved for merge. It merges into another branch which is still awaiting a second review as of 5 Jan 2024. Replicating the fix here would require changing multiple files that have already been reviewed separately which I think adds unnecessary complexity to this PR. 

Note, we will need to test `run_add_features.py` again later with a focus on the anchor properties feature when branch 86 is merged to dev.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
