### PR TITLE
Set null protected areas in E and W to false

### DIFF
--- a/asf_heat_pump_suitability/pipeline/prepare_features/protected_areas.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/protected_areas.py
@@ -4,6 +4,7 @@ import numpy as np
 import polars as pl
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.getters import get_datasets
+from asf_heat_pump_suitability.pipeline.prepare_features import epc
 
 
 def load_transform_df_uprn_in_protected_area(gdf: gpd.GeoDataFrame) -> pl.DataFrame:
@@ -72,7 +73,7 @@ def generate_df_uprn_in_whs(
     Generate dataframe to flag UPRNs located within World Heritage Sites in Scotland.
 
     Args:
-        gdf (pl.DataFrame): dataframe with point geometries per UPRN in BNG
+        gdf (gpd.GeoDataFrame): dataframe with point geometries per UPRN in BNG
         country_col (str): column containing country names
 
     Returns:
@@ -84,7 +85,10 @@ def generate_df_uprn_in_whs(
     gdf = gdf.sjoin(whs_gdf, how="left", predicate="intersects").drop_duplicates(
         subset="UPRN"
     )
-    gdf["in_world_heritage_site_s"] = gdf["in_world_heritage_site_s"].fillna(False)
+    # Fill null with False if row has geometry, otherwise leave as null
+    gdf.loc[~gdf["geometry"].is_empty, "in_world_heritage_site_s"] = gdf.loc[
+        ~gdf["geometry"].is_empty, "in_world_heritage_site_s"
+    ].fillna(False)
 
     return pl.from_pandas(gdf[["UPRN", "in_world_heritage_site_s"]])
 
@@ -109,14 +113,14 @@ def generate_df_conservation_area_data_availability(
     ladcd_col: str = "LAD23CD",
 ) -> pl.DataFrame:
     """
-    Generate dataframe of UK local authority districts (LADs) with indicator of building conservation area data
+    Generate dataframe of local authority districts (LADs) in England and Wales with indicator of building conservation area data
     availability.
 
     Args:
         ladcd_col (str): name of column in local authority district (LAD) boundaries file with LAD codes
 
     Returns:
-        pl.DataFrame: building conservation area data availability per LAD in the UK
+        pl.DataFrame: building conservation area data availability per LAD in England and Wales
     """
     cons_areas_gdf = transform_gdf_building_cons_areas()
     council_bounds = get_datasets.load_gdf_ons_council_bounds()
@@ -131,5 +135,12 @@ def generate_df_conservation_area_data_availability(
         "in_conservation_area_ew"
     ].astype(bool)
     df = df.drop(columns=["in_conservation_area_ew"]).reset_index()
+    df = pl.from_pandas(df)
 
-    return pl.from_pandas(df)
+    df = (
+        epc.extend_df_country_col(df, lsoa_col="LAD23CD")
+        .filter(pl.col("country").is_in(["England", "Wales"]))
+        .drop("country")
+    )
+
+    return df

--- a/asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py
@@ -152,7 +152,7 @@ if __name__ == "__main__":
     )
 
     epc_df = epc_df.with_columns(
-        pl.when(pl.col("lad_conservation_area_data_available_ew") == True)
+        pl.when((pl.col("lad_conservation_area_data_available_ew")) & pl.col("COUNTRY").is_in(["England", "Wales"]))
         .then(pl.col("in_protected_area").fill_null(False))
         .otherwise(pl.col("in_protected_area"))
         .alias("in_protected_area")

--- a/asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py
@@ -139,7 +139,9 @@ if __name__ == "__main__":
     uprns_in_protected_area_df = (
         protected_areas.load_transform_df_uprn_in_protected_area(epc_gdf)
     )
-    epc_df = epc_df.join(uprns_in_protected_area_df, how="left", on="UPRN")
+    epc_df = epc_df.join(
+        uprns_in_protected_area_df, how="left", on="UPRN"
+    ).with_columns(pl.col("in_protected_area").fill_null(False))
 
     logging.info(
         "Adding local authority building conservation area data availability flag for England and Wales"

--- a/asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py
@@ -139,9 +139,7 @@ if __name__ == "__main__":
     uprns_in_protected_area_df = (
         protected_areas.load_transform_df_uprn_in_protected_area(epc_gdf)
     )
-    epc_df = epc_df.join(
-        uprns_in_protected_area_df, how="left", on="UPRN"
-    ).with_columns(pl.col("in_protected_area").fill_null(False))
+    epc_df = epc_df.join(uprns_in_protected_area_df, how="left", on="UPRN")
 
     logging.info(
         "Adding local authority building conservation area data availability flag for England and Wales"
@@ -151,6 +149,13 @@ if __name__ == "__main__":
     )
     epc_df = epc_df.join(
         lad_cons_areas_df, how="left", left_on="lad_code", right_on="LAD23CD"
+    )
+
+    epc_df = epc_df.with_columns(
+        pl.when(pl.col("lad_conservation_area_data_available_ew") == True)
+        .then(pl.col("in_protected_area").fill_null(False))
+        .otherwise(pl.col("in_protected_area"))
+        .alias("in_protected_area")
     )
 
     logging.info("Adding property density to EPC")


### PR DESCRIPTION
Fixes #116 (description of why in issue description)

# Instructions for Reviewer

I found that all of England and Wales protected areas were either Null or True, so I think it is correct to set the Nulls to False, but perhaps I am missing something?

I ran 
```
python -i asf_heat_pump_suitability/pipeline/run_scripts/run_add_features.py --epc s3://asf-daps/lakehouse/processed/epc/old/deduplicated/processed_dedupl-0.parquet -y 2023 -q 4
```

to create `'s3://asf-heat-pump-suitability/outputs/2023Q4/20250204_2023_Q4_EPC_features.parquet'`

and then ran

```
python -i asf_heat_pump_suitability/pipeline/run_scripts/run_calculate_suitability.py --weights s3://asf-heat-pump-suitability/outputs/2023Q4/weights/20250102_2023_Q4_EPC_weights.parquet --features s3://asf-heat-pump-suitability/outputs/2023Q4/20250204_2023_Q4_EPC_features.parquet --gardens s3://asf-heat-pump-suitability/outputs/2023Q4/gardens/20250114_2023_Q4_EPC_garden_size_estimates_EWS_deduplicated.parquet -y 2023 -q 4
```

which saved to `s3://asf-heat-pump-suitability/outputs/2023Q4/suitability/20250206_2023_Q4_heat_pump_suitability_per_lsoa.csv`

