### PR TITLE
remove glm_net from requirements. no longer required by balance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 polars-lts-cpu==1.5.0
-glmnet_python @ git+https://github.com/bbalasub1/glmnet_python.git@1.0
 ipfn @ git+https://github.com/nestauk/ipfn.git@master
 balance
 jupytext


### PR DESCRIPTION
Fixes #82 

# Description

Remove `glmnet` from requirements which was outdated and causing dependency issues. It was previously required by the `balance` package but `balance` has now been updated and no longer requires `glmnet`, instead using `sklearn`. https://github.com/facebookresearch/balance

After removing from `requirements.txt` I ran the following to test setup:
```
conda deactivate
conda deactivate
make install
conda activate asf_heat_pump_suitability
python -i asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --epc s3://asf-daps/lakehouse/processed/epc/old/deduplicated/processed_dedupl-0.parquet -y 2023 -q 4
```

This process works and no bugs were encountered. I did not run the full reweighting script, I just let it reweight a few LSOAs and it worked.

# Instructions for Reviewer

Please could you run the code above and make sure it works for you as well.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
