### PR TITLE
Correct building intersection size calculation

### DIFF
--- a/asf_heat_pump_suitability/pipeline/prepare_features/garden_size.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/garden_size.py
@@ -64,14 +64,14 @@ def generate_gdf_land_building_overlay(
 
     gdf = gdf[
         (
-            (gdf["building_intersection_area_m2"] <= outbuilding_size)
+            (gdf["building_area_m2"] <= outbuilding_size)
             & (
                 gdf["building_intersection_area_m2"]
                 >= gdf["min_size_of_small_building"]
             )
         )
         | (
-            (gdf["building_intersection_area_m2"] > outbuilding_size)
+            (gdf["building_area_m2"] > outbuilding_size)
             & (
                 gdf["building_intersection_area_m2"]
                 >= gdf["min_size_of_large_building"]


### PR DESCRIPTION
Fixes #128 

# Description

The outbuilding size calculation should apply this logic:
To be considered valid, a building chunk must be at least 45% of the whole building if it is part of a small building (≤30m2), OR at least 5% of a large building (>30m2).

Please could you check the updated calculation to ensure it is correct.

Important note: although the calculation refers to 'outbuildings', the logic will actually be applied to every single building footprint (or building chunk/intersection) that is matched to a land parcel, so it's important we get this calculation correct.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
