### PR TITLE
Remove erroneous Leicester conservation zone point

### DIFF
--- a/asf_heat_pump_suitability/pipeline/prepare_features/protected_areas.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/protected_areas.py
@@ -56,8 +56,13 @@ def transform_gdf_building_cons_areas() -> gpd.GeoDataFrame:
         gpd.GeoDataFrame: building conservation areas in England and Wales
     """
     e_gdf = get_datasets.load_gdf_historic_england_conservation_areas(
-        columns=["geometry"]
+        columns=["geometry", "name"]
     ).to_crs("EPSG:27700")
+    # Remove erroneous point where the entirety of Leicester is classified as a conservation zone
+    e_gdf = e_gdf[e_gdf["name"] != "No data available for publication by HE"][
+        ["geometry"]
+    ].reset_index(drop=True)
+
     w_gdf = get_datasets.load_gdf_welsh_gov_conservation_areas(columns=["geometry"])
 
     gdf = pd.concat([e_gdf, w_gdf])
@@ -128,7 +133,7 @@ def generate_df_conservation_area_data_availability(
     # Join conservation areas to their councils
     df = council_bounds.sjoin(cons_areas_gdf, how="left", predicate="intersects")[
         [ladcd_col, "in_conservation_area_ew"]
-    ].replace("No data available for publication by HE", np.nan)
+    ]
 
     df = df.groupby(ladcd_col).agg({"in_conservation_area_ew": "count"})
     df["lad_conservation_area_data_available_ew"] = df[


### PR DESCRIPTION
---

# Description

There are genuine conservation zones for Leicester but also one big conservation zone for the entirety of Leicester. This data point has the name "No data available for publication by HE" - so I've removed it this way.

I noticed this after seeing that Leicester had 99% of it's properties being in protected areas. The Isles of Scilly are the only other outlier in terms of % LSOAs in protected areas - but this is true.

![Screenshot 2025-02-12 at 18 00 46](https://github.com/user-attachments/assets/ba0b5f0d-0ab2-4e00-b2f3-2cfa24efa2fd)

I also removed a replace statement from `generate_df_conservation_area_data_availability`. It looks like this wasn't doing anything anyway? The following is what I got from running 

```python
from asf_heat_pump_suitability.pipeline.prepare_features import protected_areas
from asf_heat_pump_suitability.getters import get_datasets


cons_areas_gdf = protected_areas.transform_gdf_building_cons_areas()
council_bounds = get_datasets.load_gdf_ons_council_bounds()

# Join conservation areas to their councils
ladcd_col = "LAD23CD"
df = council_bounds.sjoin(cons_areas_gdf, how="left", predicate="intersects")[
    [ladcd_col, "in_conservation_area_ew"]
]
```

![Screenshot 2025-02-12 at 18 02 32](https://github.com/user-attachments/assets/1488e2e7-510e-4900-8ee3-ee9d552867e8)

# Instructions for Reviewer

Have I included any bugs? I could add the `.replace("No data available for publication by HE", np.nan)` bit back in if you think it could cause issues.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
