### PR TITLE
fix erroneously named variable in `run_calculate_garden_size.py`

### DIFF
--- a/asf_heat_pump_suitability/pipeline/run_scripts/run_calculate_garden_size.py
+++ b/asf_heat_pump_suitability/pipeline/run_scripts/run_calculate_garden_size.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
             epc_gardens = []
             if _min == -1:
                 _min = 0
-            min += 100
+            _min += 100
 
         # Set prev
         prev = land_file


### PR DESCRIPTION
Fixes #134 

# Description

Minor bug fix in interim file naming variable in `run_calculate_garden_size.py`.

Since fixing I have run the code successfully. To run:
`python -i asf_heat_pump_suitability/pipeline/run_scripts/run_calculate_garden_size.py --epc s3://asf-daps/lakehouse/processed/epc/old/deduplicated/processed_dedupl-0.parquet -y 2023 -q 4 -n ews`

# Instructions for Reviewer

In order to test the code in this PR you need to ...

Please pay special attention to ...

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
