### PR TITLE
154 parallelise reweighting

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include asf_heat_pump_suitability/config/*.yaml

--- a/asf_heat_pump_suitability/__init__.py
+++ b/asf_heat_pump_suitability/__init__.py
@@ -1,5 +1,7 @@
 """asf_heat_pump_suitability."""
+
 import logging
+import os
 import logging.config
 from pathlib import Path
 from typing import Optional
@@ -9,7 +11,9 @@ import yaml
 
 def get_yaml_config(file_path: Path) -> Optional[dict]:
     """Fetch yaml config and return as dict if it exists."""
+    print(os.listdir(Path(__file__).parent))
     if file_path.exists():
+        print(file_path)
         with open(file_path, "rt") as f:
             return yaml.load(f.read(), Loader=yaml.FullLoader)
 

--- a/asf_heat_pump_suitability/__init__.py
+++ b/asf_heat_pump_suitability/__init__.py
@@ -1,7 +1,6 @@
 """asf_heat_pump_suitability."""
 
 import logging
-import os
 import logging.config
 from pathlib import Path
 from typing import Optional
@@ -11,9 +10,7 @@ import yaml
 
 def get_yaml_config(file_path: Path) -> Optional[dict]:
     """Fetch yaml config and return as dict if it exists."""
-    print(os.listdir(Path(__file__).parent))
     if file_path.exists():
-        print(file_path)
         with open(file_path, "rt") as f:
             return yaml.load(f.read(), Loader=yaml.FullLoader)
 

--- a/asf_heat_pump_suitability/getters/get_target.py
+++ b/asf_heat_pump_suitability/getters/get_target.py
@@ -115,7 +115,7 @@ def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
             infer_schema_length=10000,
         )
         .collect()
-        .select(list(range(0, 11)))
+        .select(pl.nth(range(0, 11)))
     )
     df = (
         df[1:]
@@ -190,7 +190,7 @@ def load_transform_df_target_tenure_scotland() -> pl.DataFrame:
             infer_schema_length=10000,
         )
         .collect()
-        .select(list(range(1, 4)))
+        .select(pl.nth(range(1, 4)))
     )
     df = (
         df.drop_nulls()

--- a/asf_heat_pump_suitability/getters/get_target.py
+++ b/asf_heat_pump_suitability/getters/get_target.py
@@ -13,7 +13,7 @@ def get_df_target_nrooms() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of total number of rooms for properties in all LSOAs in England and Wales
     """
-    df = pl.read_csv(config["data_source"]["EW_census_number_of_rooms"])
+    df = pl.scan_csv(config["data_source"]["EW_census_number_of_rooms"])
     df = (
         df.drop(
             [
@@ -31,7 +31,7 @@ def get_df_target_nrooms() -> pl.DataFrame:
         .rename({"9": "9+"})
     )
 
-    return df
+    return df.collect()
 
 
 def transform_df_target_property_type() -> pl.DataFrame:
@@ -55,7 +55,7 @@ def load_transform_df_target_property_type_ew() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of property type for all LSOAs in England and Wales
     """
-    df = pl.read_csv(config["data_source"]["EW_census_accommodation_type"])
+    df = pl.scan_csv(config["data_source"]["EW_census_accommodation_type"])
     df = (
         df.select(
             [
@@ -98,7 +98,7 @@ def load_transform_df_target_property_type_ew() -> pl.DataFrame:
         )
     )
 
-    return df
+    return df.collect()
 
 
 def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
@@ -108,7 +108,7 @@ def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of property type for all data zones in Scotland
     """
-    df = pl.read_csv(
+    df = pl.scan_csv(
         config["data_source"]["S_census_accommodation_type"],
         skip_rows=10,
         columns=list(range(0, 11)),
@@ -156,7 +156,7 @@ def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
         != 0
     )
 
-    return df
+    return df.collect()
 
 
 def transform_df_target_tenure() -> pl.DataFrame:
@@ -180,7 +180,7 @@ def load_transform_df_target_tenure_scotland() -> pl.DataFrame:
     Returns:
         pl.DataFrame: tenure type counts per data zone in Scotland
     """
-    df = pl.read_csv(
+    df = pl.scan_csv(
         config["data_source"]["S_census_tenure"],
         skip_rows=10,
         columns=list(range(1, 4)),
@@ -210,7 +210,9 @@ def load_transform_df_target_tenure_scotland() -> pl.DataFrame:
         != 0
     )
 
-    return df.select(["lsoa", "owner-occupied", "rental (social)", "rental (private)"])
+    return df.select(
+        ["lsoa", "owner-occupied", "rental (social)", "rental (private)"]
+    ).collect()
 
 
 def load_transform_df_target_tenure_ew() -> pl.DataFrame:
@@ -220,7 +222,7 @@ def load_transform_df_target_tenure_ew() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of tenure type for all LSOAs in England and Wales
     """
-    df = pl.read_csv(config["data_source"]["EW_census_tenure"])
+    df = pl.scan_csv(config["data_source"]["EW_census_tenure"])
 
     owned_cols = [
         "Owned: Owns with a mortgage or loan",
@@ -259,7 +261,7 @@ def load_transform_df_target_tenure_ew() -> pl.DataFrame:
         )
     )
 
-    return df
+    return df.collect()
 
 
 def get_df_target_build_year(
@@ -279,7 +281,7 @@ def get_df_target_build_year(
     Returns:
         pl.Dataframe: counts of properties built before and after given year for all LSOAs in England and Wales.
     """
-    df = pl.read_csv(config["data_source"]["EW_cdrc_dwelling_age"])
+    df = pl.scan_csv(config["data_source"]["EW_cdrc_dwelling_age"])
     df = (
         df.with_columns(
             [
@@ -291,7 +293,7 @@ def get_df_target_build_year(
         .select(["lsoa", f"pre_{year_label}", f"post_{year_label}", "unknown"])
     )
 
-    return df
+    return df.collect()
 
 
 def get_df_target_build_year_la() -> pl.DataFrame:

--- a/asf_heat_pump_suitability/getters/get_target.py
+++ b/asf_heat_pump_suitability/getters/get_target.py
@@ -13,7 +13,7 @@ def get_df_target_nrooms() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of total number of rooms for properties in all LSOAs in England and Wales
     """
-    df = pl.scan_csv(config["data_source"]["EW_census_number_of_rooms"])
+    df = pl.scan_csv(config["data_source"]["EW_census_number_of_rooms"]).collect()
     df = (
         df.drop(
             [
@@ -31,7 +31,7 @@ def get_df_target_nrooms() -> pl.DataFrame:
         .rename({"9": "9+"})
     )
 
-    return df.collect()
+    return df
 
 
 def transform_df_target_property_type() -> pl.DataFrame:
@@ -55,7 +55,7 @@ def load_transform_df_target_property_type_ew() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of property type for all LSOAs in England and Wales
     """
-    df = pl.scan_csv(config["data_source"]["EW_census_accommodation_type"])
+    df = pl.scan_csv(config["data_source"]["EW_census_accommodation_type"]).collect()
     df = (
         df.select(
             [
@@ -98,7 +98,7 @@ def load_transform_df_target_property_type_ew() -> pl.DataFrame:
         )
     )
 
-    return df.collect()
+    return df
 
 
 def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
@@ -113,7 +113,7 @@ def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
         skip_rows=10,
         columns=list(range(0, 11)),
         infer_schema_length=10000,
-    )
+    ).collect()
     df = (
         df[1:]
         .drop_nulls(subset=cs.numeric())
@@ -156,7 +156,7 @@ def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
         != 0
     )
 
-    return df.collect()
+    return df
 
 
 def transform_df_target_tenure() -> pl.DataFrame:
@@ -185,7 +185,7 @@ def load_transform_df_target_tenure_scotland() -> pl.DataFrame:
         skip_rows=10,
         columns=list(range(1, 4)),
         infer_schema_length=10000,
-    )
+    ).collect()
     df = (
         df.drop_nulls()
         .rename({"Intermediate Zone - Data Zone 2011": "lsoa"})
@@ -210,9 +210,7 @@ def load_transform_df_target_tenure_scotland() -> pl.DataFrame:
         != 0
     )
 
-    return df.select(
-        ["lsoa", "owner-occupied", "rental (social)", "rental (private)"]
-    ).collect()
+    return df.select(["lsoa", "owner-occupied", "rental (social)", "rental (private)"])
 
 
 def load_transform_df_target_tenure_ew() -> pl.DataFrame:
@@ -222,7 +220,7 @@ def load_transform_df_target_tenure_ew() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of tenure type for all LSOAs in England and Wales
     """
-    df = pl.scan_csv(config["data_source"]["EW_census_tenure"])
+    df = pl.scan_csv(config["data_source"]["EW_census_tenure"]).collect()
 
     owned_cols = [
         "Owned: Owns with a mortgage or loan",
@@ -261,7 +259,7 @@ def load_transform_df_target_tenure_ew() -> pl.DataFrame:
         )
     )
 
-    return df.collect()
+    return df
 
 
 def get_df_target_build_year(
@@ -281,7 +279,7 @@ def get_df_target_build_year(
     Returns:
         pl.Dataframe: counts of properties built before and after given year for all LSOAs in England and Wales.
     """
-    df = pl.scan_csv(config["data_source"]["EW_cdrc_dwelling_age"])
+    df = pl.scan_csv(config["data_source"]["EW_cdrc_dwelling_age"]).collect()
     df = (
         df.with_columns(
             [
@@ -293,7 +291,7 @@ def get_df_target_build_year(
         .select(["lsoa", f"pre_{year_label}", f"post_{year_label}", "unknown"])
     )
 
-    return df.collect()
+    return df
 
 
 def get_df_target_build_year_la() -> pl.DataFrame:

--- a/asf_heat_pump_suitability/getters/get_target.py
+++ b/asf_heat_pump_suitability/getters/get_target.py
@@ -108,12 +108,15 @@ def load_transform_df_target_property_type_scotland() -> pl.DataFrame:
     Returns:
         pl.Dataframe: counts of property type for all data zones in Scotland
     """
-    df = pl.scan_csv(
-        config["data_source"]["S_census_accommodation_type"],
-        skip_rows=10,
-        columns=list(range(0, 11)),
-        infer_schema_length=10000,
-    ).collect()
+    df = (
+        pl.scan_csv(
+            config["data_source"]["S_census_accommodation_type"],
+            skip_rows=10,
+            infer_schema_length=10000,
+        )
+        .collect()
+        .select(list(range(0, 11)))
+    )
     df = (
         df[1:]
         .drop_nulls(subset=cs.numeric())
@@ -180,12 +183,15 @@ def load_transform_df_target_tenure_scotland() -> pl.DataFrame:
     Returns:
         pl.DataFrame: tenure type counts per data zone in Scotland
     """
-    df = pl.scan_csv(
-        config["data_source"]["S_census_tenure"],
-        skip_rows=10,
-        columns=list(range(1, 4)),
-        infer_schema_length=10000,
-    ).collect()
+    df = (
+        pl.scan_csv(
+            config["data_source"]["S_census_tenure"],
+            skip_rows=10,
+            infer_schema_length=10000,
+        )
+        .collect()
+        .select(list(range(1, 4)))
+    )
     df = (
         df.drop_nulls()
         .rename({"Intermediate Zone - Data Zone 2011": "lsoa"})

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -70,7 +70,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
             ],
         )
 
-        self.epc_df = self.epc_df.sample(n=1000, seed=2)
+        # self.epc_df = self.epc_df.sample(n=1000, seed=2)
 
         self.next(self.join_lsoa_code)
 
@@ -102,7 +102,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
             self.prepare_for_country_specific_reweighting, foreach="country_features"
         )
 
-    @batch(cpu=2, memory=1000)
+    @batch(cpu=2, memory=16000)
     @step
     def prepare_for_country_specific_reweighting(self):
         """
@@ -134,7 +134,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
         )
 
         self.chunks = parallel_utils.chunk_df_by_group(
-            self.epc_cleaned_df, group_col="lsoa", n=100
+            self.epc_cleaned_df, group_col="lsoa", n=1000
         )
 
         # Generate target marginals for all features and LSOAs
@@ -144,7 +144,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
         self.next(self.reweight_properties_per_lsoa, foreach="chunks")
 
-    @batch(cpu=2, memory=1000)
+    @batch(cpu=2, memory=16000)
     @step
     def reweight_properties_per_lsoa(self):
         """

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -15,18 +15,6 @@ python asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py
 NB: this pipeline takes the preprocessed and deduplicated EPC dataset in parquet file format.
 """
 
-import logging
-import polars as pl
-from tqdm import tqdm
-import time
-import itertools
-from asf_heat_pump_suitability.pipeline.prepare_features import output_areas
-from asf_heat_pump_suitability.pipeline.reweight_epc import (
-    prepare_target,
-    prepare_sample,
-    reweight_epc,
-)
-from asf_heat_pump_suitability.utils import parallel_utils, save_utils
 from metaflow import FlowSpec, step, batch, Parameter
 
 
@@ -57,6 +45,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Set parameters, load EPC data and start flow.
         """
+        import polars as pl
+        import logging
+
         # Set reweighting features for each nation
         self.country_features = [
             ("Scotland", ["property_type", "tenure"]),
@@ -88,6 +79,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Join LSOA code to each record in EPC.
         """
+        from asf_heat_pump_suitability.pipeline.prepare_features import output_areas
+
         # Join ONS Postcode Directory LSOA col
         self.epc_df = output_areas.standardise_col_postcode(
             self.epc_df, pcd_col="POSTCODE"
@@ -101,19 +94,35 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Standardise EPC features used in weighting and drop EPC rows missing data required for reweighting.
         """
+        from asf_heat_pump_suitability.pipeline.reweight_epc import prepare_sample
+
         self.epc_df = self.epc_df.drop_nulls(subset=["lsoa"])
         self.epc_df = prepare_sample.add_cols_weighting_features(self.epc_df)
         self.next(
             self.prepare_for_country_specific_reweighting, foreach="country_features"
         )
 
+    @batch(cpu=2, memory=4000)
     @step
     def prepare_for_country_specific_reweighting(self):
         """
         For each country, conduct country-specific preprocessing on the EPC data to prepare for reweighting.
         """
+        # TODO update to dev branch before merge
+        # Install repo on batch machine to access modules
+        import os
+
+        os.system(
+            "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git@154_parallelise_reweighting"
+        )
+        from asf_heat_pump_suitability.utils import parallel_utils
+        from asf_heat_pump_suitability.pipeline.reweight_epc import (
+            prepare_sample,
+            prepare_target,
+        )
+
         country, self.features = self.input
-        logging.info(
+        print(
             f"Running reweighting for {country}. Reweighting using the following features: {self.features}"
         )
         epc_cleaned_df = self.epc_df.filter(pl.col("COUNTRY") == country)
@@ -134,12 +143,27 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
         self.next(self.reweight_properties_per_lsoa, foreach="chunks")
 
+    @batch(cpu=2, memory=4000)
     @step
     def reweight_properties_per_lsoa(self):
         """
         For each chunk of EPC data per country, calculate weights for all properties in each LSOA / DZ using the census
         data.
         """
+        # TODO update to dev branch before merge
+        # Install repo on batch machine to access modules
+        import os
+
+        os.system(
+            "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git@154_parallelise_reweighting"
+        )
+        from tqdm import tqdm
+        import time
+        from asf_heat_pump_suitability.pipeline.reweight_epc import (
+            prepare_target,
+            reweight_epc,
+        )
+
         # Prepare results dicts
         self.lsoa = []
         self.uprn = []
@@ -202,6 +226,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Join chunks of weighted EPC data and weighting stats together per country.
         """
+        import polars as pl
+        import itertools
+
         self.epc_df = inputs[0].epc_df
 
         # Get df of UPRNs, reweighting features, and weights for all nations
@@ -246,6 +273,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Join weighted EPC data per country together.
         """
+        import polars as pl
+
         self.epc_df = inputs[0].epc_df
         self.weights_df = pl.concat([input.weights_df for input in inputs])
         self.lsoa_stats_df = pl.concat([input.lsoa_stats_df for input in inputs])
@@ -268,6 +297,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Save reweighted EPC data and reweighting stats to S3.
         """
+        from asf_heat_pump_suitability.utils import save_utils
+
         save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
         save_utils.save_to_s3(self.weights_df, f"{save_as}.parquet")
         save_utils.save_to_s3(self.lsoa_stats_df, f"{save_as}_stats.parquet")
@@ -278,6 +309,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         End flow.
         """
+        import logging
+
         logging.info("Compute EPC weights flow complete!")
 
 

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -115,6 +115,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
         os.system(
             "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git@154_parallelise_reweighting"
         )
+        import polars as pl
         from asf_heat_pump_suitability.utils import parallel_utils
         from asf_heat_pump_suitability.pipeline.reweight_epc import (
             prepare_sample,

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -79,7 +79,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
             ],
         )
 
-        self.epc_df = self.epc_df.sample(n=1000)
+        self.epc_df = self.epc_df.sample(n=1000, seed=2)
 
         self.next(self.join_lsoa_code)
 
@@ -137,10 +137,17 @@ class ComputeEpcWeightsFlow(FlowSpec):
     def reweight_properties_per_lsoa(self):
         """ """
         # Prepare results dicts
-        self.weights = {"UPRN": [], "lsoa": [], "weight": [], "proportional_weight": []}
-        self.lsoa_stats = {"lsoa": [], "time": [], "lost_rows": []}
+        self.lsoa = []
+        self.uprn = []
+        self.lsoas = []
+        self.weight = []
+        self.proportional_weight = []
+        self.time = []
+        self.lost_rows = []
 
         for lsoa in tqdm(self.input["lsoa"].unique()):
+            self.lsoa.append(lsoa)
+
             try:
                 start = time.time()
                 sample, lost_rows = reweight_epc.generate_balance_sample(
@@ -149,35 +156,39 @@ class ComputeEpcWeightsFlow(FlowSpec):
                     lsoa=lsoa,
                     target_marginals=self.target_marginals,
                 )
-                target = prepare_target.generate_balance_target_population(
-                    target_marginals=self.target_marginals, lsoa=lsoa
-                )
-                weighted_sample = reweight_epc.generate_weighted_sample(
-                    balance_sample=sample, balance_target=target
-                )
-                _weights = reweight_epc.get_dict_sample_weights(
-                    weighted_sample=weighted_sample
-                )
 
-                # Add outputs weights for LSOA to dict
-                self.weights["UPRN"].extend(_weights["UPRN"])
-                # Adding LSOA required for dummy rows
-                self.weights["lsoa"].extend(
-                    [lsoa for i in range(len(_weights["UPRN"]))]
-                )
-                self.weights["weight"].extend(_weights["weight"])
-                self.weights["proportional_weight"].extend(
-                    _weights["proportional_weight"]
-                )
+                if sample:
+                    target = prepare_target.generate_balance_target_population(
+                        target_marginals=self.target_marginals, lsoa=lsoa
+                    )
+                    weighted_sample = reweight_epc.generate_weighted_sample(
+                        balance_sample=sample, balance_target=target
+                    )
+                    _weights = reweight_epc.get_dict_sample_weights(
+                        weighted_sample=weighted_sample
+                    )
+
+                    # Add output weights for LSOA to dict
+                    self.uprn.extend(_weights["UPRN"])
+                    # Adding LSOA required for dummy rows
+                    self.lsoas.extend([lsoa for i in range(len(_weights["UPRN"]))])
+                    self.weight.extend(_weights["weight"])
+                    self.proportional_weight.extend(_weights["proportional_weight"])
+
+                else:
+                    print(
+                        f"No records remaining to reweight after preprocessing for LSOA: {lsoa}. Skipping."
+                    )
 
                 # LSOA stats
                 end = time.time()
-                self.lsoa_stats["lsoa"].append(lsoa)
-                self.lsoa_stats["time"].append(end - start)
-                self.lsoa_stats["lost_rows"].append(lost_rows)
+                self.time.append(end - start)
+                self.lost_rows.append(lost_rows)
 
             except KeyError:
                 print(f"No target data found for LSOA: {lsoa}. Skipping.")
+                self.time.append(None)
+                self.lost_rows.append(None)
                 continue
 
         self.next(self.join_weights)
@@ -185,18 +196,49 @@ class ComputeEpcWeightsFlow(FlowSpec):
     @step
     def join_weights(self, inputs):
         """ """
+        self.epc_df = inputs[0].epc_df
+
         # Get df of UPRNs, reweighting features, and weights for all nations
         self.weights_df = pl.DataFrame(
-            list(itertools.chain.from_iterable([input.weights for input in inputs]))
+            {
+                "UPRN": list(
+                    itertools.chain.from_iterable([input.uprn for input in inputs])
+                ),
+                "lsoa": list(
+                    itertools.chain.from_iterable([input.lsoas for input in inputs])
+                ),
+                "weight": list(
+                    itertools.chain.from_iterable([input.weight for input in inputs])
+                ),
+                "proportional_weight": list(
+                    itertools.chain.from_iterable(
+                        [input.proportional_weight for input in inputs]
+                    )
+                ),
+            }
         )
+
+        # Get df of stats for all nations
         self.lsoa_stats_df = pl.DataFrame(
-            list(itertools.chain.from_iterable([input.lsoa_stats for input in inputs]))
+            {
+                "lsoa": list(
+                    itertools.chain.from_iterable([input.lsoa for input in inputs])
+                ),
+                "time": list(
+                    itertools.chain.from_iterable([input.time for input in inputs])
+                ),
+                "lost_rows": list(
+                    itertools.chain.from_iterable([input.lost_rows for input in inputs])
+                ),
+            }
         )
+
         self.next(self.join_countries)
 
     @step
     def join_countries(self, inputs):
         """ """
+        self.epc_df = inputs[0].epc_df
         self.weights_df = pl.concat([input.weights_df for input in inputs])
         self.lsoa_stats_df = pl.concat([input.lsoa_stats_df for input in inputs])
         self.next(self.join_weights_to_epc)

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -57,6 +57,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         Load EPC data and start flow.
         """
+        dataset_desc = "sample" if self.sample else "full"
+        print(f"Running CalculateSuitabilityFlow on {dataset_desc} EPC dataset.")
+
         import polars as pl
 
         # Set reweighting features for each nation
@@ -82,13 +85,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
         )
 
         if self.sample:
-            print("Running ComputeEpcWeightsFlow on a sample of EPC data (N=1000)")
+            print("Sampling 1000 rows from EPC data to run pipeline on")
             self.epc_df = self.epc_df.sample(n=1000, seed=2)
-            self.batch_memory = 1000
-        else:
-            self.batch_memory = 16000
-
-        print(f"Setting memory for batch steps to {self.batch_memory} MB")
 
         self.next(self.join_lsoa_code)
 
@@ -121,8 +119,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
             self.prepare_for_country_specific_reweighting, foreach="country_features"
         )
 
-    # @batch(cpu=2, memory=16000)
-    @batch(cpu=2, memory=1000)
+    @batch(cpu=2, memory=16000)
     @step
     def prepare_for_country_specific_reweighting(self):
         """
@@ -169,8 +166,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
         self.next(self.reweight_properties_per_lsoa, foreach="chunks")
 
-    # @batch(cpu=2, memory=16000)
-    @batch(cpu=2, memory=1000)
+    @batch(cpu=2, memory=16000)
     @step
     def reweight_properties_per_lsoa(self):
         """

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -71,7 +71,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
         )
 
         # TODO remove before merge
-        # self.epc_df = self.epc_df.sample(n=1000, seed=2)
+        self.epc_df = self.epc_df.sample(n=1000, seed=2)
 
         self.next(self.join_lsoa_code)
 
@@ -103,7 +103,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
             self.prepare_for_country_specific_reweighting, foreach="country_features"
         )
 
-    @batch(cpu=2, memory=16000)
+    # @batch(cpu=2, memory=16000)
+    @batch(cpu=2, memory=1000)
     @step
     def prepare_for_country_specific_reweighting(self):
         """
@@ -135,7 +136,10 @@ class ComputeEpcWeightsFlow(FlowSpec):
         )
 
         self.chunks = parallel_utils.chunk_df_by_group(
-            self.epc_cleaned_df, group_col="lsoa", n=1000
+            # self.epc_cleaned_df, group_col="lsoa", n=1000
+            self.epc_cleaned_df,
+            group_col="lsoa",
+            n=100,
         )
 
         # Generate target marginals for all features and LSOAs
@@ -145,7 +149,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
         self.next(self.reweight_properties_per_lsoa, foreach="chunks")
 
-    @batch(cpu=2, memory=16000)
+    # @batch(cpu=2, memory=16000)
+    @batch(cpu=2, memory=1000)
     @step
     def reweight_properties_per_lsoa(self):
         """
@@ -301,7 +306,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         from asf_heat_pump_suitability.utils import save_utils
 
-        save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
+        # save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
+        save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights_SAMPLE"
         save_utils.save_to_s3(self.weights_df, f"{save_as}.parquet")
         save_utils.save_to_s3(self.lsoa_stats_df, f"{save_as}_stats.parquet")
         self.next(self.end)

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -10,7 +10,7 @@ only (property type and tenure) because there is no target build year data aggre
 Scotland.
 
 To run:
-python asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --datastore=s3 run --epc [path/to/EPC] -y [YYYY] -q [Q]
+python asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --datastore=s3 run --epc [path/to/EPC] --year [YYYY] --quarter [Q]
 
 NB: this pipeline takes the preprocessed and deduplicated EPC dataset in parquet file format.
 """
@@ -39,18 +39,25 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     quarter = Parameter(
         name="quarter",
-        help="EPC data quarter",
+        help="EPC data quarter, 1-4",
         type=int,
         required=True,
+    )
+
+    sample = Parameter(
+        name="sample",
+        help="Set to True to sample 1000 rows from the EPC dataset to run the flow on. Defaults to False which runs the flow on the full EPC dataset.",
+        type=bool,
+        default=False,
+        required=False,
     )
 
     @step
     def start(self):
         """
-        Set parameters, load EPC data and start flow.
+        Load EPC data and start flow.
         """
         import polars as pl
-        import logging
 
         # Set reweighting features for each nation
         self.country_features = [
@@ -60,7 +67,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
         ]
 
         # Import processed & deduplicated EPC
-        logging.info(f"Loading EPC file from path: {self.epc_path}")
+        print(f"Loading EPC file from path: {self.epc_path}")
         self.epc_df = pl.read_parquet(
             self.epc_path,
             columns=[
@@ -74,8 +81,14 @@ class ComputeEpcWeightsFlow(FlowSpec):
             ],
         )
 
-        # TODO remove before merge
-        self.epc_df = self.epc_df.sample(n=1000, seed=2)
+        if self.sample:
+            print("Running ComputeEpcWeightsFlow on a sample of EPC data (N=1000)")
+            self.epc_df = self.epc_df.sample(n=1000, seed=2)
+            self.batch_memory = 1000
+        else:
+            self.batch_memory = 16000
+
+        print(f"Setting memory for batch steps to {self.batch_memory} MB")
 
         self.next(self.join_lsoa_code)
 
@@ -97,8 +110,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
     @step
     def prepare_for_reweighting(self):
         """
-        Standardise EPC features used in weighting and drop EPC rows missing data required for reweighting (missing LSOA
-        information or reweighting features).
+        Standardise EPC features used in weighting and drop EPC rows missing data required for reweighting (those missing
+        LSOA information or reweighting features).
         """
         from asf_heat_pump_suitability.pipeline.reweight_epc import prepare_sample
 
@@ -140,12 +153,14 @@ class ComputeEpcWeightsFlow(FlowSpec):
             df=epc_cleaned_df, features=self.features
         )
 
-        self.chunks = parallel_utils.chunk_df_by_group(
-            # self.epc_cleaned_df, group_col="lsoa", n=1000
-            self.epc_cleaned_df,
-            group_col="lsoa",
-            n=100,
-        )
+        if self.sample:
+            self.chunks = parallel_utils.chunk_df_by_group(
+                self.epc_cleaned_df, group_col="lsoa", n=100
+            )
+        else:
+            self.chunks = parallel_utils.chunk_df_by_group(
+                self.epc_cleaned_df, group_col="lsoa", n=1000
+            )
 
         # Generate target marginals for all features and LSOAs
         self.target_marginals = prepare_target.get_dict_target_marginals(
@@ -162,6 +177,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
         For each chunk of EPC data per country, use Iterative Proportional Fitting (IPF) to calculate weights for all
         properties per LSOA / DZ. Properties are weighted so that the total proportions of each target feature match as
         closely as possible to the target marginals of each target feature in the census data for the LSOA / DZ.
+
+        This step also saves information about how long each LSOA / DZ takes to reweight and how many EPC rows are
+        not weighted due to preprocessing.
         """
         # TODO update to dev branch before merge
         # Install repo on batch machine to access modules
@@ -262,7 +280,13 @@ class ComputeEpcWeightsFlow(FlowSpec):
                         [input.proportional_weight for input in inputs]
                     )
                 ),
-            }
+            },
+            schema={
+                "UPRN": pl.String,
+                "lsoa": pl.String,
+                "weight": pl.Float64,
+                "proportional_weight": pl.Float64,
+            },
         )
 
         # Get df of stats for all nations
@@ -277,7 +301,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
                 "lost_rows": list(
                     itertools.chain.from_iterable([input.lost_rows for input in inputs])
                 ),
-            }
+            },
+            schema={"lsoa": pl.String, "time": pl.Float64, "lost_rows": pl.Float64},
         )
 
         self.next(self.join_countries)
@@ -285,7 +310,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
     @step
     def join_countries(self, inputs):
         """
-        Join weighted EPC data per country together.
+        Concatenate weighted EPC data from each country together into single dataframe.
         """
         import polars as pl
 
@@ -313,8 +338,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         from asf_heat_pump_suitability.utils import save_utils
 
-        # save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
-        save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights_SAMPLE"
+        save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
+        if self.sample:
+            save_as = save_as + "_SAMPLE"
         save_utils.save_to_s3(self.weights_df, f"{save_as}.parquet")
         save_utils.save_to_s3(self.lsoa_stats_df, f"{save_as}_stats.parquet")
         self.next(self.end)
@@ -324,9 +350,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         End flow.
         """
-        import logging
-
-        logging.info("Compute EPC weights flow complete!")
+        print("Compute EPC weights flow complete!")
 
 
 if __name__ == "__main__":

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -12,6 +12,8 @@ Scotland.
 To run:
 python asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py --datastore=s3 run --epc [path/to/EPC] --year [YYYY] --quarter [Q]
 
+Set --sample to True to run on a sample of 1000 EPC records
+
 NB: this pipeline takes the preprocessed and deduplicated EPC dataset in parquet file format.
 """
 
@@ -125,12 +127,11 @@ class ComputeEpcWeightsFlow(FlowSpec):
         """
         For each country, conduct country-specific preprocessing on the EPC data to prepare for reweighting.
         """
-        # TODO update to dev branch before merge
         # Install repo on batch machine to access modules
         import os
 
         os.system(
-            "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git@154_parallelise_reweighting"
+            "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git"
         )
         import polars as pl
         from asf_heat_pump_suitability.utils import parallel_utils
@@ -177,12 +178,11 @@ class ComputeEpcWeightsFlow(FlowSpec):
         This step also saves information about how long each LSOA / DZ takes to reweight and how many EPC rows are
         not weighted due to preprocessing.
         """
-        # TODO update to dev branch before merge
         # Install repo on batch machine to access modules
         import os
 
         os.system(
-            "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git@154_parallelise_reweighting"
+            "pip install git+https://github.com/nestauk/asf_heat_pump_suitability.git"
         )
         from tqdm import tqdm
         import time

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -102,7 +102,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
             self.prepare_for_country_specific_reweighting, foreach="country_features"
         )
 
-    @batch(cpu=2, memory=4000)
+    @batch(cpu=2, memory=1000)
     @step
     def prepare_for_country_specific_reweighting(self):
         """
@@ -144,7 +144,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
         self.next(self.reweight_properties_per_lsoa, foreach="chunks")
 
-    @batch(cpu=2, memory=4000)
+    @batch(cpu=2, memory=1000)
     @step
     def reweight_properties_per_lsoa(self):
         """

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -1,5 +1,5 @@
 """
-Weight properties with Iterative Proportional Fitting per LSOA / Data Zone according to the
+FLow to weight properties with Iterative Proportional Fitting per LSOA / Data Zone according to the
 following features:
 - property type (detached, semi-detached, terraced, flats, other);
 - tenure (owner-occupied, social rental, private rental)
@@ -10,7 +10,7 @@ only (property type and tenure) because there is no target build year data aggre
 Scotland.
 
 To run:
-python -i asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --epc [path/to/EPC] -y [YYYY] -q [Q]
+python asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --datastore=s3 run --epc [path/to/EPC] -y [YYYY] -q [Q]
 
 NB: this pipeline takes the preprocessed and deduplicated EPC dataset in parquet file format.
 """
@@ -99,9 +99,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
     @step
     def prepare_for_reweighting(self):
         """
-        Prepare EPC data for reweighting.
+        Standardise EPC features used in weighting and drop EPC rows missing data required for reweighting.
         """
-        # Add standardised weighting feature columns to EPC and drop rows missing data required for reweighting
         self.epc_df = self.epc_df.drop_nulls(subset=["lsoa"])
         self.epc_df = prepare_sample.add_cols_weighting_features(self.epc_df)
         self.next(
@@ -110,7 +109,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def prepare_for_country_specific_reweighting(self):
-        """ """
+        """
+        For each country, conduct country-specific preprocessing on the EPC data to prepare for reweighting.
+        """
         country, self.features = self.input
         logging.info(
             f"Running reweighting for {country}. Reweighting using the following features: {self.features}"
@@ -135,7 +136,10 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def reweight_properties_per_lsoa(self):
-        """ """
+        """
+        For each chunk of EPC data per country, calculate weights for all properties in each LSOA / DZ using the census
+        data.
+        """
         # Prepare results dicts
         self.lsoa = []
         self.uprn = []
@@ -195,7 +199,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def join_weights(self, inputs):
-        """ """
+        """
+        Join chunks of weighted EPC data and weighting stats together per country.
+        """
         self.epc_df = inputs[0].epc_df
 
         # Get df of UPRNs, reweighting features, and weights for all nations
@@ -237,7 +243,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def join_countries(self, inputs):
-        """ """
+        """
+        Join weighted EPC data per country together.
+        """
         self.epc_df = inputs[0].epc_df
         self.weights_df = pl.concat([input.weights_df for input in inputs])
         self.lsoa_stats_df = pl.concat([input.lsoa_stats_df for input in inputs])
@@ -245,7 +253,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def join_weights_to_epc(self):
-        """ """
+        """
+        Merge weighted EPC with reweighting features.
+        """
         # Left join ensures we retain dummy rows which we need to retain for reweighting evaluation
         self.epc_df = self.epc_df.select(
             ["UPRN", "property_type", "tenure", "build_year"]
@@ -255,7 +265,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def save_results(self):
-        """ """
+        """
+        Save reweighted EPC data and reweighting stats to S3.
+        """
         save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
         save_utils.save_to_s3(self.weights_df, f"{save_as}.parquet")
         save_utils.save_to_s3(self.lsoa_stats_df, f"{save_as}_stats.parquet")
@@ -263,6 +275,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
 
     @step
     def end(self):
+        """
+        End flow.
+        """
         logging.info("Compute EPC weights flow complete!")
 
 

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -1,0 +1,228 @@
+"""
+Weight properties with Iterative Proportional Fitting per LSOA / Data Zone according to the
+following features:
+- property type (detached, semi-detached, terraced, flats, other);
+- tenure (owner-occupied, social rental, private rental)
+- build year (pre- and post-1930 split, and unknown); [applies to England and Wales only*]
+
+*Data Zones in Scotland are the closest equivalent to LSOAs in England and Wales. They are reweighted on two features
+only (property type and tenure) because there is no target build year data aggregated to Data Zone-level available for
+Scotland.
+
+To run:
+python -i asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --epc [path/to/EPC] -y [YYYY] -q [Q]
+
+NB: this pipeline takes the preprocessed and deduplicated EPC dataset in parquet file format.
+"""
+
+import logging
+import polars as pl
+from tqdm import tqdm
+import time
+import itertools
+from asf_heat_pump_suitability.pipeline.prepare_features import output_areas
+from asf_heat_pump_suitability.pipeline.reweight_epc import (
+    prepare_target,
+    prepare_sample,
+    reweight_epc,
+)
+from asf_heat_pump_suitability.utils import parallel_utils, save_utils
+from metaflow import FlowSpec, step, batch, Parameter
+
+
+class ComputeEpcWeightsFlow(FlowSpec):
+    epc_path = Parameter(
+        name="epc",
+        help="Path to processed and deduplicated EPC dataset in parquet file format",
+        type=str,
+        required=True,
+    )
+
+    year = Parameter(
+        name="year",
+        help="EPC data year. Format YYYY",
+        type=int,
+        required=True,
+    )
+
+    quarter = Parameter(
+        name="quarter",
+        help="EPC data quarter",
+        type=int,
+        required=True,
+    )
+
+    @step
+    def start(self):
+        """
+        Set parameters, load EPC data and start flow.
+        """
+        # Set reweighting features for each nation
+        self.country_features = [
+            ("Scotland", ["property_type", "tenure"]),
+            ("England", ["property_type", "tenure", "build_year"]),
+            ("Wales", ["property_type", "tenure", "build_year"]),
+        ]
+
+        # Import processed & deduplicated EPC
+        logging.info(f"Loading EPC file from path: {self.epc_path}")
+        self.epc_df = pl.read_parquet(
+            self.epc_path,
+            columns=[
+                "UPRN",
+                "POSTCODE",
+                "COUNTRY",
+                "TENURE",
+                "PROPERTY_TYPE",
+                "BUILT_FORM",
+                "CONSTRUCTION_AGE_BAND",
+            ],
+        )
+
+        self.epc_df = self.epc_df.sample(n=1000)
+
+        self.next(self.join_lsoa_code)
+
+    @step
+    def join_lsoa_code(self):
+        """
+        Join LSOA code to each record in EPC.
+        """
+        # Join ONS Postcode Directory LSOA col
+        self.epc_df = output_areas.standardise_col_postcode(
+            self.epc_df, pcd_col="POSTCODE"
+        )
+        lsoa_df = output_areas.load_transform_df_lsoas()
+        self.epc_df = self.epc_df.join(lsoa_df, how="left", on="POSTCODE")
+        self.next(self.prepare_for_reweighting)
+
+    @step
+    def prepare_for_reweighting(self):
+        """
+        Prepare EPC data for reweighting.
+        """
+        # Add standardised weighting feature columns to EPC and drop rows missing data required for reweighting
+        self.epc_df = self.epc_df.drop_nulls(subset=["lsoa"])
+        self.epc_df = prepare_sample.add_cols_weighting_features(self.epc_df)
+        self.next(
+            self.prepare_for_country_specific_reweighting, foreach="country_features"
+        )
+
+    @step
+    def prepare_for_country_specific_reweighting(self):
+        """ """
+        country, self.features = self.input
+        logging.info(
+            f"Running reweighting for {country}. Reweighting using the following features: {self.features}"
+        )
+        epc_cleaned_df = self.epc_df.filter(pl.col("COUNTRY") == country)
+        assert len(epc_cleaned_df) > 0, f"No EPC records found for {country}."
+
+        self.epc_cleaned_df = prepare_sample.drop_nulls_feature_cols(
+            df=epc_cleaned_df, features=self.features
+        )
+
+        self.chunks = parallel_utils.chunk_df_by_group(
+            self.epc_cleaned_df, group_col="lsoa", n=100
+        )
+
+        # Generate target marginals for all features and LSOAs
+        self.target_marginals = prepare_target.get_dict_target_marginals(
+            features=self.features
+        )
+
+        self.next(self.reweight_properties_per_lsoa, foreach="chunks")
+
+    @step
+    def reweight_properties_per_lsoa(self):
+        """ """
+        # Prepare results dicts
+        self.weights = {"UPRN": [], "lsoa": [], "weight": [], "proportional_weight": []}
+        self.lsoa_stats = {"lsoa": [], "time": [], "lost_rows": []}
+
+        for lsoa in tqdm(self.input["lsoa"].unique()):
+            try:
+                start = time.time()
+                sample, lost_rows = reweight_epc.generate_balance_sample(
+                    df=self.input,
+                    features=self.features,
+                    lsoa=lsoa,
+                    target_marginals=self.target_marginals,
+                )
+                target = prepare_target.generate_balance_target_population(
+                    target_marginals=self.target_marginals, lsoa=lsoa
+                )
+                weighted_sample = reweight_epc.generate_weighted_sample(
+                    balance_sample=sample, balance_target=target
+                )
+                _weights = reweight_epc.get_dict_sample_weights(
+                    weighted_sample=weighted_sample
+                )
+
+                # Add outputs weights for LSOA to dict
+                self.weights["UPRN"].extend(_weights["UPRN"])
+                # Adding LSOA required for dummy rows
+                self.weights["lsoa"].extend(
+                    [lsoa for i in range(len(_weights["UPRN"]))]
+                )
+                self.weights["weight"].extend(_weights["weight"])
+                self.weights["proportional_weight"].extend(
+                    _weights["proportional_weight"]
+                )
+
+                # LSOA stats
+                end = time.time()
+                self.lsoa_stats["lsoa"].append(lsoa)
+                self.lsoa_stats["time"].append(end - start)
+                self.lsoa_stats["lost_rows"].append(lost_rows)
+
+            except KeyError:
+                print(f"No target data found for LSOA: {lsoa}. Skipping.")
+                continue
+
+        self.next(self.join_weights)
+
+    @step
+    def join_weights(self, inputs):
+        """ """
+        # Get df of UPRNs, reweighting features, and weights for all nations
+        self.weights_df = pl.DataFrame(
+            list(itertools.chain.from_iterable([input.weights for input in inputs]))
+        )
+        self.lsoa_stats_df = pl.DataFrame(
+            list(itertools.chain.from_iterable([input.lsoa_stats for input in inputs]))
+        )
+        self.next(self.join_countries)
+
+    @step
+    def join_countries(self, inputs):
+        """ """
+        self.weights_df = pl.concat([input.weights_df for input in inputs])
+        self.lsoa_stats_df = pl.concat([input.lsoa_stats_df for input in inputs])
+        self.next(self.join_weights_to_epc)
+
+    @step
+    def join_weights_to_epc(self):
+        """ """
+        # Left join ensures we retain dummy rows which we need to retain for reweighting evaluation
+        self.epc_df = self.epc_df.select(
+            ["UPRN", "property_type", "tenure", "build_year"]
+        )
+        self.weights_df = self.weights_df.join(self.epc_df, how="left", on="UPRN")
+        self.next(self.save_results)
+
+    @step
+    def save_results(self):
+        """ """
+        save_as = f"s3://asf-heat-pump-suitability/outputs/{self.year}Q{self.quarter}/weights/{self.year}_Q{self.quarter}_EPC_weights"
+        save_utils.save_to_s3(self.weights_df, f"{save_as}.parquet")
+        save_utils.save_to_s3(self.lsoa_stats_df, f"{save_as}_stats.parquet")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        logging.info("Compute EPC weights flow complete!")
+
+
+if __name__ == "__main__":
+    ComputeEpcWeightsFlow()

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -10,7 +10,7 @@ only (property type and tenure) because there is no target build year data aggre
 Scotland.
 
 To run:
-python asf_heat_pump_suitability/pipeline/run_scripts/run_compute_epc_weights.py --datastore=s3 run --epc [path/to/EPC] --year [YYYY] --quarter [Q]
+python asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py --datastore=s3 run --epc [path/to/EPC] --year [YYYY] --quarter [Q]
 
 NB: this pipeline takes the preprocessed and deduplicated EPC dataset in parquet file format.
 """

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -1,5 +1,5 @@
 """
-FLow to weight properties with Iterative Proportional Fitting per LSOA / Data Zone according to the
+Flow to weight properties with Iterative Proportional Fitting per LSOA / Data Zone according to the
 following features:
 - property type (detached, semi-detached, terraced, flats, other);
 - tenure (owner-occupied, social rental, private rental)
@@ -19,6 +19,10 @@ from metaflow import FlowSpec, step, batch, Parameter
 
 
 class ComputeEpcWeightsFlow(FlowSpec):
+    """
+    Flow to weight properties with Iterative Proportional Fitting per LSOA / Data Zone.
+    """
+
     epc_path = Parameter(
         name="epc",
         help="Path to processed and deduplicated EPC dataset in parquet file format",
@@ -93,7 +97,8 @@ class ComputeEpcWeightsFlow(FlowSpec):
     @step
     def prepare_for_reweighting(self):
         """
-        Standardise EPC features used in weighting and drop EPC rows missing data required for reweighting.
+        Standardise EPC features used in weighting and drop EPC rows missing data required for reweighting (missing LSOA
+        information or reweighting features).
         """
         from asf_heat_pump_suitability.pipeline.reweight_epc import prepare_sample
 
@@ -154,8 +159,9 @@ class ComputeEpcWeightsFlow(FlowSpec):
     @step
     def reweight_properties_per_lsoa(self):
         """
-        For each chunk of EPC data per country, calculate weights for all properties in each LSOA / DZ using the census
-        data.
+        For each chunk of EPC data per country, use Iterative Proportional Fitting (IPF) to calculate weights for all
+        properties per LSOA / DZ. Properties are weighted so that the total proportions of each target feature match as
+        closely as possible to the target marginals of each target feature in the census data for the LSOA / DZ.
         """
         # TODO update to dev branch before merge
         # Install repo on batch machine to access modules
@@ -236,6 +242,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
         import polars as pl
         import itertools
 
+        # This line exists to persist the epc_df variable to the next step in the flow
         self.epc_df = inputs[0].epc_df
 
         # Get df of UPRNs, reweighting features, and weights for all nations

--- a/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
+++ b/asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py
@@ -70,6 +70,7 @@ class ComputeEpcWeightsFlow(FlowSpec):
             ],
         )
 
+        # TODO remove before merge
         # self.epc_df = self.epc_df.sample(n=1000, seed=2)
 
         self.next(self.join_lsoa_code)

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
@@ -5,6 +5,7 @@ Functions to reweight EPC using IPF against target marginals.
 import polars as pl
 import random
 from typing import Dict, Tuple
+import logging
 import balance
 from asf_heat_pump_suitability.pipeline.reweight_epc import prepare_target
 
@@ -67,7 +68,7 @@ def generate_balance_sample(
 
     Returns:
         Tuple[balance.sample_class.Sample, int]: EPC data sample for a single LSOA prepared for weighting with number of
-        rows lost during preprocessing
+        rows lost during preprocessing. Returns `None` in place of EPC data sample if all EPC rows are lost during preprocessing.
     """
     # Get EPC sample filtered for single given LSOA
     cols = ["lsoa", "UPRN"]
@@ -88,18 +89,22 @@ def generate_balance_sample(
         sample = sample.filter(~pl.col(feature).is_in(missing))
     lost_rows = len_before - len(sample)
 
-    # TODO generating dummies will fail and cause pipeline error if all rows are removed from sample in code above
-    # TODO we need to check if len(sample) > 0 and only proceed with remaining code if it is
-    # Add dummy rows for feature categories missing from sample but present in target
-    dummies = generate_df_dummies(lsoa_marginals=lsoa_marginals, sample=sample)
-    sample = pl.concat([sample, dummies[sample.columns]])
+    if len(sample) > 0:
+        # Add dummy rows for feature categories missing from sample but present in target
+        dummies = generate_df_dummies(lsoa_marginals=lsoa_marginals, sample=sample)
+        sample = pl.concat([sample, dummies[sample.columns]])
 
-    # Convert to balance sample
-    cols.remove("lsoa")
-    balance_sample = sample.to_pandas()
-    balance_sample = balance.Sample.from_frame(balance_sample[cols], id_column="UPRN")
+        # Convert to balance sample
+        cols.remove("lsoa")
+        balance_sample = sample.to_pandas()
+        balance_sample = balance.Sample.from_frame(
+            balance_sample[cols], id_column="UPRN"
+        )
 
-    return balance_sample, lost_rows
+        return balance_sample, lost_rows
+
+    else:
+        return None, lost_rows
 
 
 def generate_df_dummies(

--- a/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
+++ b/asf_heat_pump_suitability/pipeline/reweight_epc/reweight_epc.py
@@ -5,7 +5,6 @@ Functions to reweight EPC using IPF against target marginals.
 import polars as pl
 import random
 from typing import Dict, Tuple
-import logging
 import balance
 from asf_heat_pump_suitability.pipeline.reweight_epc import prepare_target
 

--- a/asf_heat_pump_suitability/utils/parallel_utils.py
+++ b/asf_heat_pump_suitability/utils/parallel_utils.py
@@ -1,0 +1,23 @@
+from typing import List
+import polars as pl
+
+
+def chunk_df_by_group(df: pl.DataFrame, group_col: str, n: int) -> List[pl.DataFrame]:
+    """
+    Split dataframe into chunks of group IDs.
+
+    Args:
+        df (pl.DataFrame): dataframe
+        group_col (str): column with group IDs
+        n (int): number of group IDs in each chunk
+
+    Returns:
+        List[pl.DataFrame]: list of dataframe chunks
+    """
+    # Get unique group IDs
+    group_ids = list(df[group_col].drop_nulls().unique())
+
+    # Get groups of IDs
+    group_chunks = [group_ids[i : i + n] for i in range(0, len(group_ids), n)]
+
+    return [df.filter(pl.col(group_col).is_in(chunk)) for chunk in group_chunks]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,3 +36,6 @@ per-file-ignores =
 # Don't pester about parameters for a one-line docstring
 strictness=short
 docstring_style=google
+
+[options]
+include_package_data = True

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=read_lines(BASE_DIR / "requirements.txt"),
     extras_require={"dev": read_lines(BASE_DIR / "requirements_dev.txt")},
     packages=find_packages(exclude=["docs"]),
-    package_data={"config": [".txt", "*.yaml"]},
+    package_data={"": ["*.txt", "*.yaml"]},
     version="0.1.0",
     description="Early-stage scoping of a project to identify which homes/streets are likely to be suitable (or unsuitable) for which types of heat pumps.",
     author="Nesta",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     long_description=open(BASE_DIR / "README.md").read(),
     install_requires=read_lines(BASE_DIR / "requirements.txt"),
     extras_require={"dev": read_lines(BASE_DIR / "requirements_dev.txt")},
+    include_package_data=True,
     packages=find_packages(exclude=["docs"]),
     package_data={"": ["*.txt", "*.yaml"]},
     version="0.1.0",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """asf_heat_pump_suitability."""
+
 from pathlib import Path
 from setuptools import find_packages
 from setuptools import setup
@@ -19,6 +20,7 @@ setup(
     install_requires=read_lines(BASE_DIR / "requirements.txt"),
     extras_require={"dev": read_lines(BASE_DIR / "requirements_dev.txt")},
     packages=find_packages(exclude=["docs"]),
+    package_data={"config": [".txt", "*.yaml"]},
     version="0.1.0",
     description="Early-stage scoping of a project to identify which homes/streets are likely to be suitable (or unsuitable) for which types of heat pumps.",
     author="Nesta",


### PR DESCRIPTION
Fixes #154 

# Description

Refactor EPC reweighting script into metaflow. Summary of changes:

New files:
- `/pipeline/flows/run_compute_epc_weights_flow.py` - new flow to reweight EPC data. Refactored version of `/pipeline/run_scripts/run_compute_epc_weights.py`
- `/pipeline/reweight_epc/__init__.py` - required to import from package
- `/utils/parallel_utils.py` - new utils file with new function to assist parallelisation


Updated files:
- `MANIFEST.in` ; `setup.cfg` ; `setup.py` - changes required to import `asf_heat_pump_suitability` as package in batch machine
- `/getters/get_target.py` - updated existing function to use `polars.lazyframe` instead of `polars.dataframe` to read a csv file. For some reason, the way csv files are loaded from S3 is different between loading using `scan_csv` and `read_csv` and the latter does not work in a batch machine but the former does.
- `/pipeline/reweight_epc/reweight_epc.py` - fix bug in function which was revealed when reweighting edge case LSOAs. Previously, generating dummies will fail and cause pipeline error if all rows are removed from sample in code above. We need to check if len(sample) > 0 and only proceed with remaining code if it is. I have implemented this.

# Instructions for Reviewer

In order to test the code in this PR you need to ...
I have set up the script to run on a sample of 1000 EPC records and save it to S3. The results will not make sense because there will be lots of records missing for each LSOA. So this is simply to test the flow of the whole pipeline, not the results.
```
export METAFLOW_USER=yournamewithnospacesorpunctuation
python asf_heat_pump_suitability/pipeline/flows/run_compute_epc_weights_flow.py --datastore=s3  run --epc s3://asf-daps/lakehouse/processed/epc/old/deduplicated/processed_dedupl-0.parquet --year 2023 --quarter 4 --max-workers 4
```

- Please do test that the creation of the sample works for you.
- Please could you also check that the results look sensible to you by loading and viewing the full dataset that i've already created with this new flow. I've put some code below. Feel free to do other basic checks you can think of!

```
import polars as pl
df = pl.read_parquet("s3://asf-heat-pump-suitability/outputs/2023Q4/weights/2023_Q4_EPC_weights.parquet")
df.describe()
df.group_by("lsoa").agg(pl.col("proportional_weight").sum()).describe()
```

I've already noticed there are 44 LSOAs with total weight greater than 1.1 (i set to 1.1 rather than 1 to allow for small errors introduced in rounding). They seem to have total weights around 2! I'm not sure what happened here...we should investigate this in a separate PR. I checked this in an old version of the weights data which was created using the original pipeline and the same issue is present there so it doesnt seem to be coming from this refactoring.

If you want to look at the old version as well, here is the file:
`s3://asf-heat-pump-suitability/outputs/2023Q4/weights/20250305_2023_Q4_EPC_weights.parquet`

Please pay special attention to ...
- the logic of the refactored flow steps where it has changed from the original script. I've indicated the parts of the script that don't need a thorough review because they are unchanged (except to refactor into metaflow syntax. Please still do review these steps for the new syntax but the logic has been reviewed. And please do review the general overall flow and the documentation.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
