### PR TITLE
Fix grid capacity max score

### DIFF
--- a/asf_heat_pump_suitability/pipeline/suitability/calculate_suitability.py
+++ b/asf_heat_pump_suitability/pipeline/suitability/calculate_suitability.py
@@ -164,7 +164,7 @@ def compute_df_max_score_per_epc(df: pl.DataFrame, tech_type: str) -> pl.DataFra
         .otherwise(0)
         .alias("anchor_properties_max"),
         pl.when(pl.col("heatpump_installation_percentage").is_not_null())
-        .then(scoring.epc_threshold_scores.get(tech_type))
+        .then(scoring.grid_capacity_scores.get(tech_type))
         .otherwise(0)
         .alias("grid_capacity_max"),
     )


### PR DESCRIPTION
## Summary
- fix grid capacity max scoring

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_68484c2ae2c88324a97aea8423a29dfb