### PR TITLE
188 impute property type (flats)

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -1,3 +1,6 @@
+data:
+  geodata:
+    uk_osopen_uprn: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/geodata/osopenuprn_202510_csv.zip"
 data_source:
   gb_ons_postcode_dir_url: "https://www.arcgis.com/sharing/rest/content/items/487a5ba62c8b4da08f01eb3c08e304f6/data" # Aug 2023 data
   gb_ons_postcode_dir_file_path: "Data/ONSPD_AUG_2023_UK.csv" # Aug 2023 data

--- a/asf_heat_pump_suitability/getters/base_getters.py
+++ b/asf_heat_pump_suitability/getters/base_getters.py
@@ -55,6 +55,7 @@ def get_df_from_zip_csv_s3(path: str, extract_file: str, **kwargs) -> pl.DataFra
     Returns:
         pl.DataFrame: dataset from ZIP file
     """
+    print(f"Loading file from path: {path}")
     content = BytesIO(get_content_from_s3_path(path))
     df = pl.read_csv(ZipFile(content).open(name=extract_file), **kwargs)
 

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -12,7 +12,7 @@ def load_df_osopen_uprn(**kwargs) -> pl.DataFrame:
     coordinates for all UPRNs in Great Britain.
 
     Args:
-        **kwargs fo pl.read_csv
+        **kwargs for pl.read_csv
 
     Returns:
         pl.DataFrame: raw OS Open UPRN dataset with lat/lon and x/y coordinates for every UPRN
@@ -20,10 +20,10 @@ def load_df_osopen_uprn(**kwargs) -> pl.DataFrame:
     print("Loading OSOpen UPRNs...")
     path = config["data"]["geodata"]["uk_osopen_uprn"]
     # extract_file = re.search(r"osopenuprn_\d{6}", path).group()
-    extract_file = os.path.basename(path).split("_csv")[0]
+    filename = os.path.basename(path).split("_csv")[0]
     df = base_getters.get_df_from_zip_csv_s3(
         path,
-        extract_file=f"{extract_file}.csv",
+        extract_file=f"{filename}.csv",
         **kwargs,
     )
 

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -1,0 +1,30 @@
+import polars as pl
+import regex as re
+import os
+
+from asf_heat_pump_suitability import config
+from asf_heat_pump_suitability.getters import base_getters
+
+
+def load_df_osopen_uprn(**kwargs) -> pl.DataFrame:
+    """
+    Get raw OS (Ordnance Survey) Open UPRN dataset containing latitude and longitude and British National Grid X and Y
+    coordinates for all UPRNs in Great Britain.
+
+    Args:
+        **kwargs fo pl.read_csv
+
+    Returns:
+        pl.DataFrame: raw OS Open UPRN dataset with lat/lon and x/y coordinates for every UPRN
+    """
+    print("Loading OSOpen UPRNs...")
+    path = config["data"]["geodata"]["uk_osopen_uprn"]
+    # extract_file = re.search(r"osopenuprn_\d{6}", path).group()
+    extract_file = os.path.basename(path).split("_csv")[0]
+    df = base_getters.get_df_from_zip_csv_s3(
+        path,
+        extract_file=f"{extract_file}.csv",
+        **kwargs,
+    )
+
+    return df

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -19,7 +19,6 @@ def load_df_osopen_uprn(**kwargs) -> pl.DataFrame:
     """
     print("Loading OSOpen UPRNs...")
     path = config["data"]["geodata"]["uk_osopen_uprn"]
-    # extract_file = re.search(r"osopenuprn_\d{6}", path).group()
     filename = os.path.basename(path).split("_csv")[0]
     df = base_getters.get_df_from_zip_csv_s3(
         path,

--- a/asf_heat_pump_suitability/pipeline/impute/property_type.py
+++ b/asf_heat_pump_suitability/pipeline/impute/property_type.py
@@ -1,0 +1,25 @@
+import geopandas as gpd
+
+
+def impute_set_flat_properties(uprns_gdf: gpd.GeoDataFrame) -> set:
+    """
+    Identify domestic UPRNs which are flats from their geometries.
+
+    Args:
+        uprns_gdf (gpd.GeoDataFrame): all domestic UPRNs and their point geometries in area of interest
+
+    Returns:
+        set: UPRNs which are flats / apartments
+    """
+    # Count how many times each geometry occurs
+    geom_counts = uprns_gdf["geometry"].value_counts()
+
+    # Get the geometries that appear more than once (the index is the geometry)
+    duplicate_geoms = geom_counts[geom_counts > 1].index
+
+    # Filter the GeoDataFrame to only those geometries
+    flats = set(uprns_gdf[uprns_gdf["geometry"].isin(duplicate_geoms)]["UPRN"])
+    print(
+        f"{len(flats)} flats found in UPRN dataset, N={len(uprns_gdf)}, {round(len(flats)/len(uprns_gdf)*100, 2)}%"
+    )
+    return flats

--- a/asf_heat_pump_suitability/pipeline/run/flat_blocks.py
+++ b/asf_heat_pump_suitability/pipeline/run/flat_blocks.py
@@ -2,7 +2,7 @@
 Script to label UPRNs with flat / apartment property type boolean flag.
 
 Run:
-python asf_heat_pump_suitability/pipeline/run/impute.py
+python asf_heat_pump_suitability/pipeline/run/flat_blocks.py
 """
 
 import argparse
@@ -29,12 +29,12 @@ def parse_arguments() -> argparse.Namespace:
 
 
 if __name__ == "__main__":
-    import polars as pl
     import os
+    import polars as pl
 
-    from asf_heat_pump_suitability.pipeline.transform import uprns
-    from asf_heat_pump_suitability.pipeline.impute import property_type
     from asf_heat_pump_suitability.utils import save_utils
+    from asf_heat_pump_suitability.pipeline.impute import property_type
+    from asf_heat_pump_suitability.pipeline.transform import uprns
 
     args = parse_arguments()
 
@@ -55,5 +55,5 @@ if __name__ == "__main__":
 
     save_utils.save_to_s3(
         uprns_df,
-        path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns)}_with_flats.parquet",
+        path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns).split('.')[0]}_with_flats.parquet",
     )

--- a/asf_heat_pump_suitability/pipeline/run/flat_blocks.py
+++ b/asf_heat_pump_suitability/pipeline/run/flat_blocks.py
@@ -2,7 +2,7 @@
 Script to label UPRNs with flat / apartment property type boolean flag.
 
 Run:
-python asf_heat_pump_suitability/pipeline/run/flat_blocks.py
+python asf_heat_pump_suitability/pipeline/run/flat_blocks.py --uprns path/to/domestic/UPRNs
 """
 
 import argparse

--- a/asf_heat_pump_suitability/pipeline/run/flat_blocks.py
+++ b/asf_heat_pump_suitability/pipeline/run/flat_blocks.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     # Get geopoints of UPRNs
     uprns_gdf = uprns.generate_gdf_uprn_coords(df=uprns_df)
 
-    # Label flats
+    # Create boolean column called `property_type_flat` to identify flats
     flat_uprns = property_type.impute_set_flat_properties(uprns_gdf=uprns_gdf)
     uprns_df = uprns_df.with_columns(
         pl.col("UPRN").is_in(flat_uprns).alias("property_type_flat")

--- a/asf_heat_pump_suitability/pipeline/run/impute.py
+++ b/asf_heat_pump_suitability/pipeline/run/impute.py
@@ -1,0 +1,59 @@
+"""
+Script to label UPRNs with flat / apartment property type boolean flag.
+
+Run:
+python asf_heat_pump_suitability/pipeline/run/impute.py
+"""
+
+import argparse
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Create ArgumentParser and parse.
+
+    Returns:
+        argparse.Namespace: populated `Namespace`
+    """
+    parser = argparse.ArgumentParser()
+
+    # TODO this is a placeholder and likely to change as the script develops
+    parser.add_argument(
+        "--uprns",
+        help="Path to domestic UPRN dataset with X and Y coordinates in parquet.",
+        type=str,
+        required=True,
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    import polars as pl
+    import os
+
+    from asf_heat_pump_suitability.pipeline.transform import uprns
+    from asf_heat_pump_suitability.pipeline.impute import property_type
+    from asf_heat_pump_suitability.utils import save_utils
+
+    args = parse_arguments()
+
+    # Load UPRN data
+    print(f"Loading domestic UPRNs from: {args.uprns}")
+    uprns_df = pl.read_parquet(
+        args.uprns, columns=["UPRN", "X_COORDINATE", "Y_COORDINATE"]
+    )
+
+    # Get geopoints of UPRNs
+    uprns_gdf = uprns.generate_gdf_uprn_coords(df=uprns_df)
+
+    # Label flats
+    flat_uprns = property_type.impute_set_flat_properties(uprns_gdf=uprns_gdf)
+    uprns_df = uprns_df.with_columns(
+        pl.col("UPRN").is_in(flat_uprns).alias("property_type_flat")
+    )
+
+    save_utils.save_to_s3(
+        uprns_df,
+        path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns)}_with_flats.parquet",
+    )

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -21,9 +21,11 @@ def generate_gdf_uprn_coords(
     Returns:
         gpd.GeoDataFrame: UPRNs with BNG coordinate point geometries
     """
+    # If usecols is not specified, use all columns in the dataframe
     if not usecols:
         usecols = ["*"]
     else:
+        # If usecols is specified, check that X and Y coordinate columns are included, otherwise add them
         for col in [x_col, y_col]:
             if col not in usecols:
                 usecols.append(col)

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -1,0 +1,39 @@
+import polars as pl
+import geopandas as gpd
+
+
+def generate_gdf_uprn_coords(
+    df: pl.DataFrame,
+    usecols: list = None,
+    x_col: str = "X_COORDINATE",
+    y_col: str = "Y_COORDINATE",
+) -> gpd.GeoDataFrame:
+    """
+    Generate GeoDataFrame of British National Grid (BNG) coordinate point geometries for UPRNs from BNG x and y
+    coordinates.
+
+    Args:
+        df (pl.DataFrame): dataframe with x, y coordinates in BNG (CRS: EPSG:27700) and UPRNs
+        usecols (list): columns of dataframe to use. Default None.
+        x_col (str): name of BNG x coordinate column
+        y_col (str): name of BNG y coordinate column
+
+    Returns:
+        gpd.GeoDataFrame: UPRNs with BNG coordinate point geometries
+    """
+    if not usecols:
+        usecols = ["*"]
+    else:
+        for col in [x_col, y_col]:
+            if col not in usecols:
+                usecols.append(col)
+    df = df.select(usecols)
+    df = df.to_pandas()
+
+    gdf = gpd.GeoDataFrame(
+        df,
+        geometry=gpd.points_from_xy(df[x_col], df[y_col]),
+        crs="EPSG:27700",
+    )
+
+    return gdf


### PR DESCRIPTION
Fixes #188 

# Description

Add functions and script to impute boolean flag for whether an individual UPRN is a flat or not.

New files:
- `asf_heat_pump_suitability/getters/load_geodata.py` - new file to add getters for geodata specifically
- `asf_heat_pump_suitability/pipeline/impute/property_type.py` - functions to impute property type
- `asf_heat_pump_suitability/pipeline/run/flat_blocks.py` - script to impute flat property type
- `asf_heat_pump_suitability/pipeline/transform/uprns.py` - functions to transform OS Open UPRN data

Modified files:
- `asf_heat_pump_suitability/config/base.yaml` - added latest OS Open UPRN file to source data

# Instructions for Reviewer

In order to test the code in this PR you need to ...

Run the following line in the terminal:
`python asf_heat_pump_suitability/pipeline/run/flat_blocks.py --uprns s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet`

This will run the script to take the domestic UPRNs for Plymouth (which we have preprocessed in a separate PR #184) and add a boolean flag to say whether or not the UPRN is a flat.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
