### PR TITLE
add file extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,18 @@ target/
 /outputs/models/*
 !/outputs/models/*.md
 
+# exclude file types
+*.kml
+*.csv
+*.parquet
+*.shp
+*.shx
+*.dbf
+*.prj
+*.cpg
+*.geojson
+*.gml
+
 # Mac OS-specific storage files
 .DS_Store
 


### PR DESCRIPTION
Fixes #195 

# Description

Exclude certain file extensions using `.gitignore` so we don't add them to git. These are mostly geospatial file types.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
