### PR TITLE
use new getter for OSOpenUPRN across pipeline folder

### DIFF
--- a/asf_heat_pump_suitability/pipeline/prepare_features/lat_lon.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/lat_lon.py
@@ -1,6 +1,6 @@
 import polars as pl
 import geopandas as gpd
-from asf_heat_pump_suitability.getters import get_datasets
+from asf_heat_pump_suitability.getters import load_geodata
 
 
 def transform_df_osopen_uprn_latlon() -> pl.DataFrame:
@@ -10,7 +10,7 @@ def transform_df_osopen_uprn_latlon() -> pl.DataFrame:
     Returns:
         pl.DataFrame: OS Open UPRN dataset with UPRN column in same format as in EPC
     """
-    df = get_datasets.get_df_osopen_uprn_latlon()
+    df = load_geodata.load_df_osopen_uprn()
     # Following line required to convert UPRNs to same format as in EPC
     df = df.with_columns(pl.col("UPRN").cast(pl.Float64).cast(pl.String).alias("UPRN"))
 

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -164,11 +164,10 @@ if __name__ == "__main__":
     import polars as pl
 
     from asf_heat_pump_suitability.getters import (
-        get_datasets,
+        load_geodata,
         load_tree_input,
         load_boundaries,
     )
-    from asf_heat_pump_suitability.pipeline.prepare_features import lat_lon
     from asf_heat_pump_suitability.pipeline.transform import (
         non_residential_entities,
         poi,
@@ -177,7 +176,7 @@ if __name__ == "__main__":
 
     args = parse_arguments()
 
-    uprns_df = get_datasets.get_df_osopen_uprn_latlon()
+    uprns_df = load_geodata.load_df_osopen_uprn()
     uprns_gdf = generate_gdf_uprn_coords(uprns_df)
 
     # TODO I expect this to be simplified at some point but the if/else block allows us to sample from certain areas for now


### PR DESCRIPTION
Fixes #197

# Description

Use updated/new getter (already merged into dev) for loading OS Open UPRN data. It was a mistake that this was not updated here before.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
