### PR TITLE
200 label uprns in city centre

### DIFF
--- a/asf_heat_pump_suitability/analysis/spatial_signatures_hn_zones/20251205_plymouth_investigation.py
+++ b/asf_heat_pump_suitability/analysis/spatial_signatures_hn_zones/20251205_plymouth_investigation.py
@@ -1,0 +1,530 @@
+# %% [markdown]
+# ### **Investigating areas in Plymouth LA with existing heat network zones or potential for a heat network**
+
+# %%
+import pandas as pd
+import geopandas as gpd
+import polars as pl
+import textwrap
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+from matplotlib.lines import Line2D
+
+from asf_heat_pump_suitability import config
+from asf_heat_pump_suitability.getters import (
+    base_getters,
+    load_geodata,
+    load_boundaries,
+)
+from asf_heat_pump_suitability.pipeline.transform import uprns, heat_network_zones
+
+# %% [markdown]
+# Loading data
+
+# %%
+# OSOpen UPRNS filtered for Plymouth only
+plymouth_uprns_df = base_getters.load_df_from_s3(
+    "s3://asf-heat-pump-suitability/dump/plymouth_OSOpen_UPRNs_filtered.parquet"
+)
+plymouth_uprns_gdf = uprns.generate_gdf_uprn_coords(plymouth_uprns_df)
+
+# %%
+# Plymouth residential UPRNs
+plymouth_residential_uprns_df = base_getters.load_df_from_s3(
+    config["data"]["processed"]["plymouth_residential_uprns"]
+)
+plymouth_residential_uprns_gdf = uprns.generate_gdf_uprn_coords(
+    plymouth_residential_uprns_df
+)
+
+# %%
+# Plymouth LA boundary
+plymouth_la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(
+    select_las="plymouth"
+)
+
+# %%
+# Existing heat network zones in plymouth
+plymouth_hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
+    local_authority="plymouth"
+)
+
+# %%
+# Simplified form of the spatial signatures gb dataset
+spatial_signatures_gb_simplified_gdf = load_geodata.load_gdf_spatial_signatures_gb(
+    detail_level="simplified"
+)
+
+# %%
+# Confirming spatial signature types
+print("Spatial signatures:")
+counter = 1
+for type in spatial_signatures_gb_simplified_gdf["type"].unique():
+    print(f"{counter}. {type}")
+    counter += 1
+
+# %%
+# CRS checks
+gdfs = [
+    plymouth_uprns_gdf,
+    plymouth_residential_uprns_gdf,
+    plymouth_la_boundaries_gdf,
+    plymouth_hn_zones_gdf,
+    spatial_signatures_gb_simplified_gdf,
+]
+len({gdf.crs for gdf in gdfs}) == 1
+
+# %% [markdown]
+# #### **Inspecting existing heat network zones**
+
+# %%
+# Inspecting each HNZ
+plymouth_boundary = plymouth_la_boundaries_gdf.plot(
+    color="white", edgecolor="black"
+)  # Plymouth LA boundary
+
+plymouth_hn_zones_gdf.plot(
+    ax=plymouth_boundary,
+    edgecolor="blue",
+    legend=True,
+    column="ZoneID",
+)  # Existing heat network zones
+
+# %%
+# Label residential UPRNs in HNZ
+plymouth_uprns_hnz_labelled_df = heat_network_zones.label_gdf_heat_network_zone_uprns(
+    uprn_gdf=plymouth_residential_uprns_gdf,
+    hn_zone_gdf=plymouth_hn_zones_gdf,
+    usecols=["ZoneID"],
+)
+
+# Filter only in HNZ
+plymouth_hn_zone_uprns_df = plymouth_uprns_hnz_labelled_df.filter(
+    pl.col("in_hn_zone") == True
+)
+plymouth_hn_zone_uprns_gdf = uprns.generate_gdf_uprn_coords(plymouth_hn_zone_uprns_df)
+
+# %%
+# Inspecting layers of UPRNs, boundaries and HNZ
+
+# Layers
+plymouth_boundary = plymouth_la_boundaries_gdf.plot(color="white", edgecolor="black")
+
+plymouth_uprns_gdf.plot(
+    ax=plymouth_boundary, color="grey", markersize=2, label="All Plymouth UPRNs"
+)
+
+plymouth_residential_uprns_gdf.plot(
+    ax=plymouth_boundary, color="red", markersize=2, label="Residential UPRNs only"
+)
+
+plymouth_hn_zones_gdf.plot(
+    ax=plymouth_boundary, facecolor="none", edgecolor="blue", linewidth=2
+)
+
+plymouth_hn_zone_uprns_gdf.plot(
+    ax=plymouth_boundary, color="yellow", markersize=2, label="Residential UPRNs in HNZ"
+)
+
+# Manual legend patches for boundaries
+boundary_patch = mpatches.Patch(
+    facecolor="white", edgecolor="black", label="Plymouth LA boundary"
+)
+
+hn_zone_patch = mpatches.Patch(
+    facecolor="none", edgecolor="blue", label="Existing heat network zones"
+)
+
+# Combine auto and manual labels
+handles, labels = plymouth_boundary.get_legend_handles_labels()
+
+new_handles = handles + [boundary_patch, hn_zone_patch]
+new_labels = labels + ["Plymouth LA boundary", "Existing heat network zones"]
+
+plt.legend(
+    handles=new_handles,
+    labels=new_labels,
+    loc="upper left",
+    bbox_to_anchor=(1.05, 1),
+    title="Layers",
+)
+
+plt.show()
+
+# %%
+# What % of residential UPRNs are in existing HNZ?
+prop_in_hn_zone = plymouth_uprns_hnz_labelled_df.select(
+    pl.col("in_hn_zone").mean()
+).item()
+
+print(f"Proportion in HN zone: {prop_in_hn_zone:.3f}")
+
+# %% [markdown]
+# #### **Investigating which spatial signature types are in existing heat network zones**
+
+# %%
+# Spatial signatures in Plymouth LA boundaries only
+spatial_signatures_plymouth_gdf = spatial_signatures_gb_simplified_gdf.sjoin(
+    plymouth_la_boundaries_gdf, how="inner", predicate="intersects"
+).drop(columns="index_right")
+
+# %%
+# colour for spatial signature types
+unique_types = spatial_signatures_plymouth_gdf["type"].unique()
+colors = plt.cm.tab20.colors
+color_dict = {t: colors[i % len(colors)] for i, t in enumerate(unique_types)}
+
+
+fig, ax = plt.subplots(figsize=(15, 7.5))
+
+# plot spatial signatures polygons with mapped colors
+spatial_signatures_plymouth_gdf.plot(
+    ax=ax, color=spatial_signatures_plymouth_gdf["type"].map(color_dict)
+)
+
+# overlay Plymouth LA boundaries
+plymouth_la_boundaries_gdf.plot(ax=ax, facecolor="none", edgecolor="black", linewidth=1)
+
+# overlay Plymouth heat network zones
+plymouth_hn_zones_gdf.plot(ax=ax, facecolor="none", edgecolor="blue", linewidth=1)
+
+# manual legend for spatial signature types
+legend_handles = [mpatches.Patch(color=color_dict[t], label=t) for t in unique_types]
+
+# lines for boundaries and heat network zones
+legend_handles += [
+    Line2D([0], [0], color="black", lw=2, label="Plymouth LA boundary"),
+    Line2D([0], [0], color="blue", lw=2, label="Existing heat network zones"),
+]
+
+ax.legend(
+    handles=legend_handles,
+    title="Spatial Signature Type",
+    loc="upper left",
+    bbox_to_anchor=(1.05, 1),
+)
+
+plt.show()
+
+# %% [markdown]
+# 05/12/25: There is no clear consistency in the spatial signature types in existing heat network zones.
+
+# %% [markdown]
+# Inspecting existing HNZ one at a time:
+
+# %%
+plymouth_hn_zones_with_labels_gdf = gpd.sjoin(
+    plymouth_hn_zones_gdf,
+    spatial_signatures_plymouth_gdf[["type", "geometry"]],
+    how="left",
+    predicate="within",
+)
+
+plymouth_hn_zones_with_labels_agg_gdf = (
+    plymouth_hn_zones_with_labels_gdf.groupby("ZoneID")["type"]
+    .apply(lambda x: list(x.dropna().unique()))
+    .reset_index()
+)
+
+
+# %%
+# helper function to visually inspect each HNZ
+def inspect_spatial_signatures_in_hn_zone(zone_id: str):
+    zone_gdf = plymouth_hn_zones_gdf[plymouth_hn_zones_gdf["ZoneID"] == zone_id]
+
+    just_text_raw = str(zone_gdf.Just.values[0])
+    just_text = "\n".join(textwrap.wrap(just_text_raw, width=90))
+
+    spatial_signatures_gdf = spatial_signatures_plymouth_gdf.sjoin(
+        zone_gdf, how="inner", predicate="intersects"
+    )
+
+    fig, ax = plt.subplots(figsize=(12, 8))
+
+    base = spatial_signatures_gdf.plot(column="type", legend=True, ax=ax)
+    zone_gdf.plot(ax=base, facecolor="none", edgecolor="red")
+    ax.set_title(f"Zone: {zone_id}", fontsize=12)
+
+    fig.text(
+        0.5,
+        0.01,
+        just_text,
+        ha="center",
+        va="bottom",
+        fontsize=10,
+    )
+
+    return ax
+
+
+# %%
+for zone_id in plymouth_hn_zones_with_labels_agg_gdf["ZoneID"].unique():
+    inspect_spatial_signatures_in_hn_zone(zone_id)
+
+# %% [markdown]
+# #### **Testing urban spatial signatures to indicate "city centre" areas - i.e. areas potentially suitable for a heat network**
+
+# %% [markdown]
+# Labelling original residential UPRNs
+
+# %%
+# Test set of signature types
+city_centre_types = [
+    "Hyper concentrated urbanity",
+    "Concentrated urbanity",
+    "Metropolitan urbanity",
+    "Regional urbanity",
+    "Local urbanity",
+    "Dense urban neighbourhoods",
+]
+
+plymouth_uprns_spatial_signature_labelled_df = (
+    heat_network_zones.label_gdf_heat_network_spatial_signatures_uprns(
+        uprn_gdf=plymouth_residential_uprns_gdf,
+        spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
+        types=city_centre_types,
+    )
+)
+
+# %%
+# Process filtered UPRNs for plotting
+plymouth_uprns_spatial_signature_df = (
+    plymouth_uprns_spatial_signature_labelled_df.filter(
+        pl.col("in_potential_hn_zone") == True
+    )
+)
+plymouth_uprns_spatial_signature_gdf = uprns.generate_gdf_uprn_coords(
+    plymouth_uprns_spatial_signature_df
+)
+
+# %%
+# Filter spatial signatures in Plymouth to selected types
+selected_spatial_signatures_plymouth_gdf = spatial_signatures_plymouth_gdf[
+    spatial_signatures_plymouth_gdf["type"].isin(city_centre_types)
+]
+
+# %%
+# Inspect selected spatial signatures in relation to existing HNZ
+
+# colour for spatial signature types
+unique_types = selected_spatial_signatures_plymouth_gdf["type"].unique()
+colors = plt.cm.tab20.colors
+color_dict = {t: colors[i % len(colors)] for i, t in enumerate(unique_types)}
+
+
+fig, ax = plt.subplots(figsize=(15, 7.5))
+
+# plot spatial signatures polygons with mapped colors
+selected_spatial_signatures_plymouth_gdf.plot(
+    ax=ax, color=selected_spatial_signatures_plymouth_gdf["type"].map(color_dict)
+)
+
+# overlay Plymouth LA boundaries
+plymouth_la_boundaries_gdf.plot(ax=ax, facecolor="none", edgecolor="black", linewidth=1)
+
+# overlay Plymouth heat network zones
+plymouth_hn_zones_gdf.plot(ax=ax, facecolor="none", edgecolor="blue", linewidth=1)
+
+# manual legend for spatial signature types
+legend_handles = [mpatches.Patch(color=color_dict[t], label=t) for t in unique_types]
+
+# lines for boundaries and heat network zones
+legend_handles += [
+    Line2D([0], [0], color="black", lw=2, label="Plymouth LA boundary"),
+    Line2D([0], [0], color="blue", lw=2, label="Existing heat network zones"),
+]
+
+ax.legend(
+    handles=legend_handles,
+    title="Spatial Signature Type",
+    loc="upper left",
+    bbox_to_anchor=(1.05, 1),
+)
+
+plt.show()
+
+# %% [markdown]
+# 05/12/25: Only 3 of the 6 city centre spatial signature types are present within Plymouth LA boundaries (Dense urban neighbourhoods, Local urbanity and Regional urbanity). Only the existing HNZ PLYM-011 contain any of these city centre types. The remaining 7 existing HN zones are in a wide range of other spatial signature types.
+
+# %% [markdown]
+# **Comparison of zones by spatial coverage**
+
+# %%
+# Comparing total spatial overlap
+overlap = gpd.overlay(
+    plymouth_hn_zones_gdf, selected_spatial_signatures_plymouth_gdf, how="intersection"
+)
+overlap_area = overlap.geometry.area.sum()
+
+# % overlap of each layer
+area_hnz = plymouth_hn_zones_gdf.geometry.area.sum()
+area_selected = selected_spatial_signatures_plymouth_gdf.geometry.area.sum()
+
+percent_hnz_covered_by_selected = (overlap_area / area_hnz) * 100
+percent_selected_covered_by_hnz = (overlap_area / area_selected) * 100
+
+# summary table
+summary_df = pd.DataFrame(
+    {
+        "Area (m²)": [area_hnz, area_selected, overlap_area],
+        "% of HNZ covered by selected signatures": [
+            "100%",
+            f"{percent_selected_covered_by_hnz:.1f}%",
+            f"{(overlap_area / area_hnz) * 100:.1f}%",
+        ],
+        "% of selected signatures covered by HNZ": [
+            f"{(area_hnz / area_selected) * 100:.1f}%",
+            "100%",
+            f"{(overlap_area / area_selected) * 100:.1f}%",
+        ],
+    },
+    index=["Existing HNZ", "Selected signatures", "Actual overlap"],
+)
+
+summary_df
+
+# %% [markdown]
+# 05/12/25: Computing the spatial overlap, the **city centre types cover 35% of the area covered by existing heat network zones**. Conversely, the **existing heat network zones cover 83% of the area covered by city centre types**.
+# - 35% metric -> The selected signature types only partially align with the existing heat network coverage; most of the current HNZ lie outside "city centre" areas. This indicates that using "city centre" areas is not able to capture all areas that have been deemed suitable for a heat network in reality.
+# - 83% metric -> Most of the areas identified as city centre/potentially suitable for a heat network are already part of the existing heat network.
+# - Using city centre areas as proxies for heat network suitability: most areas selected are part of an existing HNZ (high precision) - but many existing HNZ areas outside these urban centres are missed, since HNZ are not chosen based on urban location alone.
+
+# %%
+# Inspecting layers of UPRNs, boundaries and spatial signatures
+
+# Layers
+plymouth_boundary = plymouth_la_boundaries_gdf.plot(color="white", edgecolor="grey")
+
+
+plymouth_residential_uprns_gdf.plot(
+    ax=plymouth_boundary, color="#8B0000", markersize=2, label="Residential UPRNs only"
+)
+
+plymouth_hn_zones_gdf.plot(
+    ax=plymouth_boundary,
+    facecolor="none",
+    edgecolor="#1f77b4",
+    linewidth=2,
+    alpha=0.8,
+    label="HNZ Zones",
+)
+
+plymouth_hn_zone_uprns_gdf.plot(
+    ax=plymouth_boundary,
+    color="#FFD700",
+    markersize=3,
+    label="Residential UPRNs in HNZ",
+)
+
+selected_spatial_signatures_plymouth_gdf.plot(
+    ax=plymouth_boundary,
+    facecolor="none",
+    edgecolor="#800080",
+    linewidth=2,
+    label="Selected Spatial Signatures",
+)
+
+plymouth_uprns_spatial_signature_gdf.plot(
+    ax=plymouth_boundary,
+    color="#228B22",
+    markersize=3,
+    label="Residential UPRNs in selected spatial signatures",
+)
+
+# Manual legend patches for boundaries
+boundary_patch = mpatches.Patch(
+    facecolor="white", edgecolor="grey", label="Plymouth LA boundary"
+)
+
+hn_zone_patch = mpatches.Patch(
+    facecolor="none", edgecolor="#1f77b4", label="Existing heat network zones"
+)
+
+spatial_signature_patch = mpatches.Patch(
+    facecolor="none", edgecolor="#800080", label="Selected spatial signatures"
+)
+
+# Combine auto and manual labels
+handles, labels = plymouth_boundary.get_legend_handles_labels()
+
+new_handles = handles + [boundary_patch, hn_zone_patch, spatial_signature_patch]
+new_labels = labels + [
+    "Plymouth LA boundary",
+    "Existing heat network zones",
+    "Selected spatial signatures",
+]
+
+plt.legend(
+    handles=new_handles,
+    labels=new_labels,
+    loc="upper left",
+    bbox_to_anchor=(1.05, 1),
+    title="Layers",
+)
+
+plt.show()
+
+# %% [markdown]
+# Labelling UPRNs with existing HNZ labels **and** spatial signature types
+
+# %%
+plymouth_uprns_hnz_labelled_gdf = uprns.generate_gdf_uprn_coords(
+    plymouth_uprns_hnz_labelled_df
+)
+
+
+# Test set of signature types
+city_centre_types = [
+    "Hyper concentrated urbanity",
+    "Concentrated urbanity",
+    "Metropolitan urbanity",
+    "Regional urbanity",
+    "Local urbanity",
+    "Dense urban neighbourhoods",
+]
+
+plymouth_uprns_hnz_spatial_signature_labelled_df = (
+    heat_network_zones.label_gdf_heat_network_spatial_signatures_uprns(
+        uprn_gdf=plymouth_uprns_hnz_labelled_gdf,
+        spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
+        types=city_centre_types,
+    )
+)
+
+# %% [markdown]
+# **Comparison of zones by UPRNs coverage**
+
+# %%
+plymouth_uprns_hnz_spatial_signature_labelled_df.group_by(
+    ["in_hn_zone", "in_potential_hn_zone"]
+).len().with_columns((pl.col("len") / pl.col("len").sum()).alias("percent"))
+
+# %%
+# UPRNs in existing HNZ
+hnz_true_df = plymouth_uprns_hnz_spatial_signature_labelled_df.filter(
+    (pl.col("in_hn_zone") == True)
+)
+prop_true = hnz_true_df.select(pl.col("in_potential_hn_zone").mean()).item()
+
+print(
+    f"Proportion of UPRNs in an existing heat network zone which are classified to be in a potential heat network zone (by the set of spatial signature types) [recall]: {prop_true:.3f}"
+)
+
+# %%
+potential_hnz_true_df = plymouth_uprns_hnz_spatial_signature_labelled_df.filter(
+    pl.col("in_potential_hn_zone") == True
+)
+
+prop_true = potential_hnz_true_df.select(pl.col("in_hn_zone").mean()).item()
+
+print(
+    f"Proportion of UPRNs in a potential heat network zone (as classified by the set of spatial signature types) which are already in an existing heat network zone [precision]: {prop_true:.3f}"
+)
+
+# %% [markdown]
+# 05/12/25: City centres as a proxy performs better at capturing properties in existing HNZ, compared to land area. Mainly because of the higher density of properties in the selected urban area types.
+# - 84% of UPRNs in existing HNZ are in city centre spatial signature types -> most properties already served are captured, showing our proxy effectively targets relevant properties
+# - 82% of UPRNs in city centre types are in existing HNZ -> few properties outside existing HNZ are incorrectly flagged, indicating the proxy is precise
+#
+#
+# For our purpose of flagging potential properties for future heat networks, city centre spatial signatures seem to be a suitable proxy as it captures the most relevant properties with moderately high precision, even if many of the existing HNZ total land area lies outside city centres.

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -14,6 +14,13 @@ data:
     heat_network_zones:
       # Plymouth Heat Network zones
       plymouth: "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/NMR3 Heat Network Zones (Post-Ref).gpkg"
+
+    gb_spatial_signatures:
+      # UrbanGrammarAI Spatial Signatures GB simplified
+      simplified: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/v202301_UrbanGrammarAI_SpatialSignatures_GB/spatial_signatures_GB_simplified.gpkg"
+      # UrbanGrammarAI Spatial Signatures GB detailed
+      full: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/v202301_UrbanGrammarAI_SpatialSignatures_GB/spatial_signatures_GB.gpkg"
+
   epc:
     domestic: "s3://asf-daps/lakehouse/2025_Q1/processed/epc/deduplicated/processed_dedupl-0.parquet"
     commercial: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/v092025_EPC_NonDomestic_EW.csv"

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -60,17 +60,26 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
 
 
 def load_gdf_spatial_signatures_gb(
-    detail_level: str = "simplified", **kwargs
+    detail_level: str = "full", **kwargs
 ) -> gpd.GeoDataFrame:
     """
     Load GeoDataFrame with polygons in GB from the Spatial Signatures Framework  classified by their
-    Spatial Signature type. (Source: https://doi.org/10.6084/m9.figshare.16691575).
+    Spatial Signature type. CRS British National Grid (27700). (Source: https://doi.org/10.6084/m9.figshare.16691575).
 
-    The dataset can be loaded at two levels of detail:
-    - "simplified": polygon geometries provided with descriptive columns "id" [int64] and "type" [str]
-    - "full": polygon geometries provided with descriptive columns "id" [str], "code" [str] and "type" [str]
+    Two versions of the dataset are available, differing in the geometric detail of the
+    polygon geometries:
 
-    The dataset at both levels of detail contain 96,704 polygons.
+    - "simplified":
+        Polygon geometries have been geometrically simplified, containing fewer coordinate
+        vertices than the full-resolution version.
+        Attribute fields include: "id" (int64) and "type" (str).
+
+    - "full":
+        Polygon geometries are provided at full resolution, retaining the complete set of
+        coordinate vertices.
+        Attribute fields include: "id" (str), "code" (str), and "type" (str).
+
+    Both versions contain 96,704 polygons.
 
     Args:
         detail_level (str, optional): Which level of descriptive detail to load.

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -57,3 +57,39 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
         f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
     )
     return gdf
+
+
+def load_gdf_spatial_signatures_gb(
+    detail_level: str = "simplified", **kwargs
+) -> gpd.GeoDataFrame:
+    """
+    Load GeoDataFrame with polygons in GB from the Spatial Signatures Framework  classified by their
+    Spatial Signature type. (Source: https://doi.org/10.6084/m9.figshare.16691575).
+
+    The dataset can be loaded at two levels of detail:
+    - "simplified": geometries provided with only fields "id" and "type"
+    - "full": geometries provided with all fields
+
+    Args:
+        detail_level (str, optional): Which level of descriptive detail to load.
+            Must be either "simplified" or "full". Defaults to "simplified".
+
+    Returns:
+        gpd.GeoDataFrame: spatial signature polygons in GB.
+    """
+
+    if detail_level not in {"full", "simplified"}:
+        raise ValueError(
+            f"detail_level must be 'full' or 'simplified', not {detail_level}"
+        )
+
+    gdf = base_getters.get_gdf_from_gpkg_s3_path(
+        path=config["data"]["geodata"]["gb_spatial_signatures"][detail_level],
+        **kwargs,
+    )
+
+    print(
+        f"Spatial signatures {detail_level} geodataframe successfully loaded with CRS {gdf.crs}."
+    )
+
+    return gdf

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -67,8 +67,10 @@ def load_gdf_spatial_signatures_gb(
     Spatial Signature type. (Source: https://doi.org/10.6084/m9.figshare.16691575).
 
     The dataset can be loaded at two levels of detail:
-    - "simplified": geometries provided with only fields "id" and "type"
-    - "full": geometries provided with all fields
+    - "simplified": polygon geometries provided with descriptive columns "id" [int64] and "type" [str]
+    - "full": polygon geometries provided with descriptive columns "id" [str], "code" [str] and "type" [str]
+
+    The dataset at both levels of detail contain 96,704 polygons.
 
     Args:
         detail_level (str, optional): Which level of descriptive detail to load.

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -41,7 +41,10 @@ if __name__ == "__main__":
     from asf_heat_pump_suitability import config
     from asf_heat_pump_suitability.getters import base_getters, load_geodata
     from asf_heat_pump_suitability.pipeline.transform import uprns
-    from asf_heat_pump_suitability.pipeline.transform import heat_network_zones
+    from asf_heat_pump_suitability.pipeline.transform import (
+        heat_network_zones,
+        city_centres,
+    )
     from asf_heat_pump_suitability.utils import save_utils
 
     args = parse_arguments()
@@ -63,7 +66,7 @@ if __name__ == "__main__":
             local_authority="plymouth"
         )
 
-        # Label UPRNs in existing heat network zones
+        # Label UPRNs in existing, potential and planned heat network zones
         print(
             "Identifying residential UPRNs in heat network zones for Plymouth Local Authority..."
         )
@@ -89,36 +92,28 @@ if __name__ == "__main__":
         )
 
         # Label UPRNs in city centres
-        city_centre_types = [  # TODO confirm types
-            "Hyper concentrated urbanity",
-            "Concentrated urbanity",
-            "Metropolitan urbanity",
-            "Regional urbanity",
-            "Local urbanity",
-            "Dense urban neighbourhoods",
-        ]
         print(
             "Identifying residential UPRNs in city centre areas for Plymouth Local Authority..."
         )
-        city_centre_uprn_df = (
-            heat_network_zones.label_gdf_heat_network_spatial_signatures_uprns(
-                uprn_gdf=uprn_gdf,
-                spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
-                types=city_centre_types,
-            )
+        hn_zone_uprn_gdf = uprns.generate_gdf_uprn_coords(hn_zone_uprn_df)
+        hn_zone_city_centre_uprn_df = city_centres.label_gdf_city_centre_spatial_signatures_uprns(
+            uprn_gdf=hn_zone_uprn_gdf,  # add city centre labels to gdf with hnz labels
+            spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
         )
 
         # Clean up columns
-        city_centre_uprn_df = city_centre_uprn_df.select(
+        hn_zone_city_centre_uprn_df = hn_zone_city_centre_uprn_df.select(
             [
                 "UPRN",
                 "LAD23NM",
                 "X_COORDINATE",
                 "Y_COORDINATE",
-                "spatial_signature_type",
-                "in_potential_hn_zone",
+                "HNZoneID",
+                "in_hn_zone",
+                "spatial_signature_types",
+                "in_city_centre",
             ]
-        ).rename({"in_potential_hn_zone": "in_city_centre"})
+        )
 
     elif args.local_authorities.lower() in ["plymouth_similar", "sampling_areas"]:
         # Placeholder for future implementation (subject to heat network zone data availability)
@@ -130,14 +125,8 @@ if __name__ == "__main__":
         # Placeholder for future implementation
         raise NotImplementedError("Processing for all of GB is not yet supported.")
 
-    # Save residential UPRNs with existing hn zone labels to S3
+    # Save residential UPRNs with existing heat network zone and city centre labels to S3
     save_utils.save_to_s3(
-        hn_zone_uprn_df,
-        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones.parquet",
-    )
-
-    # Save residential UPRNs with city centre labels to S3
-    save_utils.save_to_s3(
-        city_centre_uprn_df,
-        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_city_centres.parquet",
+        hn_zone_city_centre_uprn_df,
+        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones_city_centres.parquet",
     )

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         # Load spatial signature polygons
         print("Loading spatial signatures dataset...")
         spatial_signatures_gb_simplified_gdf = (
-            load_geodata.load_gdf_spatial_signatures_gb(detail_level="simplified")
+            load_geodata.load_gdf_spatial_signatures_gb(detail_level="full")
         )
 
         # Label UPRNs in city centres

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -55,13 +55,15 @@ if __name__ == "__main__":
         )
         uprn_gdf = uprns.generate_gdf_uprn_coords(uprn_df)
 
+        """ Existing heat network zones """
+
         # Load Plymouth existing heat network zone polygons
         print("Loading heat network zone data for Plymouth Local Authority...")
         plymouth_hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
             local_authority="plymouth"
         )
 
-        # Filter for UPRNs in existing heat network zones
+        # Label UPRNs in existing heat network zones
         print(
             "Identifying residential UPRNs in heat network zones for Plymouth Local Authority..."
         )
@@ -78,7 +80,45 @@ if __name__ == "__main__":
             ["UPRN", "LAD23NM", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", "ZoneID"]
         ).rename({"ZoneID": "HNZoneID"})
 
-        # TODO filter and add label for UPRNs in city centres
+        """ City centre areas """
+
+        # Load spatial signature polygons
+        print("Loading spatial signatures dataset...")
+        spatial_signatures_gb_simplified_gdf = (
+            load_geodata.load_gdf_spatial_signatures_gb(detail_level="simplified")
+        )
+
+        # Label UPRNs in city centres
+        city_centre_types = [  # TODO confirm types
+            "Hyper concentrated urbanity",
+            "Concentrated urbanity",
+            "Metropolitan urbanity",
+            "Regional urbanity",
+            "Local urbanity",
+            "Dense urban neighbourhoods",
+        ]
+        print(
+            "Identifying residential UPRNs in city centre areas for Plymouth Local Authority..."
+        )
+        city_centre_uprn_df = (
+            heat_network_zones.label_gdf_heat_network_spatial_signatures_uprns(
+                uprn_gdf=uprn_gdf,
+                spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
+                types=city_centre_types,
+            )
+        )
+
+        # Clean up columns
+        city_centre_uprn_df = city_centre_uprn_df.select(
+            [
+                "UPRN",
+                "LAD23NM",
+                "X_COORDINATE",
+                "Y_COORDINATE",
+                "spatial_signature_type",
+                "in_potential_hn_zone",
+            ]
+        ).rename({"in_potential_hn_zone": "in_city_centre"})
 
     elif args.local_authorities.lower() in ["plymouth_similar", "sampling_areas"]:
         # Placeholder for future implementation (subject to heat network zone data availability)
@@ -90,8 +130,14 @@ if __name__ == "__main__":
         # Placeholder for future implementation
         raise NotImplementedError("Processing for all of GB is not yet supported.")
 
-    # Save residential UPRNs with labels to S3
+    # Save residential UPRNs with existing hn zone labels to S3
     save_utils.save_to_s3(
         hn_zone_uprn_df,
         f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones.parquet",
+    )
+
+    # Save residential UPRNs with city centre labels to S3
+    save_utils.save_to_s3(
+        city_centre_uprn_df,
+        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_city_centres.parquet",
     )

--- a/asf_heat_pump_suitability/pipeline/transform/city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/transform/city_centres.py
@@ -59,19 +59,23 @@ def label_gdf_city_centre_spatial_signatures_uprns(
         predicate="intersects",  # include properties intersecting spatial signature cell boundary
     ).drop(columns="index_right")
 
+    # Add city centre boolean label
+    labelled_uprn_gdf["in_city_centre"] = labelled_uprn_gdf["type"].isin(types)
+
     # Combine multiple matches into a single row per UPRN
     uprn_columns = [col for col in uprn_gdf.columns if col != "geometry"]
-    labelled_uprn_gdf = labelled_uprn_gdf.groupby("UPRN", group_keys=False).agg(
-        {
-            **{col: "first" for col in uprn_columns},  # keep original UPRN columns
-            "geometry": "first",  # keep the point geometry
-            "type": list,  # combine types into a list
-        }
-    )
-
-    # Add city centre boolean label
-    labelled_uprn_gdf["in_city_centre"] = labelled_uprn_gdf["type"].apply(
-        lambda x: any(t in types for t in x)
+    labelled_uprn_gdf = (
+        labelled_uprn_gdf.groupby("UPRN", as_index=False)
+        .agg(
+            {
+                **{col: "first" for col in uprn_columns},  # keep original UPRN columns
+                "geometry": "first",  # keep the point geometry
+                "type": list,  # combine types into a list
+                "in_city_centre": sum,  # sums >0 indicate UPRN in a city centre signature
+            }
+            # Convert city centre to boolean label
+        )
+        .astype({"in_city_centre": bool})
     )
 
     # UPRNs with no spatial signature match are ultimately classified as not in city centre

--- a/asf_heat_pump_suitability/pipeline/transform/city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/transform/city_centres.py
@@ -61,9 +61,7 @@ def label_gdf_city_centre_spatial_signatures_uprns(
 
     # Combine multiple matches into a single row per UPRN
     uprn_columns = [col for col in uprn_gdf.columns if col != "geometry"]
-    labelled_uprn_gdf = labelled_uprn_gdf.groupby(
-        labelled_uprn_gdf.index, group_keys=False
-    ).agg(
+    labelled_uprn_gdf = labelled_uprn_gdf.groupby("UPRN", group_keys=False).agg(
         {
             **{col: "first" for col in uprn_columns},  # keep original UPRN columns
             "geometry": "first",  # keep the point geometry

--- a/asf_heat_pump_suitability/pipeline/transform/city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/transform/city_centres.py
@@ -1,0 +1,90 @@
+"""
+Functions to label UPRNs within city centre areas.
+"""
+
+import geopandas as gpd
+import polars as pl
+
+from asf_heat_pump_suitability import config
+
+CITY_CENTRE_TYPES = [  # TODO: confirm types with scaling
+    "Hyper concentrated urbanity",
+    "Concentrated urbanity",
+    "Metropolitan urbanity",
+    "Regional urbanity",
+    "Local urbanity",
+    "Dense urban neighbourhoods",
+]
+
+
+def label_gdf_city_centre_spatial_signatures_uprns(
+    uprn_gdf: gpd.GeoDataFrame,
+    spatial_signatures_gdf: gpd.GeoDataFrame,
+    types: list = CITY_CENTRE_TYPES,
+) -> pl.DataFrame:
+    """
+    Labels UPRNs that are located within a city centre based on its matched Spatial Signature type.
+
+    Args:
+        uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be labelled
+        spatial_signatures_gdf (gpd.GeoDataFrame): polygons of spatial signatures
+        types (list, optional): spatial signature types assumed to be representative of city centre areas. Defaults to a list containing:
+            - "Hyper concentrated urbanity"
+            - "Concentrated urbanity"
+            - "Metropolitan urbanity"
+            - "Regional urbanity"
+            - "Local urbanity"
+            - "Dense urban neighbourhoods"
+
+    Returns:
+        pl.DataFrame: input UPRNs labelled with spatial signature identifiers and booleans indicating that they are located within
+            a city centre spatial signature type
+    """
+
+    # CRS checks and reprojection if needed
+    target_crs = config["constant"]["target_crs"]
+
+    if uprn_gdf.crs != target_crs:
+        uprn_gdf = uprn_gdf.to_crs(target_crs)
+        print(f"uprn_gdf reprojected to target CRS: {target_crs}")
+
+    if spatial_signatures_gdf.crs != target_crs:
+        spatial_signatures_gdf = spatial_signatures_gdf.to_crs(target_crs)
+        print(f"spatial_signatures_gdf reprojected to target CRS: {target_crs}")
+
+    # Spatial join for labelling UPRN with signature type
+    labelled_uprn_gdf = uprn_gdf.sjoin(
+        spatial_signatures_gdf[["geometry", "type"]],
+        how="left",
+        predicate="intersects",  # include properties intersecting spatial signature cell boundary
+    ).drop(columns="index_right")
+
+    # Combine multiple matches into a single row per UPRN
+    uprn_columns = [col for col in uprn_gdf.columns if col != "geometry"]
+    labelled_uprn_gdf = labelled_uprn_gdf.groupby(
+        labelled_uprn_gdf.index, group_keys=False
+    ).agg(
+        {
+            **{col: "first" for col in uprn_columns},  # keep original UPRN columns
+            "geometry": "first",  # keep the point geometry
+            "type": list,  # combine types into a list
+        }
+    )
+
+    # Add city centre boolean label
+    labelled_uprn_gdf["in_city_centre"] = labelled_uprn_gdf["type"].apply(
+        lambda x: any(t in types for t in x)
+    )
+
+    # UPRNs with no spatial signature match are ultimately classified as not in city centre
+    # TODO: consider if unassigned UPRNs should be handled differently in the future
+    labelled_uprn_gdf["in_city_centre"] = labelled_uprn_gdf["in_city_centre"].fillna(
+        False
+    )
+
+    # Return as polars df without geometry
+    labelled_uprn_df = pl.from_pandas(
+        labelled_uprn_gdf.drop(columns="geometry")
+    ).rename({"type": "spatial_signature_types"})
+
+    return labelled_uprn_df

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -19,7 +19,8 @@ def label_gdf_heat_network_zone_uprns(
     Args:
         uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be labelled
         hn_zone_gdf (gpd.GeoDataFrame): polygons of heat network zones
-        usecols (list, optional): names of descriptive columns in hn_zone_gdf (excluding "geometry") to be joined with uprn_gdf. Default is None to use all columns.
+        usecols (list, optional): names of descriptive columns in hn_zone_gdf to be joined with uprn_gdf (in addition to "geometry").
+            Default is None to only use "geometry".
 
     Returns:
         pl.DataFrame: input UPRNs labelled with heat network zone identifiers
@@ -39,6 +40,8 @@ def label_gdf_heat_network_zone_uprns(
     # If usecols specified, filter columns in hn_zone_gdf
     if usecols:
         hn_zone_gdf = hn_zone_gdf[["geometry"] + usecols]
+    else:
+        hn_zone_gdf = hn_zone_gdf[["geometry"]]
 
     # Spatial join for labelling UPRNs
     labelled_uprn_gdf = uprn_gdf.sjoin(
@@ -52,5 +55,66 @@ def label_gdf_heat_network_zone_uprns(
 
     # Return as polars df without geometry
     labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry"))
+
+    return labelled_uprn_df
+
+
+def label_gdf_heat_network_spatial_signatures_uprns(
+    uprn_gdf: gpd.GeoDataFrame,
+    spatial_signatures_gdf: gpd.GeoDataFrame,
+    usecols: list = None,
+    types: list = None,
+) -> pl.DataFrame:
+    """
+    Labels UPRNs that are located within a given Spatial Signature type deemed to be potentially
+    suitable for a heat network.
+
+    Args:
+        uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be labelled
+        spatial_signatures_gdf (gpd.GeoDataFrame): polygons of spatial signatures
+        usecols (list, optional): names of descriptive columns from spatial_signatures_gdf to be joined with uprn_gdf (in addition to "geometry" and "type").
+            Default is None to use only "geometry" and "type".
+        types (list, optional): spatial signature types potentially suitable for a heat network. Default is None to use all spatial signature types.
+
+    Returns:
+        pl.DataFrame: input UPRNs labelled with spatial signature identifiers and booleans indicating potential for a heat network
+    """
+
+    # CRS checks and reprojection if needed
+    target_crs = config["constant"]["target_crs"]
+
+    if uprn_gdf.crs != target_crs:
+        uprn_gdf = uprn_gdf.to_crs(target_crs)
+        print(f"uprn_gdf reprojected to target CRS: {target_crs}")
+
+    if spatial_signatures_gdf.crs != target_crs:
+        spatial_signatures_gdf = spatial_signatures_gdf.to_crs(target_crs)
+        print(f"spatial_signatures_gdf reprojected to target CRS: {target_crs}")
+
+    # If usecols specified, filter columns in spatial_signatures_gdf
+    if usecols:
+        spatial_signatures_gdf = spatial_signatures_gdf[["geometry", "type"] + usecols]
+    else:
+        spatial_signatures_gdf = spatial_signatures_gdf[["geometry", "type"]]
+
+    # Spatial join for for labelling UPRN with signature type
+    labelled_uprn_gdf = uprn_gdf.sjoin(
+        spatial_signatures_gdf,
+        how="left",
+        predicate="intersects",  # include properties intersecting spatial signature cell boundary
+    ).drop(columns="index_right")
+
+    # Add potential heat network zone boolean label to original uprn_gdf
+    labelled_uprn_gdf["in_potential_hn_zone"] = (
+        labelled_uprn_gdf["type"].isin(types) if types else True
+    )
+    labelled_uprn_gdf["in_potential_hn_zone"] = labelled_uprn_gdf[
+        "in_potential_hn_zone"
+    ].fillna(False)
+
+    # Return as polars df without geometry
+    labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry"))
+
+    labelled_uprn_df = labelled_uprn_df.rename({"type": "spatial_signature_type"})
 
     return labelled_uprn_df

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -1,5 +1,5 @@
 """
-Functions to label UPRNs within existing or potential heat network zones.
+Functions to label UPRNs within official existing, potential or planned heat network zones.
 """
 
 import geopandas as gpd
@@ -55,66 +55,5 @@ def label_gdf_heat_network_zone_uprns(
 
     # Return as polars df without geometry
     labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry"))
-
-    return labelled_uprn_df
-
-
-def label_gdf_heat_network_spatial_signatures_uprns(
-    uprn_gdf: gpd.GeoDataFrame,
-    spatial_signatures_gdf: gpd.GeoDataFrame,
-    usecols: list = None,
-    types: list = None,
-) -> pl.DataFrame:
-    """
-    Labels UPRNs that are located within a given Spatial Signature type deemed to be potentially
-    suitable for a heat network.
-
-    Args:
-        uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be labelled
-        spatial_signatures_gdf (gpd.GeoDataFrame): polygons of spatial signatures
-        usecols (list, optional): names of descriptive columns from spatial_signatures_gdf to be joined with uprn_gdf (in addition to "geometry" and "type").
-            Default is None to use only "geometry" and "type".
-        types (list, optional): spatial signature types potentially suitable for a heat network. Default is None to use all spatial signature types.
-
-    Returns:
-        pl.DataFrame: input UPRNs labelled with spatial signature identifiers and booleans indicating potential for a heat network
-    """
-
-    # CRS checks and reprojection if needed
-    target_crs = config["constant"]["target_crs"]
-
-    if uprn_gdf.crs != target_crs:
-        uprn_gdf = uprn_gdf.to_crs(target_crs)
-        print(f"uprn_gdf reprojected to target CRS: {target_crs}")
-
-    if spatial_signatures_gdf.crs != target_crs:
-        spatial_signatures_gdf = spatial_signatures_gdf.to_crs(target_crs)
-        print(f"spatial_signatures_gdf reprojected to target CRS: {target_crs}")
-
-    # If usecols specified, filter columns in spatial_signatures_gdf
-    if usecols:
-        spatial_signatures_gdf = spatial_signatures_gdf[["geometry", "type"] + usecols]
-    else:
-        spatial_signatures_gdf = spatial_signatures_gdf[["geometry", "type"]]
-
-    # Spatial join for for labelling UPRN with signature type
-    labelled_uprn_gdf = uprn_gdf.sjoin(
-        spatial_signatures_gdf,
-        how="left",
-        predicate="intersects",  # include properties intersecting spatial signature cell boundary
-    ).drop(columns="index_right")
-
-    # Add potential heat network zone boolean label to original uprn_gdf
-    labelled_uprn_gdf["in_potential_hn_zone"] = (
-        labelled_uprn_gdf["type"].isin(types) if types else True
-    )
-    labelled_uprn_gdf["in_potential_hn_zone"] = labelled_uprn_gdf[
-        "in_potential_hn_zone"
-    ].fillna(False)
-
-    # Return as polars df without geometry
-    labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry"))
-
-    labelled_uprn_df = labelled_uprn_df.rename({"type": "spatial_signature_type"})
 
     return labelled_uprn_df

--- a/asf_heat_pump_suitability/research/exploratory/20251205_plymouth_investigation.py
+++ b/asf_heat_pump_suitability/research/exploratory/20251205_plymouth_investigation.py
@@ -1,5 +1,11 @@
 # %% [markdown]
-# ### **Investigating areas in Plymouth LA with existing heat network zones or potential for a heat network**
+# ### **Investigating areas in Plymouth LA with existing/planned heat network zones or areas which are city areas**
+
+# %% [markdown]
+# This is an exploratory notebook where:
+# 1. Existing/planned heat network zones in Plymouth are inspected visually and the % of UPRNs in a zone is calculated.
+# 2. Which spatial signature types from the Spatial Signatures Framework are in existing/planned heat network zones. Within each existing/planned heat network zone in Plymouth, each type is identified.
+# 3. A subset of spatial signature types selected to represent city centre areas are examined and their spatial and UPRN coverage is compared with that of existing/planned heat network zones.
 
 # %%
 import pandas as pd
@@ -16,7 +22,11 @@ from asf_heat_pump_suitability.getters import (
     load_geodata,
     load_boundaries,
 )
-from asf_heat_pump_suitability.pipeline.transform import uprns, heat_network_zones
+from asf_heat_pump_suitability.pipeline.transform import (
+    uprns,
+    heat_network_zones,
+    city_centres,
+)
 
 # %% [markdown]
 # Loading data
@@ -44,7 +54,7 @@ plymouth_la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries
 )
 
 # %%
-# Existing heat network zones in plymouth
+# Existing/planned heat network zones in plymouth
 plymouth_hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
     local_authority="plymouth"
 )
@@ -75,7 +85,7 @@ gdfs = [
 len({gdf.crs for gdf in gdfs}) == 1
 
 # %% [markdown]
-# #### **Inspecting existing heat network zones**
+# #### **Inspecting existing/planned heat network zones**
 
 # %%
 # Inspecting each HNZ
@@ -153,9 +163,7 @@ plt.show()
 
 # %%
 # What % of residential UPRNs are in existing HNZ?
-prop_in_hn_zone = plymouth_uprns_hnz_labelled_df.select(
-    pl.col("in_hn_zone").mean()
-).item()
+prop_in_hn_zone = plymouth_uprns_hnz_labelled_df["in_hn_zone"].mean()
 
 print(f"Proportion in HN zone: {prop_in_hn_zone:.3f}")
 
@@ -232,6 +240,7 @@ plymouth_hn_zones_with_labels_agg_gdf = (
 def inspect_spatial_signatures_in_hn_zone(zone_id: str):
     zone_gdf = plymouth_hn_zones_gdf[plymouth_hn_zones_gdf["ZoneID"] == zone_id]
 
+    # Add HN zone notes
     just_text_raw = str(zone_gdf.Just.values[0])
     just_text = "\n".join(textwrap.wrap(just_text_raw, width=90))
 
@@ -262,7 +271,7 @@ for zone_id in plymouth_hn_zones_with_labels_agg_gdf["ZoneID"].unique():
     inspect_spatial_signatures_in_hn_zone(zone_id)
 
 # %% [markdown]
-# #### **Testing urban spatial signatures to indicate "city centre" areas - i.e. areas potentially suitable for a heat network**
+# #### **Testing urban spatial signatures to indicate city centre areas**
 
 # %% [markdown]
 # Labelling original residential UPRNs
@@ -278,8 +287,9 @@ city_centre_types = [
     "Dense urban neighbourhoods",
 ]
 
+# %%
 plymouth_uprns_spatial_signature_labelled_df = (
-    heat_network_zones.label_gdf_heat_network_spatial_signatures_uprns(
+    city_centres.label_gdf_city_centre_spatial_signatures_uprns(
         uprn_gdf=plymouth_residential_uprns_gdf,
         spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
         types=city_centre_types,
@@ -290,7 +300,7 @@ plymouth_uprns_spatial_signature_labelled_df = (
 # Process filtered UPRNs for plotting
 plymouth_uprns_spatial_signature_df = (
     plymouth_uprns_spatial_signature_labelled_df.filter(
-        pl.col("in_potential_hn_zone") == True
+        pl.col("in_city_centre") == True
     )
 )
 plymouth_uprns_spatial_signature_gdf = uprns.generate_gdf_uprn_coords(
@@ -304,7 +314,7 @@ selected_spatial_signatures_plymouth_gdf = spatial_signatures_plymouth_gdf[
 ]
 
 # %%
-# Inspect selected spatial signatures in relation to existing HNZ
+# Inspect selected spatial signatures in relation to existing/planned HNZ
 
 # colour for spatial signature types
 unique_types = selected_spatial_signatures_plymouth_gdf["type"].unique()
@@ -368,17 +378,17 @@ summary_df = pd.DataFrame(
     {
         "Area (m²)": [area_hnz, area_selected, overlap_area],
         "% of HNZ covered by selected signatures": [
-            "100%",
-            f"{percent_selected_covered_by_hnz:.1f}%",
-            f"{(overlap_area / area_hnz) * 100:.1f}%",
+            f"{percent_hnz_covered_by_selected:.1f}%",
+            "",
+            "",
         ],
         "% of selected signatures covered by HNZ": [
-            f"{(area_hnz / area_selected) * 100:.1f}%",
-            "100%",
-            f"{(overlap_area / area_selected) * 100:.1f}%",
+            "",
+            f"{percent_selected_covered_by_hnz:.1f}%",
+            "",
         ],
     },
-    index=["Existing HNZ", "Selected signatures", "Actual overlap"],
+    index=["Existing HNZ", "Selected signatures", "Overlap"],
 )
 
 summary_df
@@ -386,7 +396,7 @@ summary_df
 # %% [markdown]
 # 05/12/25: Computing the spatial overlap, the **city centre types cover 35% of the area covered by existing heat network zones**. Conversely, the **existing heat network zones cover 83% of the area covered by city centre types**.
 # - 35% metric -> The selected signature types only partially align with the existing heat network coverage; most of the current HNZ lie outside "city centre" areas. This indicates that using "city centre" areas is not able to capture all areas that have been deemed suitable for a heat network in reality.
-# - 83% metric -> Most of the areas identified as city centre/potentially suitable for a heat network are already part of the existing heat network.
+# - 83% metric -> Most of the areas identified as city centre are already part of the existing heat network.
 # - Using city centre areas as proxies for heat network suitability: most areas selected are part of an existing HNZ (high precision) - but many existing HNZ areas outside these urban centres are missed, since HNZ are not chosen based on urban location alone.
 
 # %%
@@ -406,7 +416,7 @@ plymouth_hn_zones_gdf.plot(
     edgecolor="#1f77b4",
     linewidth=2,
     alpha=0.8,
-    label="HNZ Zones",
+    label="HN Zones",
 )
 
 plymouth_hn_zone_uprns_gdf.plot(
@@ -484,7 +494,7 @@ city_centre_types = [
 ]
 
 plymouth_uprns_hnz_spatial_signature_labelled_df = (
-    heat_network_zones.label_gdf_heat_network_spatial_signatures_uprns(
+    city_centres.label_gdf_city_centre_spatial_signatures_uprns(
         uprn_gdf=plymouth_uprns_hnz_labelled_gdf,
         spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
         types=city_centre_types,
@@ -496,7 +506,7 @@ plymouth_uprns_hnz_spatial_signature_labelled_df = (
 
 # %%
 plymouth_uprns_hnz_spatial_signature_labelled_df.group_by(
-    ["in_hn_zone", "in_potential_hn_zone"]
+    ["in_hn_zone", "in_city_centre"]
 ).len().with_columns((pl.col("len") / pl.col("len").sum()).alias("percent"))
 
 # %%
@@ -504,25 +514,25 @@ plymouth_uprns_hnz_spatial_signature_labelled_df.group_by(
 hnz_true_df = plymouth_uprns_hnz_spatial_signature_labelled_df.filter(
     (pl.col("in_hn_zone") == True)
 )
-prop_true = hnz_true_df.select(pl.col("in_potential_hn_zone").mean()).item()
+prop_true = hnz_true_df["in_city_centre"].mean()
 
 print(
-    f"Proportion of UPRNs in an existing heat network zone which are classified to be in a potential heat network zone (by the set of spatial signature types) [recall]: {prop_true:.3f}"
+    f"Proportion of UPRNs in an existing heat network zone which are classified to be in a city centre (by the set of spatial signature types) [recall]: {prop_true:.3f}"
 )
 
 # %%
-potential_hnz_true_df = plymouth_uprns_hnz_spatial_signature_labelled_df.filter(
-    pl.col("in_potential_hn_zone") == True
+city_centre_true_df = plymouth_uprns_hnz_spatial_signature_labelled_df.filter(
+    pl.col("in_city_centre") == True
 )
 
-prop_true = potential_hnz_true_df.select(pl.col("in_hn_zone").mean()).item()
+prop_true = city_centre_true_df["in_hn_zone"].mean()
 
 print(
-    f"Proportion of UPRNs in a potential heat network zone (as classified by the set of spatial signature types) which are already in an existing heat network zone [precision]: {prop_true:.3f}"
+    f"Proportion of UPRNs in a city centre area (as classified by the set of spatial signature types) which are already in an existing heat network zone [precision]: {prop_true:.3f}"
 )
 
 # %% [markdown]
-# 05/12/25: City centres as a proxy performs better at capturing properties in existing HNZ, compared to land area. Mainly because of the higher density of properties in the selected urban area types.
+# 05/12/25: City centres as a potential proxy performs better at capturing properties in existing HNZ (i.e. UPRN coverage), compared to spatial coverage. Mainly because of the higher density of properties in the selected urban area types.
 # - 84% of UPRNs in existing HNZ are in city centre spatial signature types -> most properties already served are captured, showing our proxy effectively targets relevant properties
 # - 82% of UPRNs in city centre types are in existing HNZ -> few properties outside existing HNZ are incorrectly flagged, indicating the proxy is precise
 #


### PR DESCRIPTION
Fixes https://github.com/nestauk/asf_heat_pump_suitability/issues/200

# Description

Code to process UPRNs and identify whether they are in a potential heat network zone, based on which spatial signature type area they are in.

Changed files:
- `config/base.yaml` - add path to datasets containing the spatial signatures dataset for GB. There is one version with the suffix `_simplified` and the other without a suffix. **The code and run script I've developed is based only on the `_simplified` version. (I've not been able to inspect the full version as loading it keeps crashing my kernel 🥲)**

- `getters/load_geodata.py` - add getter for spatial signatures dataset for GB with arguments to select `simplified` or `full` version.

- `pipeline/transform/heat_network_zones.py` - add function to label UPRNs that are in one of the given spatial signature types. This function does the same processing as the HNZ labeller, so there might be opportunity to streamline but I think keeping them distinctly separate is best for clarity at this stage.
Note: I've changed the logic for `usecols` in both the HNZ and spatial signature labeller so that default `usecols=None` no longer means that all columns are used but rather only the columns essential for processing.

- `pipeline/run/heat_network_city_centres.py` - add code block to existing script that adds boolean flags labelling residential UPRNs indicating whether they're in one of spatial signature types we're currently considering to be representative of a city centre. This script now saves two separate dataframes to S3 - one with existing HNZ labels, and one with spatial signature types and city centre boolean labels. For simplicity, I've kept them separate but we could in future, combine both HNZ and city centre labels one dataframe by converting `hp_zone_uprn_df` to a `gdf` and passing that to `heat_network_zones.label_gdf_heat_network_spatial_signature_uprns()`.

- `analysis/spatial_signatures_hn_zones.py` - add analytical notebook that compares existing HNZ and city centre spatial signature types. This is specific to Plymouth LA. Open as Jupyter Notebook.

# Instructions for Reviewer

To run the script: python asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py --local_authorities plymouth
- Please inspect the new `city_centre_uprn_df` that is saved out to S3

Please pay special attention to
* Any bugs or opportunities for improvement in the loading and labelling functions, as well as the new code block in the run script
* Whether you're happy with the saved location of the spatial signatures dataset, as well as how their paths are inserted in config
* Schema of the saved output dataframe

With regards to the analysis notebook, please run all the cells and have a look at the outputs. Let me know if you have any other thoughts on how we're evaluating whether the city centre signature types do a good enough job at flagging potential heat network zones. Please also flag if there are any errors in the analysis or interpretation.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
