### PR TITLE
209 enable running pipelines for any LA + prep data for manchester workshop

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -34,7 +34,7 @@ data:
 constant:
   plymouth:
     la_names: "Plymouth"
-    grid_square: "SX"
+    grid_squares: "SX"
   plymouth_similar_cities:
     la_names:
       - "Liverpool"

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -31,9 +31,17 @@ data:
     plymouth_residential_uprns: "s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet"
 
 constant:
-  grid_squares:
-    plymouth: "SX"
-    plymouth_similar_cities: # Liverpool, Plymouth, Portsmouth, Southampton, Swansea
+  plymouth:
+    la_names: "Plymouth"
+    grid_square: "SX"
+  plymouth_similar_cities:
+    la_names:
+      - "Liverpool"
+      - "Plymouth"
+      - "Portsmouth"
+      - "Southampton"
+      - "Swansea"
+    grid_squares:
       - "SD"
       - "SJ"
       - "SN"
@@ -41,7 +49,15 @@ constant:
       - "SU"
       - "SX"
       - "SZ"
-    sampling_areas: # Plymouth, Nottingham, Bradford, Glasgow, Manchester, Bath
+  sampling_areas:
+    la_names:
+      - "Bath and North East Somerset"
+      - "Bradford"
+      - "Glasgow City"
+      - "Manchester"
+      - "Nottingham"
+      - "Plymouth"
+    grid_squares:
       - "NS"
       - "SD"
       - "SE"
@@ -49,21 +65,24 @@ constant:
       - "SK"
       - "ST"
       - "SX"
-  plymouth_similar_cities:
-    - "Liverpool"
-    - "Plymouth"
-    - "Portsmouth"
-    - "Southampton"
-    - "Swansea"
-  sampling_areas:
-    - "Bath and North East Somerset"
-    - "Bradford"
-    - "Glasgow City"
-    - "Manchester"
-    - "Nottingham"
-    - "Plymouth"
+  greater_manchester_las:
+    la_names:
+      - "Bolton"
+      - "Bury"
+      - "Manchester"
+      - "Oldham"
+      - "Rochdale"
+      - "Salford"
+      - "Stockport"
+      - "Tameside"
+      - "Trafford"
+      - "Wigan"
+    grid_squares:
+      - "SD"
+      - "SE"
+      - "SJ"
+      - "SK"
   target_crs: 27700 # British National Grid
-
 data_source:
   gb_ons_postcode_dir_url: "https://www.arcgis.com/sharing/rest/content/items/487a5ba62c8b4da08f01eb3c08e304f6/data" # Aug 2023 data
   gb_ons_postcode_dir_file_path: "Data/ONSPD_AUG_2023_UK.csv" # Aug 2023 data

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -14,6 +14,7 @@ data:
     heat_network_zones:
       # Plymouth Heat Network zones
       plymouth: "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/NMR3 Heat Network Zones (Post-Ref).gpkg"
+      greater_manchester_las: "s3://asf-heat-pump-suitability/heat_network_desnz_data/heat-network-zone-map-Greater-Manchester.gpkg"
 
     gb_spatial_signatures:
       # UrbanGrammarAI Spatial Signatures GB simplified

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -46,6 +46,7 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
     Load GeoDataFrame with heat network zone polygons in given Local Authority.
 
     Args:
+        local_authority (str): Local Authority to load Heat Network zone polygons for.
         **kwargs for `gpd.read_file()`
 
     Returns:

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -7,8 +7,8 @@ Script to add features to UPRNs:
 Run:
 python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs.parquet
 
-To save outputs, add --save_outputs True flag:
-python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs.parquet --save_outputs True
+To save outputs to S3, add --save flag:
+python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs.parquet --save
 """
 
 import argparse

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -41,7 +41,6 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--save",
         help="If --save is set, it saves outputs to S3.",
-        type=bool,
         required=False,
         action="store_true",
     )

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -5,6 +5,11 @@ Script to add features to UPRNs:
 
 Run:
 python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs
+
+where you should replace `path/to/domestic/UPRNs` with the path to the parquet file
+
+To run in test mode without saving outputs, add --test_mode flag.
+python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs --test_mode
 """
 
 import argparse
@@ -35,6 +40,12 @@ def parse_arguments() -> argparse.Namespace:
         required=True,
     )
 
+    parser.add_argument(
+        "--test_mode",
+        help="If set, runs in test mode without saving outputs.",
+        action="store_true",
+    )
+
     return parser.parse_args()
 
 
@@ -42,11 +53,15 @@ if __name__ == "__main__":
     import os
     import polars as pl
     import geopandas as gpd
+    import pandas as pd
 
     from asf_heat_pump_suitability.utils import save_utils
     from asf_heat_pump_suitability.getters import load_tree_input
     from asf_heat_pump_suitability.pipeline.impute import property_type
     from asf_heat_pump_suitability.pipeline.transform import uprns, outdoor_space
+    from asf_heat_pump_suitability.getters.get_datasets import (
+        load_gdf_inspire_land_parcels,
+    )
 
     args = parse_arguments()
     las = args.local_authorities.lower()
@@ -70,36 +85,28 @@ if __name__ == "__main__":
 
     # ------------------------ #
     # ESTIMATE OUTDOOR SPACE
-    # TODO scale beyond Plymouth
+    # TODO scale beyond Plymouth. This is a temporary fix to working with multiple LAs
     print("Loading land registry data...")
 
-    # from asf_heat_pump_suitability.getters import load_boundaries
-    # boundaries = load_boundaries.load_gdf_local_authority_boundaries(select_las=config["constant"][las]["la_names"])
-    # print(boundaries.head())
-    import pandas as pd
-    import geopandas as gpd
-    from asf_heat_pump_suitability.getters.get_datasets import (
-        load_gdf_inspire_land_parcels,
-    )
-
-    inspire_file_names = load_gdf_inspire_land_parcels(
-        path="s3://asf-heat-pump-suitability/outputs/2023Q4/gardens/inspire_file_bounds_EW.geojson"
-    )
-    inspire_file_names = inspire_file_names[
-        inspire_file_names["LAD23NM"].isin(config["constant"][las]["la_names"])
-    ]
-    inspire_file_names = inspire_file_names["inspire_file_name"].unique()
-    land_parcels_gdf = gpd.GeoDataFrame()
-    for file_name in inspire_file_names:
-        print(f"Loading land parcels from {file_name}...")
-        temp_gdf = load_gdf_inspire_land_parcels(path=f"s3://{file_name}")
-        land_parcels_gdf = pd.concat([land_parcels_gdf, temp_gdf], ignore_index=True)
-
-    print(land_parcels_gdf.head())
-
-    # land_parcels_gdf = gpd.read_file(
-    #     "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/Plymouth_Land_Registry_Cadastral_Parcels.gml"
-    # )
+    if las == "plymouth":
+        land_parcels_gdf = gpd.read_file(
+            "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/Plymouth_Land_Registry_Cadastral_Parcels.gml"
+        )
+    else:
+        inspire_file_names = load_gdf_inspire_land_parcels(
+            path="s3://asf-heat-pump-suitability/outputs/2023Q4/gardens/inspire_file_bounds_EW.geojson"
+        )
+        inspire_file_names = inspire_file_names[
+            inspire_file_names["LAD23NM"].isin(config["constant"][las]["la_names"])
+        ]
+        inspire_file_names = inspire_file_names["inspire_file_name"].unique()
+        land_parcels_gdf = gpd.GeoDataFrame()
+        for file_name in inspire_file_names:
+            print(f"Loading land parcels from {file_name}...")
+            temp_gdf = load_gdf_inspire_land_parcels(path=f"s3://{file_name}")
+            land_parcels_gdf = pd.concat(
+                [land_parcels_gdf, temp_gdf], ignore_index=True
+            )
 
     building_footprints_gdf = load_tree_input.load_gdf_os_openmap_local_layer(
         layer="building", grid_squares=config["constant"][las]["grid_squares"]
@@ -136,7 +143,9 @@ if __name__ == "__main__":
 
     # ------------------------ #
     # SAVE OUTPUTS
-    save_utils.save_to_s3(
-        features_df,
-        path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns).split('.')[0]}_with_features.parquet",
-    )
+
+    if not args.test_mode:
+        save_utils.save_to_s3(
+            features_df,
+            path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns).split('.')[0]}_with_features.parquet",
+        )

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -4,12 +4,10 @@ Script to add features to UPRNs:
 - estimated max contiguous and total outdoor space (m2)
 
 Run:
-python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs
+python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs.parquet
 
-where you should replace `path/to/domestic/UPRNs` with the path to the parquet file
-
-To run in test mode without saving outputs, add --test_mode flag.
-python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs --test_mode
+To save outputs, add --save_outputs True flag:
+python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/domestic/UPRNs.parquet --save_outputs True
 """
 
 import argparse
@@ -35,15 +33,17 @@ def parse_arguments() -> argparse.Namespace:
 
     parser.add_argument(
         "--local_authorities",
-        help="",
+        help="Local authority or authorities. See base.yaml's `constant` section for options e.g. `plymouth`, `plymouth_similar_cities`, `sampling_areas`, `greater_manchester_las`.",
         type=str,
         required=True,
     )
 
     parser.add_argument(
-        "--test_mode",
-        help="If set, runs in test mode without saving outputs.",
-        action="store_true",
+        "--save_outputs",
+        help="If set to `True`, it saves the outputs. Otherwise, outputs are not saved. Defaults to `False`, i.e. not saving outputs.",
+        type=bool,
+        required=False,
+        default=False,
     )
 
     return parser.parse_args()
@@ -59,9 +59,7 @@ if __name__ == "__main__":
     from asf_heat_pump_suitability.getters import load_tree_input
     from asf_heat_pump_suitability.pipeline.impute import property_type
     from asf_heat_pump_suitability.pipeline.transform import uprns, outdoor_space
-    from asf_heat_pump_suitability.getters.get_datasets import (
-        load_gdf_inspire_land_parcels,
-    )
+    from asf_heat_pump_suitability.getters import get_datasets
 
     args = parse_arguments()
     las = args.local_authorities.lower()
@@ -93,20 +91,20 @@ if __name__ == "__main__":
             "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/Plymouth_Land_Registry_Cadastral_Parcels.gml"
         )
     else:
-        inspire_file_names = load_gdf_inspire_land_parcels(
+        inspire_file_names = get_datasets.load_gdf_inspire_land_parcels(
             path="s3://asf-heat-pump-suitability/outputs/2023Q4/gardens/inspire_file_bounds_EW.geojson"
         )
         inspire_file_names = inspire_file_names[
             inspire_file_names["LAD23NM"].isin(config["constant"][las]["la_names"])
-        ]
-        inspire_file_names = inspire_file_names["inspire_file_name"].unique()
-        land_parcels_gdf = gpd.GeoDataFrame()
-        for file_name in inspire_file_names:
-            print(f"Loading land parcels from {file_name}...")
-            temp_gdf = load_gdf_inspire_land_parcels(path=f"s3://{file_name}")
-            land_parcels_gdf = pd.concat(
-                [land_parcels_gdf, temp_gdf], ignore_index=True
-            )
+        ]["inspire_file_name"].unique()
+
+        land_parcels_gdf = pd.concat(
+            [
+                get_datasets.load_gdf_inspire_land_parcels(path=f"s3://{file}")
+                for file in inspire_file_names
+            ],
+            ignore_index=False,
+        )
 
     building_footprints_gdf = load_tree_input.load_gdf_os_openmap_local_layer(
         layer="building", grid_squares=config["constant"][las]["grid_squares"]
@@ -144,7 +142,7 @@ if __name__ == "__main__":
     # ------------------------ #
     # SAVE OUTPUTS
 
-    if not args.test_mode:
+    if args.save_outputs:
         save_utils.save_to_s3(
             features_df,
             path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns).split('.')[0]}_with_features.parquet",

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -37,13 +37,12 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         required=True,
     )
-
     parser.add_argument(
-        "--save_outputs",
-        help="If set to `True`, it saves the outputs. Otherwise, outputs are not saved. Defaults to `False`, i.e. not saving outputs.",
+        "--save",
+        help="If --save is set, it saves outputs to S3.",
         type=bool,
         required=False,
-        default=False,
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -142,7 +141,7 @@ if __name__ == "__main__":
     # ------------------------ #
     # SAVE OUTPUTS
 
-    if args.save_outputs:
+    if args.save:
         save_utils.save_to_s3(
             features_df,
             path=f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{os.path.basename(args.uprns).split('.')[0]}_with_features.parquet",

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -8,6 +8,7 @@ python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns path/to/do
 """
 
 import argparse
+from asf_heat_pump_suitability import config
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -27,6 +28,13 @@ def parse_arguments() -> argparse.Namespace:
         required=True,
     )
 
+    parser.add_argument(
+        "--local_authorities",
+        help="",
+        type=str,
+        required=True,
+    )
+
     return parser.parse_args()
 
 
@@ -41,6 +49,7 @@ if __name__ == "__main__":
     from asf_heat_pump_suitability.pipeline.transform import uprns, outdoor_space
 
     args = parse_arguments()
+    las = args.local_authorities.lower()
 
     # Load UPRN data
     print(f"Loading domestic UPRNs from: {args.uprns}")
@@ -63,11 +72,37 @@ if __name__ == "__main__":
     # ESTIMATE OUTDOOR SPACE
     # TODO scale beyond Plymouth
     print("Loading land registry data...")
-    land_parcels_gdf = gpd.read_file(
-        "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/Plymouth_Land_Registry_Cadastral_Parcels.gml"
+
+    # from asf_heat_pump_suitability.getters import load_boundaries
+    # boundaries = load_boundaries.load_gdf_local_authority_boundaries(select_las=config["constant"][las]["la_names"])
+    # print(boundaries.head())
+    import pandas as pd
+    import geopandas as gpd
+    from asf_heat_pump_suitability.getters.get_datasets import (
+        load_gdf_inspire_land_parcels,
     )
+
+    inspire_file_names = load_gdf_inspire_land_parcels(
+        path="s3://asf-heat-pump-suitability/outputs/2023Q4/gardens/inspire_file_bounds_EW.geojson"
+    )
+    inspire_file_names = inspire_file_names[
+        inspire_file_names["LAD23NM"].isin(config["constant"][las]["la_names"])
+    ]
+    inspire_file_names = inspire_file_names["inspire_file_name"].unique()
+    land_parcels_gdf = gpd.GeoDataFrame()
+    for file_name in inspire_file_names:
+        print(f"Loading land parcels from {file_name}...")
+        temp_gdf = load_gdf_inspire_land_parcels(path=f"s3://{file_name}")
+        land_parcels_gdf = pd.concat([land_parcels_gdf, temp_gdf], ignore_index=True)
+
+    print(land_parcels_gdf.head())
+
+    # land_parcels_gdf = gpd.read_file(
+    #     "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/Plymouth_Land_Registry_Cadastral_Parcels.gml"
+    # )
+
     building_footprints_gdf = load_tree_input.load_gdf_os_openmap_local_layer(
-        layer="building", grid_squares="SX"
+        layer="building", grid_squares=config["constant"][las]["grid_squares"]
     )
 
     # Get intersection of building footprint polygons and land polygons

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -17,7 +17,7 @@ Defaults to `GB` (all of Great Britain), but this is not yet implemented.
 
 Temporary (before we scale): Set up a new local authority or group of local authorities by adding an entry to the `constant` section of the config.yaml file.
 
-Set --test_mode flag to run in test mode without saving outputs.
+Set --save_outputs flag to True to save the outputs to S3. By default, outputs are not saved.
 """
 
 import argparse
@@ -35,7 +35,7 @@ def parse_arguments() -> argparse.Namespace:
     # Placeholder - this arg is to look up correct paths for residential UPRNs and heat network dataset
     parser.add_argument(
         "--local_authorities",
-        help="Run script for specific local authority or group of local authorities. Defaults to GB (all of Great Britain).",
+        help="Local authority or authorities. See base.yaml's `constant` section for options e.g. `plymouth`, `plymouth_similar_cities`, `sampling_areas`, `greater_manchester_las`.",
         type=str,
         default="GB",
         required=False,
@@ -49,9 +49,11 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--test_mode",
-        help="If set, runs in test mode without saving outputs.",
-        action="store_true",
+        "--save_outputs",
+        help="If set to `True`, it saves the outputs. Otherwise, outputs are not saved. Defaults to `False`, i.e. not saving outputs.",
+        type=bool,
+        required=False,
+        default=False,
     )
 
     return parser.parse_args()
@@ -85,13 +87,13 @@ if __name__ == "__main__":
         ### Existing heat network zones
 
         # Load Plymouth existing heat network zone polygons
-        la_names = config["constant"][las]["la_names"]
         print(f"Loading heat network zone data for {las} Local Authority...")
         hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(local_authority=las)
 
         # Label UPRNs in existing, potential and planned heat network zones
         print(f"Identifying residential UPRNs in heat network zones for {las}...")
         id_col = [col for col in hn_zones_gdf.columns if "ID" in col][0]
+        print(f"Using Heat Network Zone {id_col} column as ID")
 
         hn_zone_uprn_df = heat_network_zones.label_gdf_heat_network_zone_uprns(
             uprn_gdf=uprn_gdf,
@@ -136,7 +138,7 @@ if __name__ == "__main__":
         )
 
     # Save residential UPRNs with existing heat network zone and city centre labels to S3
-    if not args.test_mode:
+    if args.save_outputs:
         save_utils.save_to_s3(
             hn_zone_city_centre_uprn_df,
             f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones_city_centres.parquet",

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -79,24 +79,20 @@ if __name__ == "__main__":
 
         # Label UPRNs in existing, potential and planned heat network zones
         print(f"Identifying residential UPRNs in heat network zones for {las}...")
+        id_col = [col for col in hn_zones_gdf.columns if "ID" in col][0]
+
         hn_zone_uprn_df = heat_network_zones.label_gdf_heat_network_zone_uprns(
             uprn_gdf=uprn_gdf,
             hn_zone_gdf=hn_zones_gdf,
-            # usecols=[
-            #     "ZoneID",  # zone unique identifier
-            # ],
+            usecols=[
+                id_col,  # zone unique identifier
+            ],
         )
 
         # Clean up columns
         hn_zone_uprn_df = hn_zone_uprn_df.select(
-            [
-                "UPRN",
-                "LAD23NM",
-                "X_COORDINATE",
-                "Y_COORDINATE",
-                "in_hn_zone",  # "ZoneID"
-            ]
-        )  # .rename({"ZoneID": "HNZoneID"})
+            ["UPRN", "LAD23NM", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", id_col]
+        ).rename({id_col: "HNZoneID"})
 
         """ City centre areas """
 

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -1,16 +1,21 @@
 """
 Contains script to add boolean flags to label residential UPRNs indicating whether they are:
 - located within a heat network zone
-- located within a city centre
+- located within a city centre (according to Spatial Signatures Framework)
 
 To run the script:
-python asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+python asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py --uprns_path path/to/residential/uprns.parquet
 
-Set the optional `local_authorities` parameter to `plymouth`, `plymouth_similar`, or `sampling_areas`.
-Set to `plymouth` to run for Plymouth Local Authority; `plymouth_similar` to run for Plymouth plus four other similar
-Local Authorities (Liverpool, Portsmouth, Southampton, Swansea); 'sampling_areas' to run for Plymouth plus five other
-Local Authorities for sampling buildings (Bath, Bradford, Glasgow, Manchester, Nottingham); or do not use to run for all
-of Great Britain.
+where you should replace `path/to/residential/uprns.parquet` with the path to the parquet file containing residential UPRNs with X and Y coordinates.
+
+Set the `local_authorities` parameter to:
+- `plymouth` for Plymouth only
+- `plymouth_similar` for Plymouth and 4 similar local authorities (Liverpool, Portsmouth, Southampton, Swansea)
+- `sampling_areas` for Plymouth and 5 different local authorities for sampling buildings (Bath, Bradford, Glasgow, Manchester, Nottingham)
+- `greater_manchester_las` for all Greater Manchester local authorities (Bolton, Bury, Manchester, Oldham, Rochdale, Salford, Stockport, Tameside, Trafford, Wigan)
+Defaults to `GB` (all of Great Britain), but this is not yet implemented.
+
+Set --test_mode flag to run in test mode without saving outputs.
 """
 
 import argparse
@@ -28,7 +33,7 @@ def parse_arguments() -> argparse.Namespace:
     # Placeholder - this arg is to look up correct paths for residential UPRNs and heat network dataset
     parser.add_argument(
         "--local_authorities",
-        help="Run script for either all of Great Britain; Plymouth only {plymouth}; or Plymouth and 4 similar local authorities {plymouth_similar}; or Plymouth and 5 different local authorities {sampling_areas}. Default to all of GB",
+        help="Run script for either all of Great Britain; Plymouth",
         type=str,
         default="GB",
         required=False,
@@ -39,6 +44,12 @@ def parse_arguments() -> argparse.Namespace:
         help="Path to residential UPRN dataset with X and Y coordinates in parquet.",
         type=str,
         required=True,
+    )
+
+    parser.add_argument(
+        "--test_mode",
+        help="If set, runs in test mode without saving outputs.",
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -59,6 +70,7 @@ if __name__ == "__main__":
     las = args.local_authorities.lower()
     uprns_path = args.uprns_path
 
+    # TODO scale to GB
     if las == "gb":  # all GB
         # Placeholder for future implementation
         raise NotImplementedError("Processing for all of GB is not yet supported.")
@@ -68,14 +80,12 @@ if __name__ == "__main__":
         uprn_df = base_getters.load_df_from_s3(uprns_path)
         uprn_gdf = uprns.generate_gdf_uprn_coords(uprn_df)
 
-        """ Existing heat network zones """
+        ### Existing heat network zones
 
         # Load Plymouth existing heat network zone polygons
         la_names = config["constant"][las]["la_names"]
         print(f"Loading heat network zone data for {las} Local Authority...")
         hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(local_authority=las)
-
-        print(hn_zones_gdf.head())
 
         # Label UPRNs in existing, potential and planned heat network zones
         print(f"Identifying residential UPRNs in heat network zones for {las}...")
@@ -94,7 +104,7 @@ if __name__ == "__main__":
             ["UPRN", "LAD23NM", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", id_col]
         ).rename({id_col: "HNZoneID"})
 
-        """ City centre areas """
+        ### City centre areas
 
         # Load spatial signature polygons
         print("Loading spatial signatures dataset...")
@@ -117,7 +127,6 @@ if __name__ == "__main__":
                 "LAD23NM",
                 "X_COORDINATE",
                 "Y_COORDINATE",
-                # "HNZoneID",
                 "in_hn_zone",
                 "spatial_signature_types",
                 "in_city_centre",
@@ -125,7 +134,8 @@ if __name__ == "__main__":
         )
 
     # Save residential UPRNs with existing heat network zone and city centre labels to S3
-    save_utils.save_to_s3(
-        hn_zone_city_centre_uprn_df,
-        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones_city_centres.parquet",
-    )
+    if not args.test_mode:
+        save_utils.save_to_s3(
+            hn_zone_city_centre_uprn_df,
+            f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones_city_centres.parquet",
+        )

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -15,6 +15,8 @@ Set the `local_authorities` parameter to:
 - `greater_manchester_las` for all Greater Manchester local authorities (Bolton, Bury, Manchester, Oldham, Rochdale, Salford, Stockport, Tameside, Trafford, Wigan)
 Defaults to `GB` (all of Great Britain), but this is not yet implemented.
 
+Temporary (before we scale): Set up a new local authority or group of local authorities by adding an entry to the `constant` section of the config.yaml file.
+
 Set --test_mode flag to run in test mode without saving outputs.
 """
 
@@ -33,7 +35,7 @@ def parse_arguments() -> argparse.Namespace:
     # Placeholder - this arg is to look up correct paths for residential UPRNs and heat network dataset
     parser.add_argument(
         "--local_authorities",
-        help="Run script for either all of Great Britain; Plymouth",
+        help="Run script for specific local authority or group of local authorities. Defaults to GB (all of Great Britain).",
         type=str,
         default="GB",
         required=False,

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -34,6 +34,13 @@ def parse_arguments() -> argparse.Namespace:
         required=False,
     )
 
+    parser.add_argument(
+        "--uprns_path",
+        help="Path to residential UPRN dataset with X and Y coordinates in parquet.",
+        type=str,
+        required=True,
+    )
+
     return parser.parse_args()
 
 
@@ -49,39 +56,47 @@ if __name__ == "__main__":
 
     args = parse_arguments()
 
-    if args.local_authorities.lower() == "plymouth":
+    las = args.local_authorities.lower()
+    uprns_path = args.uprns_path
 
+    if las == "gb":  # all GB
+        # Placeholder for future implementation
+        raise NotImplementedError("Processing for all of GB is not yet supported.")
+    else:
         # Load residential OS UPRNs in Plymouth
-        print("Loading residential UPRN dataset for Plymouth Local Authority...")
-        uprn_df = base_getters.load_df_from_s3(
-            config["data"]["processed"]["plymouth_residential_uprns"]
-        )
+        print(f"Loading residential UPRN dataset for {las}...")
+        uprn_df = base_getters.load_df_from_s3(uprns_path)
         uprn_gdf = uprns.generate_gdf_uprn_coords(uprn_df)
 
         """ Existing heat network zones """
 
         # Load Plymouth existing heat network zone polygons
-        print("Loading heat network zone data for Plymouth Local Authority...")
-        plymouth_hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
-            local_authority="plymouth"
-        )
+        la_names = config["constant"][las]["la_names"]
+        print(f"Loading heat network zone data for {las} Local Authority...")
+        hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(local_authority=las)
+
+        print(hn_zones_gdf.head())
 
         # Label UPRNs in existing, potential and planned heat network zones
-        print(
-            "Identifying residential UPRNs in heat network zones for Plymouth Local Authority..."
-        )
+        print(f"Identifying residential UPRNs in heat network zones for {las}...")
         hn_zone_uprn_df = heat_network_zones.label_gdf_heat_network_zone_uprns(
             uprn_gdf=uprn_gdf,
-            hn_zone_gdf=plymouth_hn_zones_gdf,
-            usecols=[
-                "ZoneID",  # zone unique identifier
-            ],
+            hn_zone_gdf=hn_zones_gdf,
+            # usecols=[
+            #     "ZoneID",  # zone unique identifier
+            # ],
         )
 
         # Clean up columns
         hn_zone_uprn_df = hn_zone_uprn_df.select(
-            ["UPRN", "LAD23NM", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", "ZoneID"]
-        ).rename({"ZoneID": "HNZoneID"})
+            [
+                "UPRN",
+                "LAD23NM",
+                "X_COORDINATE",
+                "Y_COORDINATE",
+                "in_hn_zone",  # "ZoneID"
+            ]
+        )  # .rename({"ZoneID": "HNZoneID"})
 
         """ City centre areas """
 
@@ -92,9 +107,7 @@ if __name__ == "__main__":
         )
 
         # Label UPRNs in city centres
-        print(
-            "Identifying residential UPRNs in city centre areas for Plymouth Local Authority..."
-        )
+        print(f"Identifying residential UPRNs in city centre areas for {las}...")
         hn_zone_uprn_gdf = uprns.generate_gdf_uprn_coords(hn_zone_uprn_df)
         hn_zone_city_centre_uprn_df = city_centres.label_gdf_city_centre_spatial_signatures_uprns(
             uprn_gdf=hn_zone_uprn_gdf,  # add city centre labels to gdf with hnz labels
@@ -108,22 +121,12 @@ if __name__ == "__main__":
                 "LAD23NM",
                 "X_COORDINATE",
                 "Y_COORDINATE",
-                "HNZoneID",
+                # "HNZoneID",
                 "in_hn_zone",
                 "spatial_signature_types",
                 "in_city_centre",
             ]
         )
-
-    elif args.local_authorities.lower() in ["plymouth_similar", "sampling_areas"]:
-        # Placeholder for future implementation (subject to heat network zone data availability)
-        raise NotImplementedError(
-            f"Processing for {args.local_authorities} is not yet supported."
-        )
-
-    else:  # all GB
-        # Placeholder for future implementation
-        raise NotImplementedError("Processing for all of GB is not yet supported.")
 
     # Save residential UPRNs with existing heat network zone and city centre labels to S3
     save_utils.save_to_s3(

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -51,7 +51,6 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--save",
         help="If --save is set, it saves outputs to S3.",
-        type=bool,
         required=False,
         action="store_true",
     )

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -17,7 +17,7 @@ Defaults to `GB` (all of Great Britain), but this is not yet implemented.
 
 Temporary (before we scale): Set up a new local authority or group of local authorities by adding an entry to the `constant` section of the config.yaml file.
 
-Set --save_outputs flag to True to save the outputs to S3. By default, outputs are not saved.
+Set --save to save the outputs to S3. By default, outputs are not saved.
 """
 
 import argparse
@@ -49,11 +49,11 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--save_outputs",
-        help="If set to `True`, it saves the outputs. Otherwise, outputs are not saved. Defaults to `False`, i.e. not saving outputs.",
+        "--save",
+        help="If --save is set, it saves outputs to S3.",
         type=bool,
         required=False,
-        default=False,
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         )
 
     # Save residential UPRNs with existing heat network zone and city centre labels to S3
-    if args.save_outputs:
+    if args.save:
         save_utils.save_to_s3(
             hn_zone_city_centre_uprn_df,
             f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones_city_centres.parquet",

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -50,8 +50,9 @@ def label_gdf_heat_network_zone_uprns(
         predicate="intersects",  # include properties intersecting heat network zone boundary
     ).drop(columns="index_right")
 
+    id_col = [col for col in labelled_uprn_gdf.columns if "ID" in col][0]
     # Add heat network zone boolean label
-    labelled_uprn_gdf["in_hn_zone"] = labelled_uprn_gdf["geometry"].notna()
+    labelled_uprn_gdf["in_hn_zone"] = labelled_uprn_gdf[id_col].notna()
 
     # Return as polars df without geometry
     labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry"))

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -51,7 +51,7 @@ def label_gdf_heat_network_zone_uprns(
     ).drop(columns="index_right")
 
     # Add heat network zone boolean label
-    labelled_uprn_gdf["in_hn_zone"] = labelled_uprn_gdf["ZoneID"].notna()
+    labelled_uprn_gdf["in_hn_zone"] = labelled_uprn_gdf["geometry"].notna()
 
     # Return as polars df without geometry
     labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry"))

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -51,6 +51,8 @@ def label_gdf_heat_network_zone_uprns(
     ).drop(columns="index_right")
 
     id_col = [col for col in labelled_uprn_gdf.columns if "ID" in col][0]
+    print(f"Using Heat Network Zone {id_col} column as ID")
+
     # Add heat network zone boolean label
     labelled_uprn_gdf["in_hn_zone"] = labelled_uprn_gdf[id_col].notna()
 

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -19,7 +19,7 @@ Defaults to `GB` (all of Great Britain), but this is not yet implemented.
 
 Temporary (before we scale): Set up a new local authority or group of local authorities by adding an entry to the `constant` section of the config.yaml file.
 
-Set --save_outputs flag to True to save the outputs to S3. By default, outputs are not saved.
+Set --save to save the outputs to S3. By default, outputs are not saved.
 """
 
 import geopandas as gpd
@@ -194,11 +194,11 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--save_outputs",
-        help="If set to `True`, it saves the outputs. Otherwise, outputs are not saved. Defaults to `False`, i.e. not saving outputs.",
+        "--save",
+        help="If --save is set, it saves outputs to S3.",
         type=bool,
         required=False,
-        default=False,
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -283,7 +283,7 @@ if __name__ == "__main__":
         ]
     )
 
-    if args.save_outputs:
+    if args.save:
         save_utils.save_to_s3(
             df,
             f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns.parquet",

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -19,7 +19,7 @@ Defaults to `GB` (all of Great Britain), but this is not yet implemented.
 
 Temporary (before we scale): Set up a new local authority or group of local authorities by adding an entry to the `constant` section of the config.yaml file.
 
-Set --test_mode flag to run in test mode without saving outputs.
+Set --save_outputs flag to True to save the outputs to S3. By default, outputs are not saved.
 """
 
 import geopandas as gpd
@@ -157,16 +157,18 @@ def parse_arguments() -> argparse.Namespace:
 
     parser.add_argument(
         "--local_authorities",
-        help="Run script for specific local authority or group of local authorities. Defaults to GB (all of Great Britain).",
+        help="Local authority or authorities. See base.yaml's `constant` section for options e.g. `plymouth`, `plymouth_similar_cities`, `sampling_areas`, `greater_manchester_las`.",
         type=str,
         default="GB",
         required=False,
     )
 
     parser.add_argument(
-        "--test_mode",
-        help="If set, runs in test mode without saving outputs.",
-        action="store_true",
+        "--save_outputs",
+        help="If set to `True`, it saves the outputs. Otherwise, outputs are not saved. Defaults to `False`, i.e. not saving outputs.",
+        type=bool,
+        required=False,
+        default=False,
     )
 
     return parser.parse_args()
@@ -251,7 +253,7 @@ if __name__ == "__main__":
         ]
     )
 
-    if not args.test_mode:
+    if args.save_outputs:
         save_utils.save_to_s3(
             df,
             f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns.parquet",

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -196,7 +196,6 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--save",
         help="If --save is set, it saves outputs to S3.",
-        type=bool,
         required=False,
         action="store_true",
     )

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -179,52 +179,22 @@ if __name__ == "__main__":
     uprns_df = load_geodata.load_df_osopen_uprn()
     uprns_gdf = generate_gdf_uprn_coords(uprns_df)
 
-    # TODO I expect this to be simplified at some point but the if/else block allows us to sample from certain areas for now
-    if args.local_authorities.lower() == "plymouth":
-        print("Creating residential UPRN dataset for Plymouth Local Authority...")
-        grid_squares = config["constant"]["grid_squares"]["plymouth"]
-        la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(
-            select_las="Plymouth"
-        )
-        uprns_gdf = uprns_gdf.sjoin(
-            la_boundaries_gdf[["LAD23CD", "LAD23NM", "geometry"]],
-            how="inner",
-            predicate="intersects",
-        ).drop(columns="index_right")
-
-    elif args.local_authorities.lower() == "plymouth_similar":
-        print(
-            "Creating residential UPRN dataset for Plymouth, Portsmouth, Southampton, Swansea, and Liverpool Local Authorities..."
-        )
-        grid_squares = config["constant"]["grid_squares"]["plymouth_similar_cities"]
-        la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(
-            select_las=config["constant"]["plymouth_similar_cities"]
-        )
-        uprns_gdf = uprns_gdf.sjoin(
-            la_boundaries_gdf[["LAD23CD", "LAD23NM", "geometry"]],
-            how="inner",
-            predicate="intersects",
-        ).drop(columns="index_right")
-
-    elif args.local_authorities.lower() == "sampling_areas":
-        print(
-            "Creating residential UPRN dataset for Bath, Bradford, Glasgow, Manchester, Nottingham, and Plymouth Local Authorities..."
-        )
-        grid_squares = config["constant"]["grid_squares"]["sampling_areas"]
-        la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(
-            select_las=config["constant"]["sampling_areas"]
-        )
-        uprns_gdf = uprns_gdf.sjoin(
-            la_boundaries_gdf[["LAD23CD", "LAD23NM", "geometry"]],
-            how="inner",
-            predicate="intersects",
-        ).drop(columns="index_right")
-
-    else:  # All of GB
+    if args.local_authorities.lower() == "gb":  # All of GB
         # TODO this may not work due to scaling and may require chunking of datasets.
         # TODO Adding here as placeholder to assist scaling later
         print("Creating residential UPRN dataset for all of GB...")
         grid_squares = None
+    else:  # Specific local authorities (any number of LAs can be specified in config file)
+        print(f"Creating residential UPRN dataset for {args.local_authorities}...")
+        grid_squares = config["constant"][args.local_authorities]["grid_squares"]
+        la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(
+            select_las=config["constant"][args.local_authorities]["la_names"]
+        )
+        uprns_gdf = uprns_gdf.sjoin(
+            la_boundaries_gdf[["LAD23CD", "LAD23NM", "geometry"]],
+            how="inner",
+            predicate="intersects",
+        ).drop(columns="index_right")
 
     poi_gdf = load_tree_input.load_gdf_poi()
     poi_gdf = poi.transform_gdf_poi(

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -9,11 +9,17 @@ residential:
 To run the script:
 python asf_heat_pump_suitability/pipeline/transform/uprns.py
 
-Set the optional `local_authorities` parameter to `plymouth`, `plymouth_similar`, or `sampling_areas`.
-Set to `plymouth` to run for Plymouth Local Authority; `plymouth_similar` to run for Plymouth plus four other similar
-Local Authorities (Liverpool, Portsmouth, Southampton, Swansea); 'sampling_areas' to run for Plymouth plus five other
-Local Authorities for sampling buildings (Bath, Bradford, Glasgow, Manchester, Nottingham); or do not use to run for all
-of Great Britain.
+Set the `local_authorities` parameter to:
+- `plymouth` for Plymouth only
+- `plymouth_similar` for Plymouth and 4 similar local authorities (Liverpool, Portsmouth, Southampton, Swansea)
+- `sampling_areas` for Plymouth and 5 different local authorities for sampling buildings (Bath, Bradford, Glasgow, Manchester, Nottingham)
+- `greater_manchester_las` for all Greater Manchester local authorities (Bolton, Bury, Manchester, Oldham, Rochdale, Salford, Stockport, Tameside, Trafford, Wigan)
+
+Defaults to `GB` (all of Great Britain), but this is not yet implemented.
+
+Temporary (before we scale): Set up a new local authority or group of local authorities by adding an entry to the `constant` section of the config.yaml file.
+
+Set --test_mode flag to run in test mode without saving outputs.
 """
 
 import geopandas as gpd
@@ -151,10 +157,16 @@ def parse_arguments() -> argparse.Namespace:
 
     parser.add_argument(
         "--local_authorities",
-        help="Run script for either all of Great Britain; Plymouth only {plymouth}; or Plymouth and 4 similar local authorities {plymouth_similar}; or Plymouth and 5 different local authorities {sampling_areas}. Default to all of GB",
+        help="Run script for specific local authority or group of local authorities. Defaults to GB (all of Great Britain).",
         type=str,
         default="GB",
         required=False,
+    )
+
+    parser.add_argument(
+        "--test_mode",
+        help="If set, runs in test mode without saving outputs.",
+        action="store_true",
     )
 
     return parser.parse_args()
@@ -238,7 +250,9 @@ if __name__ == "__main__":
             ]
         ]
     )
-    save_utils.save_to_s3(
-        df,
-        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns.parquet",
-    )
+
+    if not args.test_mode:
+        save_utils.save_to_s3(
+            df,
+            f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns.parquet",
+        )

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -1,3 +1,4 @@
+# %%
 # %% [markdown]
 # # Visualising the results of the decision tree for Greater Manchester
 #
@@ -966,5 +967,31 @@ gm_building_most_suitable_tech.to_parquet(
 # This is how data can be loaded, for future reference
 # import geopandas as gpd
 # f = gpd.read_parquet("s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_building_most_suitable_tech.parquet")
+
+# %%
+gm_building_most_suitable_tech
+
+# %%
+for lad in gm_building_most_suitable_tech["LAD23NM"].unique():
+    lad_gdf = gm_building_most_suitable_tech[
+        gm_building_most_suitable_tech["LAD23NM"] == lad
+    ]
+    lad_gdf.to_file(
+        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{lad.lower()}_building_most_suitable_tech.geojson",
+        driver="GeoJSON",
+    )
+
+# %%
+# Names of geojson files saved in the S3 bucket
+import boto3
+
+s3 = boto3.resource("s3")
+bucket = s3.Bucket("asf-heat-pump-suitability")
+
+objects = [obj for obj in bucket.objects.filter(Prefix="local_heat_planning/outputs/")]
+object_keys = [obj.key for obj in objects if obj.key.endswith(".geojson")]
+
+# %%
+
 
 # %%

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -420,17 +420,17 @@ gm_gdf["in_hn_zone"].value_counts(dropna=False)
 
 
 # %%
-def define_decision_tree(
+def identify_dict_most_suitable_tech(
     in_block_of_flats: bool, outdoor_space: float, city_centre_or_hnz: bool
 ) -> dict:
     """
     Defines the decision tree to identify:
-    - first and second most suitable low carbon heating solutions for each property.
+    - first and second most suitable low carbon heating solutions for each UPRN.
     - the path taken in the decision tree.
 
     Args:
         in_block_of_flats (bool): Whether the property is in a block of flats.
-        outdoor_space (float): Size of the maximum contiguous outdoor space in square meters.
+        outdoor_space (float): Outdoor space in square meters.
         city_centre_or_hnz (bool): Whether the property is in the city centre or in a planned heat network zone.
 
     Returns:
@@ -442,13 +442,13 @@ def define_decision_tree(
             return {
                 1: "District heat network",
                 2: "Communal solutions",
-                "path": "1. blocks of flats and city centre",
+                "path": "1. blocks of flats and HNZ/ city centre",
             }
         else:
             return {
                 1: "Communal solutions",
                 2: "Networked GSHP",
-                "path": "2. blocks of flats, not city centre",
+                "path": "2. blocks of flats, not  HNZ/ city centre",
             }
     else:
         if city_centre_or_hnz:
@@ -456,13 +456,13 @@ def define_decision_tree(
                 return {
                     1: "Individual solution or District heat network",
                     2: "Individual solution or District heat network",
-                    "path": "Unknown garden size in city centre",
+                    "path": "Unknown outdoor space in city centre",
                 }
             elif outdoor_space > 70:
                 return {
                     1: "Individual solution",
                     2: "District heat network",
-                    "path": "3. not blocks of flats, city centre, big garden (70m2)",
+                    "path": "3. not blocks of flats, city centre, large outdoor space (70m2)",
                 }
             else:
                 return {
@@ -475,19 +475,19 @@ def define_decision_tree(
                 return {
                     1: "Individual solution or Networked GSHP",
                     2: "Networked GSHP or Communal solutions",
-                    "path": "Unknown garden size not in city centre",
+                    "path": "Unknown outdoor space not in city centre",
                 }
             elif outdoor_space > 30:
                 return {
                     1: "Individual solution",
                     2: "Networked GSHP",
-                    "path": "5. not blocks of flats, not city centre, big garden (30m2)",
+                    "path": "5. not blocks of flats, not city centre, large outdoor space (30m2)",
                 }
             else:
                 return {
                     1: "Networked GSHP",
                     2: "Communal solutions",
-                    "path": "6. not blocks of flats, not city centre, small/no garden",
+                    "path": "6. not blocks of flats, not city centre, small/no outdoor space",
                 }
 
 
@@ -495,7 +495,7 @@ def define_decision_tree(
 gm_gdf["in_city_centre_or_hn_zone"] = gm_gdf["in_city_centre"] | gm_gdf["in_hn_zone"]
 
 gm_gdf["most_suitable_solutions"] = gm_gdf.apply(
-    lambda x: define_decision_tree(
+    lambda x: identify_dict_most_suitable_tech(
         x["in_block_of_flats"],
         x["max_contiguous_outdoor_space_area_m2"],
         x["in_city_centre_or_hn_zone"],

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -135,7 +135,7 @@ gm_la_boundaries_gdf
 # %% [markdown]
 # ### 1.6. Planned HN zones geometries
 #
-# This dataset contains the geometries of all planned heat network zones in Greater Manchester as per DESNZ data.
+# This dataset contains the geometries of all planned heat network zones in Greater Manchester as per DESNZ data. Data is likely outdated.
 
 # %%
 gm_hn_zones_gdf = load_gdf_heat_network_zones(local_authority="greater_manchester_las")

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -1,0 +1,970 @@
+# %% [markdown]
+# # Visualising the results of the decision tree for Greater Manchester
+#
+# In this notebook we:
+# - Code the decision tree that outputs the most suitable tech for each property given the following inputs: wether it is in a city centre or planned HN zone, garden size and whether the property is in a block of flats or not.
+# - Map the outputs of the decision tree for all domestic buildings in Greater Manchester
+
+# %%
+# package imports
+import numpy as np
+import pandas as pd
+import polars as pl
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import folium
+
+# %%
+# local imports
+from asf_heat_pump_suitability.pipeline.transform.uprns import generate_gdf_uprn_coords
+from asf_heat_pump_suitability.getters.load_tree_input import (
+    load_gdf_os_openmap_local_layer,
+)
+from asf_heat_pump_suitability.getters.load_geodata import (
+    load_gdf_heat_network_zones,
+)
+from asf_heat_pump_suitability.getters import (
+    load_boundaries,
+)
+
+# %%
+colours = {
+    "Individual solution": "#18A48C",
+    "Networked GSHP": "#0000FF",
+    "Communal solutions": "#FF6E47",
+    "District heat network": "#EA2541",
+}
+
+# %% [markdown]
+# ## 1. Loading data
+
+# %% [markdown]
+# ### 1.1. Greater Manchester residential UPRNs data
+#
+# Greater Manchester residential UPRNs data contains info about:
+# - each residential UPRN in Greater Manchester
+# - X and Y coordinates of each UPRN (as well as latitude and longitude)
+
+# %%
+# Getting data and converting polars df to geodf
+gm_uprns = pl.read_parquet(
+    "s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_residential_uprns.parquet"
+)
+gm_uprns = generate_gdf_uprn_coords(df=gm_uprns)
+gm_uprns.head()
+
+# %% [markdown]
+# ### 1.2. City centres and planned HNZ
+#
+# For each domestic UPRN we hvae:
+# - X and Y coordinates of each UPRN
+# - `in_city_centre`: a flag for whether it is located in a city centre according to a set of pre-defined spatial signature types (as per the Spatial Signatures Framework)
+# - `spatial_signature_type`: the respective spatial signature type for each UPRN
+# - `in_hn_zone`: a flag for whether it is located in a planned DESNZ heat network zone
+#
+
+# %%
+# Getting data and converting polars df to geodf
+hnz_city_centre_data = pl.read_parquet(
+    "s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_residential_uprns_with_hn_zones_city_centres.parquet"
+)
+hnz_city_centre_data = generate_gdf_uprn_coords(df=hnz_city_centre_data)
+hnz_city_centre_data.head()
+
+# %%
+hnz_city_centre_data
+
+# %% [markdown]
+# ### 1.3. Greater Manchester features dataset
+#
+# Greater Manchester features dataset will eventually contain all the features we need to run the decision tree for each domestic UPRN in Greater Manchester including garden size, blocks of flats flag, city centre flag and planned HNZ flag. For now, it only contains:
+# - each residential UPRN in Greater Manchester
+# - X and Y coordinates of each UPRN
+# - wether property is a flat
+# - NATIONALCADASTRALREFERENCE which identifies the specific building where the property is located
+# - max contiguous and total outdoor space in m2
+
+# %%
+# Getting data and converting polars df to geodf
+gm_with_features = pl.read_parquet(
+    "s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_residential_uprns_with_features.parquet"
+)
+gm_with_features = generate_gdf_uprn_coords(df=gm_with_features)
+gm_with_features.head()
+
+# %% [markdown]
+# ### 1.4. Building footprints
+#
+# Building footprints dataset contains the geometries of all buildings in grid squares including residential and non-residential buildings. This includes an area bigger than Greater Manchester boundary, so it needs to be filtered to the Greater Manchester boundary.
+#
+# It includes building footprint IDs and geometries of all buildings in grid squares To note that one building footprint ID sometimes contains multiple buildings.
+#
+# These are updated regularly by Ordnance Survey and with each update the building footprint IDs might change.
+
+# %%
+from asf_heat_pump_suitability import config
+
+# Loading building footprints for grid squares
+building_footprints = load_gdf_os_openmap_local_layer(
+    layer="building",
+    grid_squares=config["constant"]["greater_manchester_las"]["grid_squares"],
+)
+building_footprints.head()
+
+# %% [markdown]
+# ### 1.5. Greater Manchester boundaries
+
+# %%
+# Loading the Greater Manchester LAs boundaries
+gm_la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(
+    select_las=config["constant"]["greater_manchester_las"]["la_names"]
+)
+
+# %%
+gm_la_boundaries_gdf
+
+# %% [markdown]
+# ### 1.6. Planned HN zones geometries
+#
+# This dataset contains the geometries of all planned heat network zones in Greater Manchester as per DESNZ data.
+
+# %%
+gm_hn_zones_gdf = load_gdf_heat_network_zones(local_authority="greater_manchester_las")
+
+# %%
+gm_hn_zones_gdf.crs
+
+# %%
+gm_hn_zones_gdf.head()
+
+# %% [markdown]
+# ## 2. Processing data
+#
+# Most of the processing steps below are temporary as there will be pipelines that will put all of this data together into one Greater Manchester features dataset.
+
+# %% [markdown]
+# ### 2.1. [temporary] Joining all dfs into one geodf
+
+# %%
+gm_uprns.set_index("UPRN", inplace=True)
+gm_with_features.set_index("UPRN", inplace=True)
+hnz_city_centre_data.set_index("UPRN", inplace=True)
+
+# %%
+gm_uprns.head()
+
+# %%
+# checking if lengths are the same
+len(gm_uprns), len(gm_with_features), len(hnz_city_centre_data)
+
+# %%
+# Joining all geodfs into one based on UPRN
+gm_gdf = gm_uprns.join(hnz_city_centre_data[["in_city_centre", "in_hn_zone"]])
+gm_gdf = gm_gdf.join(
+    gm_with_features.drop(columns=["X_COORDINATE", "Y_COORDINATE", "geometry"])
+)
+
+# %%
+gm_gdf.reset_index(inplace=True)
+
+# %%
+gm_gdf.head()
+
+# %% [markdown]
+# ### 2.2. Spatial join to add building footprints to main geodf
+#
+# Adding geometries of building footprints in Greater Manchester to the main geodf.
+
+# %%
+# we create a copy of the (building) geometry column so that we can keep it after the spatial join
+gm_gdf["property_geometry"] = gm_gdf.geometry
+building_footprints["building_geometry"] = building_footprints["geometry"]
+gm_gdf = gm_gdf.sjoin(
+    building_footprints[["geometry", "building_geometry"]],
+    how="left",
+    predicate="within",
+).drop(columns=["index_right"])
+
+# %% [markdown]
+# ### 2.3. Spatial join with DESNZ HN zones geometries data
+#
+# For each property in a planned HN zone, we add the HN zone geometry.
+
+# %%
+# Adding a column to indicate if the property is within a DESNZ heat network zone
+gm_hn_zones_gdf["desnz_hn_zone"] = True
+
+# Creating a copy of the geometry column to keep after the spatial join
+gm_hn_zones_gdf["desnz_hn_zone_geometry"] = gm_hn_zones_gdf["geometry"]
+
+# %%
+gm_gdf = gm_gdf.sjoin(
+    gm_hn_zones_gdf[["geometry", "desnz_hn_zone_geometry"]],
+    how="left",
+    predicate="within",
+)
+
+# %% [markdown]
+# ### 2.4. Load blocks of flats model, create features and create blocks of flats flag
+
+# %%
+# Loading blocks of flats model
+import pickle
+import boto3
+
+s3client = boto3.client(
+    "s3",
+)
+s3_bucket = "asf-heat-pump-suitability"
+response = s3client.get_object(
+    Bucket=s3_bucket, Key="local_heat_planning/outputs/blocks_of_flats_model.pkl"
+)
+
+body = response["Body"].read()
+block_of_flats_model = pickle.loads(body)
+
+
+# %%
+# Create features
+
+# %%
+
+# Create features from building data
+from asf_heat_pump_suitability.pipeline.transform import uprns
+
+# pandas to polars
+df = pl.from_pandas(
+    gm_gdf.drop(
+        columns=[
+            "geometry",
+            "property_geometry",
+            "building_geometry",
+            "desnz_hn_zone_geometry",
+            "index_right",
+        ]
+    )
+)
+
+buildings_w_uprns_gdf = building_footprints.sjoin(
+    uprns.generate_gdf_uprn_coords(df=df),
+    how="left",
+    predicate="contains",
+).drop(columns=["index_right"])
+
+buildings_w_uprns_gdf = buildings_w_uprns_gdf[~buildings_w_uprns_gdf["UPRN"].isna()]
+buildings_w_uprns_gdf["building_area_m2"] = buildings_w_uprns_gdf.area
+buildings_w_uprns_gdf["building_perimeter_m"] = buildings_w_uprns_gdf.length
+buildings_w_uprns_df = pl.from_pandas(
+    buildings_w_uprns_gdf.drop(columns=["geometry", "building_geometry"])
+)
+
+agg_building_df = (
+    buildings_w_uprns_df.group_by("ID")
+    .agg(
+        pl.col("UPRN").count().alias("n_UPRNs"),
+        pl.col("property_type_flat").sum().alias("n_flats"),
+        pl.col("building_area_m2").first().name.keep(),
+        pl.col("building_perimeter_m").first().name.keep(),
+    )
+    .filter(pl.col("n_flats") > 0)
+    .with_columns(
+        (pl.col("n_flats") / pl.col("n_UPRNs")).alias("proportion_flats"),
+        (pl.col("n_UPRNs") / pl.col("building_area_m2")).alias("UPRNs_per_building_m2"),
+    )
+)
+
+
+# %%
+
+uprns_gdf = (
+    uprns.generate_gdf_uprn_coords(df=df)
+    .sjoin(building_footprints, how="inner", predicate="within")
+    .drop(columns=["index_right"])
+)
+
+
+# Create concave hull feature to represent spatial distribution of UPRNs in each building
+hull_gdf = uprns_gdf.dissolve("ID").concave_hull().reset_index()
+
+
+hull_gdf = hull_gdf.rename(columns={0: "geometry"}).set_geometry("geometry")
+hull_gdf["concave_hull_area_m2"] = hull_gdf.area
+
+# Join building features with concave hull feature
+agg_building_df = agg_building_df.join(
+    pl.from_pandas(hull_gdf.drop(columns="geometry")),
+    how="left",
+    on="ID",
+)
+
+# Calculate additional features from the concave hull area
+agg_building_df = agg_building_df.with_columns(
+    (pl.col("n_UPRNs") / pl.col("concave_hull_area_m2")).alias(
+        "uprns_per_hull_area_m2"
+    ),
+    (pl.col("n_flats") / pl.col("concave_hull_area_m2")).alias(
+        "flats_per_hull_area_m2"
+    ),
+).with_columns(
+    # UPRNs or flats per hull area can be infinite if all UPRNs/flats share the same coordinates (i.e. area = 0m2)
+    # We change this to -1 for the model
+    pl.when(pl.col("uprns_per_hull_area_m2").is_infinite())
+    .then(-1)
+    .otherwise(pl.col("uprns_per_hull_area_m2"))
+    .alias("uprns_per_hull_area_m2"),
+    pl.when(pl.col("flats_per_hull_area_m2").is_infinite())
+    .then(-1)
+    .otherwise(pl.col("flats_per_hull_area_m2"))
+    .alias("flats_per_hull_area_m2"),
+)
+
+# Get count of UPRNs at each X and Y coordinates to get the count of UPRNs which share an exact location
+uprns_df = pl.from_pandas(uprns_gdf.drop(columns=["geometry", "building_geometry"]))
+
+# Get count of UPRNs at each X and Y coordinates to get the count of UPRNs which share an exact location
+uprns_gdf = uprns_df.with_columns(
+    n_stacked_uprns=pl.col("UPRN").count().over(["X_COORDINATE", "Y_COORDINATE"])
+)
+
+
+# Group by building and get the average and STD of UPRNs sharing the same coordinates
+agg_uprns_df = uprns_gdf.group_by("ID").agg(
+    pl.col("n_stacked_uprns").mean().alias("avg_n_stacked_uprns"),
+    pl.col("n_stacked_uprns").std().alias("std_n_stacked_uprns"),
+)
+
+# Join all the calculated features together
+features_df = agg_building_df.join(
+    agg_uprns_df.select(["ID", "avg_n_stacked_uprns", "std_n_stacked_uprns"]),
+    how="left",
+    on="ID",
+)
+
+
+# %%
+features = [
+    "n_UPRNs",
+    "n_flats",
+    "building_area_m2",
+    "building_perimeter_m",
+    "proportion_flats",
+    "UPRNs_per_building_m2",
+    "concave_hull_area_m2",
+    "uprns_per_hull_area_m2",
+    "flats_per_hull_area_m2",
+    "avg_n_stacked_uprns",
+    "std_n_stacked_uprns",
+]
+
+# %%
+# apply model to create blocks of flats flag
+features_df = features_df.to_pandas()
+features_df["block_of_flats"] = block_of_flats_model.predict(features_df[features])
+
+# %%
+building_predictions_df = features_df[["ID", "block_of_flats"]]
+building_predictions_df = pl.from_pandas(building_predictions_df)
+
+# %%
+uprn_predictions = (
+    uprns_df.drop_nulls(subset="ID")
+    .select(["UPRN", "ID"])
+    .join(
+        building_predictions_df.select(
+            [
+                "ID",
+                "block_of_flats",
+            ]
+        ),
+        how="left",
+        on="ID",
+    )
+)
+
+# %%
+# uprn_predictions = uprn_predictions.with_columns(
+#     pl.col("block_of_flats").fill_null(False)
+# )
+
+uprn_predictions = uprn_predictions.to_pandas()
+
+# %%
+# Join blocks of flats model data to gm_gdf
+gm_gdf = gm_gdf.join(
+    uprn_predictions.rename(columns={"block_of_flats": "in_block_of_flats"})[
+        ["in_block_of_flats"]
+    ],
+    how="left",
+)
+
+# %%
+gm_gdf["in_block_of_flats"] = gm_gdf["in_block_of_flats"].fillna(False)
+
+# %%
+gm_gdf["in_city_centre"].value_counts(dropna=False)
+
+# %%
+gm_gdf["in_hn_zone"].value_counts(dropna=False)
+
+# %% [markdown]
+# ## 3. Defining decision tree and identifying 1st and 2nd most suitable solutions
+#
+# 2nd most suitable solution is the closest solution in the decision tree.
+
+
+# %%
+def define_decision_tree(
+    in_block_of_flats: bool, garden_size: float, city_centre_or_hnz: bool
+) -> dict:
+    """
+    Defines the decision tree to identify:
+    - first and second most suitable low carbon heating solutions for each property.
+    - the path taken in the decision tree.
+
+    Args:
+        in_block_of_flats (bool): Whether the property is in a block of flats.
+        garden_size (float): Size of the garden in square meters.
+        city_centre_or_hnz (bool): Whether the property is in the city centre or in a planned heat network zone.
+
+    Returns:
+        dict: A dictionary with the first and second most suitable heating solutions and the path taken in the decision tree.
+    """
+
+    if in_block_of_flats:
+        if city_centre_or_hnz:
+            return {
+                1: "District heat network",
+                2: "Communal solutions",
+                "path": "1. blocks of flats and city centre",
+            }
+        else:
+            return {
+                1: "Communal solutions",
+                2: "Networked GSHP",
+                "path": "2. blocks of flats, not city centre",
+            }
+    else:
+        if city_centre_or_hnz:
+            if garden_size > 70:
+                return {
+                    1: "Individual solution",
+                    2: "District heat network",
+                    "path": "3. not blocks of flats, city centre, big garden (70m2)",
+                }
+            else:
+                return {
+                    1: "District heat network",
+                    2: "Networked GSHP",
+                    "path": "4. not blocks of flats, city centre, small or no garden",
+                }
+        else:
+            if garden_size > 30:
+                return {
+                    1: "Individual solution",
+                    2: "Networked GSHP",
+                    "path": "5. not blocks of flats, not city centre, big garden (30m2)",
+                }
+            else:
+                return {
+                    1: "Networked GSHP",
+                    2: "Communal solutions",
+                    "path": "6. not blocks of flats, not city centre, small/no garden",
+                }
+
+
+# %%
+gm_gdf["in_city_centre_or_hn_zone"] = gm_gdf["in_city_centre"] | gm_gdf["in_hn_zone"]
+
+gm_gdf["most_suitable_solutions"] = gm_gdf.apply(
+    lambda x: define_decision_tree(
+        x["in_block_of_flats"],
+        x["max_contiguous_outdoor_space_area_m2"],
+        x["in_city_centre_or_hn_zone"],
+    ),
+    axis=1,
+)
+
+# %%
+gm_gdf["1st_most_suitable_solution"] = gm_gdf["most_suitable_solutions"].apply(
+    lambda x: x[1]
+)
+gm_gdf["2nd_most_suitable_solution"] = gm_gdf["most_suitable_solutions"].apply(
+    lambda x: x[2]
+)
+gm_gdf["decision_tree_path"] = gm_gdf["most_suitable_solutions"].apply(
+    lambda x: x["path"]
+)
+
+# %%
+gm_gdf["decision_tree_path"].value_counts(normalize=True)
+
+# %%
+gm_gdf["1st_most_suitable_solution"].value_counts(normalize=True)
+
+# %%
+gm_gdf["1st_most_suitable_solution"].value_counts(dropna=False)
+
+# %% [markdown]
+# ## 4. Number of solutions per land parcel and building footprint
+#
+# In this section we check wether there are multiple solutions for properties located in the same land parcel and building footprint. Ideally, all properties in the same land parcel & footprint should have the same solution.
+#
+# As we can observe below, most land parcels and building footprints have one solution for all properties, but there are some buildings with multiple solutions.
+
+# %%
+# Distribution of unique 1st most suitable solutions per land parcel (in counts)
+gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[["1st_most_suitable_solution"]].nunique()[
+    "1st_most_suitable_solution"
+].value_counts()
+
+# %%
+# Distribution of unique 1st most suitable solutions per land parcel (in proportions)
+gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[["1st_most_suitable_solution"]].nunique()[
+    "1st_most_suitable_solution"
+].value_counts(normalize=True)
+
+# %%
+# Number of unique land parcels in Greater Manchester vs. number of buildings
+# This shows that lots of land parcels are aggregated into one single building geometry/ footprint
+gm_gdf["NATIONALCADASTRALREFERENCE"].nunique(), gm_gdf["building_geometry"].nunique()
+
+# %%
+# Identifying pairs of different 1st most suitable solutions per land parcel
+solutions_per_land_parcel = gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[
+    "1st_most_suitable_solution"
+].apply(set)
+solutions_per_land_parcel = pd.DataFrame(solutions_per_land_parcel)
+solutions_per_land_parcel["n_solutions"] = solutions_per_land_parcel[
+    "1st_most_suitable_solution"
+].apply(len)
+solutions_per_land_parcel = solutions_per_land_parcel[
+    solutions_per_land_parcel["n_solutions"] > 1
+]
+solutions_per_land_parcel.reset_index(inplace=True)
+solutions_per_land_parcel["1st_most_suitable_solution_str"] = solutions_per_land_parcel[
+    "1st_most_suitable_solution"
+].apply(lambda x: ", ".join(x))
+solutions_per_land_parcel.groupby("1st_most_suitable_solution_str")[
+    ["NATIONALCADASTRALREFERENCE"]
+].nunique()
+
+
+# %%
+# Identifying pairs of different 1st most suitable solutions per building footprint
+solutions_per_footprint = gm_gdf.groupby("building_geometry")[
+    "1st_most_suitable_solution"
+].apply(set)
+solutions_per_footprint = pd.DataFrame(solutions_per_footprint)
+solutions_per_footprint["n_solutions"] = solutions_per_footprint[
+    "1st_most_suitable_solution"
+].apply(len)
+solutions_per_footprint = solutions_per_footprint[
+    solutions_per_footprint["n_solutions"] > 1
+]
+solutions_per_footprint.reset_index(inplace=True)
+solutions_per_footprint["1st_most_suitable_solution_str"] = solutions_per_footprint[
+    "1st_most_suitable_solution"
+].apply(lambda x: ", ".join(x))
+solutions_per_footprint.groupby("1st_most_suitable_solution_str")[
+    ["building_geometry"]
+].nunique()
+
+
+# %%
+# check if each land parcel appears only within one building footprint
+land_parcel_to_footprint = gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[
+    "building_geometry"
+].apply(set)
+land_parcel_to_footprint = pd.DataFrame(land_parcel_to_footprint)
+land_parcel_to_footprint["n_footprints"] = land_parcel_to_footprint[
+    "building_geometry"
+].apply(len)
+
+# %%
+# It doesn't seem to be the case
+land_parcel_to_footprint["n_footprints"].value_counts()
+
+# %%
+land_parcel_to_footprint["n_footprints"].value_counts(normalize=True) * 100
+
+# %% [markdown]
+# In most cases:
+# - the same land parcel should be in one building footprint only (hopefully?)
+# - properties in the same land parcel should have the same most suitable solution
+# - properties in the same building footprint should have the same most suitable solution
+
+# %%
+# This is currently based on Greater Manchester only (both pairs found in land parcels and building footprints)
+# but needs to be generalised to all possible cases
+
+
+def assign_unique_sol(solution_set: set) -> str:
+    """
+    Assigns a unique solution based on the combination of solutions in the set.
+
+    Args:
+        solution_set (set): A set of solutions.
+
+    Returns:
+        str: A unique solution assigned based on the combination.
+    """
+    if "District heat network" in solution_set and "Networked GSHP" in solution_set:
+        return "Communal solutions"
+    elif "District heat network" in solution_set:
+        return "District heat network"
+    elif "Networked GSHP" in solution_set:
+        return "Networked GSHP"
+    elif "Communal solutions" in solution_set:
+        return "Communal solutions"
+    else:
+        print("this shouldn't happen!")
+
+
+solutions_per_footprint["final_solution"] = solutions_per_footprint[
+    "1st_most_suitable_solution"
+].apply(lambda x: assign_unique_sol(x))
+
+# %%
+
+solutions_per_footprint["final_solution"].value_counts(dropna=False)
+
+# %%
+mapping_set_to_final_solution = solutions_per_footprint.set_index("building_geometry")[
+    "final_solution"
+].to_dict()
+
+# %%
+gm_gdf["1st_most_suitable_solution"] = gm_gdf.apply(
+    lambda x: (
+        mapping_set_to_final_solution[x["building_geometry"]]
+        if x["building_geometry"] in mapping_set_to_final_solution
+        else x["1st_most_suitable_solution"]
+    ),
+    axis=1,
+)
+
+# %%
+gm_gdf["1st_most_suitable_solution"].value_counts(dropna=False)
+
+
+# %%
+def map_blocks_of_flats_prob(
+    tech: str,
+    ward_df: gpd.GeoDataFrame,
+    specific_ward_gdf: gpd.GeoDataFrame,
+    labelled_tech: gpd.GeoDataFrame,
+    colours: dict,
+    threshold=None,
+):
+    """
+    Maps properties suitable for a specific technology where the colour indicates the confidence in the block of flats label.
+
+    Args:
+        tech (str): a low carbon heating solution in the set {"Individual solution", "Networked GSHP", "Communal solutions", "District heat network"}
+        ward_df (gpd.GeoDataFrame): ward data with most suitable solutions
+        specific_ward_gdf (gpd.GeoDataFrame): specific ward boundary data
+    """
+
+    if tech != "":
+        tech_specific_df = ward_df[ward_df["1st_most_suitable_solution"] == tech]
+    else:
+        tech_specific_df = ward_df.copy()
+    fig, ax = plt.subplots(figsize=(15, 8))
+
+    if threshold:
+        tech_specific_df = tech_specific_df[
+            tech_specific_df["block_of_flats_label_proba"] <= threshold
+        ]
+
+    print("tech:", tech)
+
+    # mapping polygons of labelled data
+    if tech != "District heat network":
+        labelled_tech_specifc_df = labelled_tech[labelled_tech["Name"] == tech]
+        labelled_tech_specifc_df.plot(
+            ax=ax,
+            column="Name",
+            categorical=True,
+            legend=True,
+            color=labelled_tech_specifc_df["Name"].map(colours),
+            edgecolor="black",
+            linestyle="--",
+            alpha=0.5,
+        )
+    else:
+        labelled_tech.plot(
+            ax=ax,
+            color=colours[tech],
+            edgecolor="black",
+            linestyle="--",
+            alpha=0.5,
+        )
+
+    greys = plt.get_cmap("Greys")
+    import matplotlib.colors as mcolors
+
+    # Create a new map using only the range from 0.2 (light gray) to 1.0 (black)
+    # 0.0 would be white, so we skip it.
+    cmap_no_white = mcolors.LinearSegmentedColormap.from_list(
+        "trunc_greys", greys(np.linspace(0.2, 1.0, 256))
+    )
+
+    # mapping individual properties where the colour indicates probability of being a block of flats
+    tech_specific_df.plot(
+        ax=ax,
+        column="block_of_flats_label_proba",
+        cmap=cmap_no_white,
+        legend=True,
+        markersize=2,
+        vmin=0.5,
+        vmax=1,
+    )
+
+    # mapping ward boundary
+    specific_ward_gdf.plot(ax=ax, facecolor="none", edgecolor="black", linewidth=1)
+
+    # title and legend
+    ax.set_title(
+        f"Confidence in the blocks of flats label\n(black = very confident; light grey = lower confidence)",
+        fontsize=12,
+    )
+
+
+# %%
+fig, ax = plt.subplots(figsize=(15, 8))
+gm_hn_zones_gdf.plot(ax=ax, facecolor="none", edgecolor="red", linewidth=1)
+gm_la_boundaries_gdf.plot(ax=ax, facecolor="none", edgecolor="black", linewidth=1)
+
+
+# %%
+def map_building_techs_in_ward(techs_gdf, col, specific_ward_gdf, colours, ward, map_):
+    """
+    Maps buildings in a specific ward with a predicted/labelled low carbon heating solutions.
+
+    Args:
+        techs_gdf (gpd.GeoDataFrame): buildings with most suitable solutions
+        col (str): column with tech solution
+        specific_ward_gdf (gpd.GeoDataFrame): specific ward boundary data
+        colours (dict): mapping of technologies to colours
+        ward (str): name of the ward
+        map_ (str): takes ["Labelled", "Predicted"]
+    """
+
+    fig, ax = plt.subplots(figsize=(15, 8))
+
+    techs_gdf.plot(
+        ax=ax,
+        column=col,
+        categorical=True,
+        legend=True,
+        color=techs_gdf[col].map(colours),
+        markersize=2,
+    )
+
+    # mapping ward boundary
+    specific_ward_gdf.plot(ax=ax, facecolor="none", edgecolor="black", linewidth=1)
+
+    # title and legend
+    ax.set_title(f"{map_} most suitable solution for {ward}", fontsize=12)
+    handles = []
+    handles = [
+        mpatches.Patch(facecolor=colours[tech], label=tech) for tech in colours.keys()
+    ]
+    ax.legend(handles=handles, loc="upper right")
+
+
+# %%
+
+
+# %% [markdown]
+# ## 5. Visualising results per building in Greater Manchester
+
+# %%
+# Estimated most suitable
+gm_building_most_suitable_tech = (
+    gm_gdf[
+        [
+            "building_geometry",
+            "1st_most_suitable_solution",
+            "LAD23NM",
+            # keeping the in_hn_zone column for pipeline changes afterwards
+            "in_hn_zone",
+        ]
+    ]
+    .drop_duplicates(
+        # we drop duplicates based on building geometry and most suitable solution, as we're assuming one solution per building
+        ["building_geometry", "1st_most_suitable_solution"]
+    )
+    .rename(columns={"building_geometry": "geometry"})
+)
+
+
+# %%
+gm_building_most_suitable_tech
+
+# %%
+# These numbers should be the same, not sure why they are not
+gm_building_most_suitable_tech["geometry"].nunique(), len(
+    gm_building_most_suitable_tech
+)
+
+# %%
+gm_building_most_suitable_tech["1st_most_suitable_solution"].value_counts(dropna=False)
+
+# %%
+gm_gdf[pd.isnull(gm_gdf["1st_most_suitable_solution"])]
+
+# %%
+map_building_techs_in_ward(
+    techs_gdf=gm_building_most_suitable_tech,
+    col="1st_most_suitable_solution",
+    specific_ward_gdf=gm_la_boundaries_gdf,
+    colours=colours,
+    ward="Greater Manchester LAs",
+    map_="Predicted",
+)
+
+# %%
+# # Save most suitable tech per building locally as kml
+# gm_building_most_suitable_tech[["geometry", "1st_most_suitable_solution"]].to_file("greater_manchester_las_building_most_suitable_tech.kml", driver="KML")
+
+# %%
+# There are 2 buildings without geometry... needs further investigation. For now we remove them!
+gm_building_most_suitable_tech[pd.isnull(gm_building_most_suitable_tech["geometry"])]
+
+# %%
+# Removing buildings with no geometry
+gm_building_most_suitable_tech = gm_building_most_suitable_tech[
+    ~pd.isnull(gm_building_most_suitable_tech["geometry"])
+]
+
+# %%
+# Adding colour column for visualisation purposes
+gm_building_most_suitable_tech["color"] = gm_building_most_suitable_tech[
+    "1st_most_suitable_solution"
+].map(colours)
+
+# %%
+for lad in gm_building_most_suitable_tech["LAD23NM"].unique():
+    print("Generating map for:", lad)
+    lad_gdf = gm_building_most_suitable_tech[
+        gm_building_most_suitable_tech["LAD23NM"] == lad
+    ]
+    # 1. Ensure the CRS is correct for Folium
+    lad_gdf = lad_gdf.to_crs(epsg=4326)
+
+    # 2. Initialize the map
+    # Centering based on the average coordinates of the polygons
+    map = folium.Map(
+        location=[
+            lad_gdf.geometry.centroid.y.mean(),
+            lad_gdf.geometry.centroid.x.mean(),
+        ],
+        zoom_start=12,
+    )
+
+    # 3. Add polygons using the color col
+    folium.GeoJson(
+        lad_gdf,
+        style_function=lambda feature: {
+            "fillColor": feature["properties"]["color"],
+            "color": feature["properties"][
+                "color"
+            ],  # Outline color (otherwise it is blue for all polygons)
+            "fillOpacity": 1,  # Opacity
+        },
+    ).add_to(map)
+
+    map.save(f"greater_manchester_lad_{lad}_most_suitable_tech_per_building.html")
+
+# %%
+# Creating a version of the map where all properties within HNZ are labelled as district heat network, even where that's not the output of our decision tree
+gdf_gm_default_hn = gm_building_most_suitable_tech.copy()
+gdf_gm_default_hn["1st_most_suitable_solution"] = gdf_gm_default_hn.apply(
+    lambda x: (
+        "District heat network" if x["in_hn_zone"] else x["1st_most_suitable_solution"]
+    ),
+    axis=1,
+)
+gdf_gm_default_hn["color"] = gdf_gm_default_hn.apply(
+    lambda x: "#EA2541" if x["in_hn_zone"] else x["color"], axis=1
+)
+
+# %%
+for lad in gdf_gm_default_hn["LAD23NM"].unique():
+    print("Generating map for:", lad)
+    lad_gdf = gdf_gm_default_hn[gdf_gm_default_hn["LAD23NM"] == lad]
+
+    # 1. Ensure the CRS is correct for Folium
+    lad_gdf = lad_gdf.to_crs(epsg=4326)
+
+    # 2. Initialize the map
+    # Centering based on the average coordinates of the polygons
+    map_gm_default_hn = folium.Map(
+        location=[
+            lad_gdf.geometry.centroid.y.mean(),
+            lad_gdf.geometry.centroid.x.mean(),
+        ],
+        zoom_start=12,
+    )
+
+    # 3. Add polygons using the color col
+    folium.GeoJson(
+        lad_gdf,
+        style_function=lambda feature: {
+            "fillColor": feature["properties"]["color"],
+            "color": feature["properties"]["color"],
+            "fillOpacity": 1,  # Opacity
+        },
+    ).add_to(map_gm_default_hn)
+
+    map_gm_default_hn.save(
+        f"greater_manchester_lad_{lad}_default_hnz_most_suitable_tech_per_building.html"
+    )
+
+# %% [markdown]
+# ## 6. Share of homes per technology
+#
+# These stats are up to date (after reassigning some solutions based on other properties in the same building footprint).
+
+# %%
+# Distribution of properties for the 1st most suitable solutions (in %)
+gm_gdf["1st_most_suitable_solution"].value_counts(normalize=True) * 100
+
+# %%
+# Distribution of properties for the 1st most suitable solutions (in counts)
+gm_gdf["1st_most_suitable_solution"].value_counts()
+
+# %%
+# Creating a version of the gdf where all properties within HNZ are labelled as district heat network, even where that's not the output of our decision tree
+gdf_gm_default_hn = gm_gdf.copy()
+gdf_gm_default_hn["1st_most_suitable_solution"] = gdf_gm_default_hn.apply(
+    lambda x: (
+        "District heat network" if x["in_hn_zone"] else x["1st_most_suitable_solution"]
+    ),
+    axis=1,
+)
+
+# %%
+# Distribution of properties for the 1st most suitable solutions (in %) - with HN zones as district heat network
+gdf_gm_default_hn["1st_most_suitable_solution"].value_counts(normalize=True) * 100
+
+# %%
+# Distribution of properties for the 1st most suitable solutions (in counts) - with HN zones as district heat network
+gdf_gm_default_hn["1st_most_suitable_solution"].value_counts()
+
+# %% [markdown]
+# ## 7. Saving data
+
+# %%
+gm_building_most_suitable_tech.to_parquet(
+    "s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_building_most_suitable_tech.parquet"
+)
+
+# %%
+# This is how data can be loaded, for future reference
+# import geopandas as gpd
+# f = gpd.read_parquet("s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_building_most_suitable_tech.parquet")
+
+# %%

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -19,6 +19,7 @@ import os
 
 # %%
 # local imports
+from asf_heat_pump_suitability import PROJECT_DIR
 from asf_heat_pump_suitability.pipeline.transform.uprns import generate_gdf_uprn_coords
 from asf_heat_pump_suitability.getters.load_tree_input import (
     load_gdf_os_openmap_local_layer,
@@ -957,7 +958,7 @@ for lad in gm_building_most_suitable_tech["LAD23NM"].unique():
 
     map.save(
         os.path.join(
-            "asf_heat_pump_suitability",
+            PROJECT_DIR,
             "outputs",
             f"greater_manchester_lad_{lad}_most_suitable_tech_per_building.html",
         )
@@ -1034,7 +1035,7 @@ for lad in gdf_gm_default_hn["LAD23NM"].unique():
 
     map_gm_default_hn.save(
         os.path.join(
-            "asf_heat_pump_suitability",
+            PROJECT_DIR,
             "outputs",
             f"greater_manchester_lad_{lad}_default_hnz_most_suitable_tech_per_building.html",
         )
@@ -1106,8 +1107,5 @@ bucket = s3.Bucket("asf-heat-pump-suitability")
 
 objects = [obj for obj in bucket.objects.filter(Prefix="local_heat_planning/outputs/")]
 object_keys = [obj.key for obj in objects if obj.key.endswith(".geojson")]
-
-# %%
-
 
 # %%

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -14,6 +14,7 @@ import polars as pl
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+import matplotlib.colors as mcolors
 import folium
 import os
 
@@ -106,7 +107,7 @@ gm_with_features.head()
 #
 # It includes building footprint IDs and geometries of all buildings in grid squares To note that one building footprint ID sometimes contains multiple buildings.
 #
-# These are updated regularly by Ordnance Survey and with each update the building footprint IDs might change.
+# These are updated regularly by Ordnance Survey and with each update the building footprint IDs change.
 
 # %%
 from asf_heat_pump_suitability import config
@@ -166,8 +167,7 @@ len(gm_uprns), len(gm_with_features), len(hnz_city_centre_data)
 
 # %%
 # Joining all geodfs into one based on UPRN
-gm_gdf = gm_uprns.join(hnz_city_centre_data[["in_city_centre", "in_hn_zone"]])
-gm_gdf = gm_gdf.join(
+gm_gdf = gm_uprns.join(hnz_city_centre_data[["in_city_centre", "in_hn_zone"]]).join(
     gm_with_features.drop(columns=["X_COORDINATE", "Y_COORDINATE", "geometry"])
 )
 
@@ -184,7 +184,7 @@ gm_gdf.head()
 
 # %%
 # we create a copy of the (building) geometry column so that we can keep it after the spatial join
-gm_gdf["property_geometry"] = gm_gdf.geometry
+gm_gdf["uprn_geometry"] = gm_gdf.geometry
 building_footprints["building_geometry"] = building_footprints["geometry"]
 gm_gdf = gm_gdf.sjoin(
     building_footprints[["geometry", "building_geometry"]],
@@ -224,7 +224,8 @@ s3client = boto3.client(
 )
 s3_bucket = "asf-heat-pump-suitability"
 response = s3client.get_object(
-    Bucket=s3_bucket, Key="local_heat_planning/outputs/blocks_of_flats_model.pkl"
+    Bucket=s3_bucket,
+    Key="local_heat_planning/outputs/block_of_flats_building_classifier.pkl",
 )
 
 body = response["Body"].read()
@@ -431,7 +432,7 @@ def define_decision_tree(
 
     Args:
         in_block_of_flats (bool): Whether the property is in a block of flats.
-        garden_size (float): Size of the garden in square meters.
+        utdoor_space (float): Size of the maximum contiguous outdoor space in square meters.
         city_centre_or_hnz (bool): Whether the property is in the city centre or in a planned heat network zone.
 
     Returns:
@@ -544,32 +545,6 @@ gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[["1st_most_suitable_solution"]].nun
 ].value_counts(normalize=True)
 
 # %%
-# Number of unique land parcels in Greater Manchester vs. number of buildings
-# This shows that lots of land parcels are aggregated into one single building geometry/ footprint
-gm_gdf["NATIONALCADASTRALREFERENCE"].nunique(), gm_gdf["building_geometry"].nunique()
-
-# %%
-# Identifying pairs of different 1st most suitable solutions per land parcel
-solutions_per_land_parcel = gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[
-    "1st_most_suitable_solution"
-].apply(set)
-solutions_per_land_parcel = pd.DataFrame(solutions_per_land_parcel)
-solutions_per_land_parcel["n_solutions"] = solutions_per_land_parcel[
-    "1st_most_suitable_solution"
-].apply(len)
-solutions_per_land_parcel = solutions_per_land_parcel[
-    solutions_per_land_parcel["n_solutions"] > 1
-]
-solutions_per_land_parcel.reset_index(inplace=True)
-solutions_per_land_parcel["1st_most_suitable_solution_str"] = solutions_per_land_parcel[
-    "1st_most_suitable_solution"
-].apply(lambda x: ", ".join(x))
-solutions_per_land_parcel.groupby("1st_most_suitable_solution_str")[
-    ["NATIONALCADASTRALREFERENCE"]
-].nunique()
-
-
-# %%
 # Identifying pairs of different 1st most suitable solutions per building footprint
 solutions_per_footprint = gm_gdf.groupby("building_geometry")[
     "1st_most_suitable_solution"
@@ -589,29 +564,6 @@ solutions_per_footprint.groupby("1st_most_suitable_solution_str")[
     ["building_geometry"]
 ].nunique()
 
-
-# %%
-# check if each land parcel appears only within one building footprint
-land_parcel_to_footprint = gm_gdf.groupby("NATIONALCADASTRALREFERENCE")[
-    "building_geometry"
-].apply(set)
-land_parcel_to_footprint = pd.DataFrame(land_parcel_to_footprint)
-land_parcel_to_footprint["n_footprints"] = land_parcel_to_footprint[
-    "building_geometry"
-].apply(len)
-
-# %%
-# It doesn't seem to be the case
-land_parcel_to_footprint["n_footprints"].value_counts()
-
-# %%
-land_parcel_to_footprint["n_footprints"].value_counts(normalize=True) * 100
-
-# %% [markdown]
-# In most cases:
-# - the same land parcel should be in one building footprint only (hopefully?)
-# - properties in the same land parcel should have the same most suitable solution
-# - properties in the same building footprint should have the same most suitable solution
 
 # %%
 # This is currently based on Greater Manchester only (both pairs found in land parcels and building footprints)
@@ -644,24 +596,24 @@ def assign_unique_sol(solution_set: set) -> str:
         print("This shouldn't happen!")
 
 
-solutions_per_footprint["final_solution"] = solutions_per_footprint[
+solutions_per_footprint["assigned_tech"] = solutions_per_footprint[
     "1st_most_suitable_solution"
 ].apply(lambda x: assign_unique_sol(x))
 
 # %%
 
-solutions_per_footprint["final_solution"].value_counts(dropna=False)
+solutions_per_footprint["assigned_tech"].value_counts(dropna=False)
 
 # %%
-mapping_set_to_final_solution = solutions_per_footprint.set_index("building_geometry")[
-    "final_solution"
+mapping_set_to_assigned_tech = solutions_per_footprint.set_index("building_geometry")[
+    "assigned_tech"
 ].to_dict()
 
 # %%
 gm_gdf["1st_most_suitable_solution"] = gm_gdf.apply(
     lambda x: (
-        mapping_set_to_final_solution[x["building_geometry"]]
-        if x["building_geometry"] in mapping_set_to_final_solution
+        mapping_set_to_assigned_tech[x["building_geometry"]]
+        if x["building_geometry"] in mapping_set_to_assigned_tech
         else x["1st_most_suitable_solution"]
     ),
     axis=1,
@@ -674,30 +626,33 @@ gm_gdf["1st_most_suitable_solution"].value_counts(dropna=False)
 # %%
 def map_blocks_of_flats_prob(
     tech: str,
-    ward_df: gpd.GeoDataFrame,
+    ward_gdf: gpd.GeoDataFrame,
     specific_ward_gdf: gpd.GeoDataFrame,
     labelled_tech: gpd.GeoDataFrame,
     colours: dict,
-    threshold=None,
+    threshold: float = None,
 ):
     """
     Maps properties suitable for a specific technology where the colour indicates the confidence in the block of flats label.
 
     Args:
-        tech (str): a low carbon heating solution in the set {"Individual solution", "Networked GSHP", "Communal solutions", "District heat network"}
-        ward_df (gpd.GeoDataFrame): ward data with most suitable solutions
+         tech (str): a low carbon heating solution in the set {"Individual solution", "Networked GSHP", "Communal solutions", "District heat network"}
+        ward_gdf (gpd.GeoDataFrame): ward data with most suitable solutions
         specific_ward_gdf (gpd.GeoDataFrame): specific ward boundary data
+        labelled_tech (gpd.GeoDataFrame): labelled technology polygons data
+        colours (dict): mapping of technologies to colours
+        threshold (float, optional): threshold for the block of flats label confidence.
     """
 
     if tech != "":
-        tech_specific_df = ward_df[ward_df["1st_most_suitable_solution"] == tech]
+        tech_specific_gdf = ward_gdf[ward_gdf["1st_most_suitable_solution"] == tech]
     else:
-        tech_specific_df = ward_df.copy()
+        tech_specific_gdf = ward_gdf.copy()
     fig, ax = plt.subplots(figsize=(15, 8))
 
     if threshold:
-        tech_specific_df = tech_specific_df[
-            tech_specific_df["block_of_flats_label_proba"] <= threshold
+        tech_specific_gdf = tech_specific_gdf[
+            tech_specific_gdf["block_of_flats_label_proba"] <= threshold
         ]
 
     print("tech:", tech)
@@ -725,7 +680,6 @@ def map_blocks_of_flats_prob(
         )
 
     greys = plt.get_cmap("Greys")
-    import matplotlib.colors as mcolors
 
     # Create a new map using only the range from 0.2 (light gray) to 1.0 (black)
     # 0.0 would be white, so we skip it.
@@ -734,7 +688,7 @@ def map_blocks_of_flats_prob(
     )
 
     # mapping individual properties where the colour indicates probability of being a block of flats
-    tech_specific_df.plot(
+    tech_specific_gdf.plot(
         ax=ax,
         column="block_of_flats_label_proba",
         cmap=cmap_no_white,
@@ -826,7 +780,7 @@ gm_building_most_suitable_tech = (
             "LAD23NM": "first",
             "property_type_flat": "sum",
             "UPRN": "count",
-            "max_contiguous_outdoor_space_area_m2": "mean",
+            "max_contiguous_outdoor_space_area_m2": "median",
             "in_block_of_flats": "first",
             "in_city_centre": "first",
             "in_hn_zone": "first",
@@ -856,7 +810,6 @@ gm_building_most_suitable_tech = gpd.GeoDataFrame(
 gm_building_most_suitable_tech
 
 # %%
-# These numbers should be the same, not sure why they are not
 gm_building_most_suitable_tech["geometry"].nunique(), len(
     gm_building_most_suitable_tech
 )
@@ -882,11 +835,11 @@ map_building_techs_in_ward(
 # gm_building_most_suitable_tech[["geometry", "1st_most_suitable_solution"]].to_file("greater_manchester_las_building_most_suitable_tech.kml", driver="KML")
 
 # %%
-# There are 2 buildings without geometry... needs further investigation. For now we remove them!
+# Checking if geometry is ever missing
 gm_building_most_suitable_tech[pd.isnull(gm_building_most_suitable_tech["geometry"])]
 
 # %%
-# Removing buildings with no geometry
+# Removing buildings with no geometry, if applicable
 gm_building_most_suitable_tech = gm_building_most_suitable_tech[
     ~pd.isnull(gm_building_most_suitable_tech["geometry"])
 ]

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -1,4 +1,6 @@
 # %%
+
+
 # %% [markdown]
 # # Visualising the results of the decision tree for Greater Manchester
 #
@@ -41,7 +43,6 @@ colours = {
     "Individual solution or Networked GSHP": "grey",
     "Individual solution or District heat network": "gray",
 }
-
 
 # %% [markdown]
 # ## 1. Loading data
@@ -225,12 +226,11 @@ s3client = boto3.client(
 s3_bucket = "asf-heat-pump-suitability"
 response = s3client.get_object(
     Bucket=s3_bucket,
-    Key="local_heat_planning/outputs/block_of_flats_building_classifier.pkl",
+    Key="local_heat_planning/outputs/models/block_of_flats_building_classifier.pkl",
 )
 
 body = response["Body"].read()
 block_of_flats_model = pickle.loads(body)
-
 
 # %%
 # Create features to apply blocks of flats model
@@ -245,7 +245,7 @@ df = pl.from_pandas(
     gm_gdf.drop(
         columns=[
             "geometry",
-            "property_geometry",
+            "uprn_geometry",
             "building_geometry",
             "desnz_hn_zone_geometry",
             "index_right",
@@ -280,7 +280,6 @@ agg_building_df = (
         (pl.col("n_UPRNs") / pl.col("building_area_m2")).alias("UPRNs_per_building_m2"),
     )
 )
-
 
 # %%
 
@@ -347,7 +346,6 @@ features_df = agg_building_df.join(
     how="left",
     on="ID",
 )
-
 
 # %%
 # These are the model features
@@ -423,7 +421,7 @@ gm_gdf["in_hn_zone"].value_counts(dropna=False)
 
 # %%
 def define_decision_tree(
-    in_block_of_flats: bool, garden_size: float, city_centre_or_hnz: bool
+    in_block_of_flats: bool, outdoor_space: float, city_centre_or_hnz: bool
 ) -> dict:
     """
     Defines the decision tree to identify:
@@ -432,7 +430,7 @@ def define_decision_tree(
 
     Args:
         in_block_of_flats (bool): Whether the property is in a block of flats.
-        utdoor_space (float): Size of the maximum contiguous outdoor space in square meters.
+        outdoor_space (float): Size of the maximum contiguous outdoor space in square meters.
         city_centre_or_hnz (bool): Whether the property is in the city centre or in a planned heat network zone.
 
     Returns:
@@ -454,13 +452,13 @@ def define_decision_tree(
             }
     else:
         if city_centre_or_hnz:
-            if pd.isnull(garden_size):
+            if pd.isnull(outdoor_space):
                 return {
                     1: "Individual solution or District heat network",
                     2: "Individual solution or District heat network",
                     "path": "Unknown garden size in city centre",
                 }
-            elif garden_size > 70:
+            elif outdoor_space > 70:
                 return {
                     1: "Individual solution",
                     2: "District heat network",
@@ -473,13 +471,13 @@ def define_decision_tree(
                     "path": "4. not blocks of flats, city centre, small or no garden",
                 }
         else:
-            if pd.isnull(garden_size):
+            if pd.isnull(outdoor_space):
                 return {
                     1: "Individual solution or Networked GSHP",
                     2: "Networked GSHP or Communal solutions",
                     "path": "Unknown garden size not in city centre",
                 }
-            elif garden_size > 30:
+            elif outdoor_space > 30:
                 return {
                     1: "Individual solution",
                     2: "Networked GSHP",
@@ -564,7 +562,6 @@ solutions_per_footprint.groupby("1st_most_suitable_solution_str")[
     ["building_geometry"]
 ].nunique()
 
-
 # %%
 # This is currently based on Greater Manchester only (both pairs found in land parcels and building footprints)
 # but needs to be generalised to all possible cases
@@ -641,7 +638,7 @@ def map_blocks_of_flats_prob(
         specific_ward_gdf (gpd.GeoDataFrame): specific ward boundary data
         labelled_tech (gpd.GeoDataFrame): labelled technology polygons data
         colours (dict): mapping of technologies to colours
-        threshold (float, optional): threshold for the block of flats label confidence.
+        threshold (float, optional): threshold for the block of flats label confidence (includes datapoints with confidence equal to or below the threshold) if provided, otherwise all datapoints are included.
     """
 
     if tech != "":

--- a/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
+++ b/asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py
@@ -15,6 +15,7 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import folium
+import os
 
 # %%
 # local imports
@@ -35,7 +36,10 @@ colours = {
     "Networked GSHP": "#0000FF",
     "Communal solutions": "#FF6E47",
     "District heat network": "#EA2541",
+    "Individual solution or Networked GSHP": "grey",
+    "Individual solution or District heat network": "gray",
 }
+
 
 # %% [markdown]
 # ## 1. Loading data
@@ -227,7 +231,7 @@ block_of_flats_model = pickle.loads(body)
 
 
 # %%
-# Create features
+# Create features to apply blocks of flats model
 
 # %%
 
@@ -344,6 +348,7 @@ features_df = agg_building_df.join(
 
 
 # %%
+# These are the model features
 features = [
     "n_UPRNs",
     "n_flats",
@@ -447,7 +452,13 @@ def define_decision_tree(
             }
     else:
         if city_centre_or_hnz:
-            if garden_size > 70:
+            if pd.isnull(garden_size):
+                return {
+                    1: "Individual solution or District heat network",
+                    2: "Individual solution or District heat network",
+                    "path": "Unknown garden size in city centre",
+                }
+            elif garden_size > 70:
                 return {
                     1: "Individual solution",
                     2: "District heat network",
@@ -460,7 +471,13 @@ def define_decision_tree(
                     "path": "4. not blocks of flats, city centre, small or no garden",
                 }
         else:
-            if garden_size > 30:
+            if pd.isnull(garden_size):
+                return {
+                    1: "Individual solution or Networked GSHP",
+                    2: "Networked GSHP or Communal solutions",
+                    "path": "Unknown garden size not in city centre",
+                }
+            elif garden_size > 30:
                 return {
                     1: "Individual solution",
                     2: "Networked GSHP",
@@ -618,8 +635,12 @@ def assign_unique_sol(solution_set: set) -> str:
         return "Networked GSHP"
     elif "Communal solutions" in solution_set:
         return "Communal solutions"
+    elif "Individual solution or Networked GSHP" in solution_set:
+        return "Individual solution or Networked GSHP"
+    elif "Individual solution or District heat network" in solution_set:
+        return "Individual solution or District heat network"
     else:
-        print("this shouldn't happen!")
+        print("This shouldn't happen!")
 
 
 solutions_per_footprint["final_solution"] = solutions_per_footprint[
@@ -789,17 +810,46 @@ gm_building_most_suitable_tech = (
             "building_geometry",
             "1st_most_suitable_solution",
             "LAD23NM",
+            "max_contiguous_outdoor_space_area_m2",
+            "property_type_flat",
+            "in_block_of_flats",
+            "in_city_centre",
             # keeping the in_hn_zone column for pipeline changes afterwards
             "in_hn_zone",
+            "UPRN",
         ]
     ]
+    .groupby(["building_geometry", "1st_most_suitable_solution"])
+    .agg(
+        {
+            "LAD23NM": "first",
+            "property_type_flat": "sum",
+            "UPRN": "count",
+            "max_contiguous_outdoor_space_area_m2": "mean",
+            "in_block_of_flats": "first",
+            "in_city_centre": "first",
+            "in_hn_zone": "first",
+        }
+    )
+    .reset_index()
     .drop_duplicates(
         # we drop duplicates based on building geometry and most suitable solution, as we're assuming one solution per building
         ["building_geometry", "1st_most_suitable_solution"]
     )
     .rename(columns={"building_geometry": "geometry"})
 )
+gm_building_most_suitable_tech["max_contiguous_outdoor_space_area_m2"] = (
+    gm_building_most_suitable_tech["max_contiguous_outdoor_space_area_m2"].round()
+)
+gm_building_most_suitable_tech["percent_flats"] = (
+    gm_building_most_suitable_tech["property_type_flat"]
+    / gm_building_most_suitable_tech["UPRN"]
+) * 100
 
+# Convert back to a GeoDataFrame
+gm_building_most_suitable_tech = gpd.GeoDataFrame(
+    gm_building_most_suitable_tech, geometry="geometry", crs=gm_gdf.crs
+)
 
 # %%
 gm_building_most_suitable_tech
@@ -865,6 +915,33 @@ for lad in gm_building_most_suitable_tech["LAD23NM"].unique():
         zoom_start=12,
     )
 
+    # 3. Create the Popup object
+    popup = folium.GeoJsonPopup(
+        fields=[
+            "property_type_flat",
+            "UPRN",
+            "percent_flats",
+            "in_block_of_flats",
+            "max_contiguous_outdoor_space_area_m2",
+            "in_city_centre",
+            "in_hn_zone",
+            "1st_most_suitable_solution",
+        ],
+        aliases=[
+            "Number of flats:",
+            "Number of properties in building:",
+            "Percent of flats (%):",
+            "Property in block of flats:",
+            "Avg max outdoor space area (m2):",
+            "In city centre:",
+            "In HN zone:",
+            "Most suitable solution:",
+        ],
+        localize=True,
+        labels=True,
+        style="background-color: white;",
+    )
+
     # 3. Add polygons using the color col
     folium.GeoJson(
         lad_gdf,
@@ -875,9 +952,16 @@ for lad in gm_building_most_suitable_tech["LAD23NM"].unique():
             ],  # Outline color (otherwise it is blue for all polygons)
             "fillOpacity": 1,  # Opacity
         },
+        popup=popup,
     ).add_to(map)
 
-    map.save(f"greater_manchester_lad_{lad}_most_suitable_tech_per_building.html")
+    map.save(
+        os.path.join(
+            "asf_heat_pump_suitability",
+            "outputs",
+            f"greater_manchester_lad_{lad}_most_suitable_tech_per_building.html",
+        )
+    )
 
 # %%
 # Creating a version of the map where all properties within HNZ are labelled as district heat network, even where that's not the output of our decision tree
@@ -910,6 +994,33 @@ for lad in gdf_gm_default_hn["LAD23NM"].unique():
         zoom_start=12,
     )
 
+    # 3. Create the Popup object
+    popup = folium.GeoJsonPopup(
+        fields=[
+            "property_type_flat",
+            "UPRN",
+            "percent_flats",
+            "in_block_of_flats",
+            "max_contiguous_outdoor_space_area_m2",
+            "in_city_centre",
+            "in_hn_zone",
+            "1st_most_suitable_solution",
+        ],
+        aliases=[
+            "Number of flats:",
+            "Number of properties in building:",
+            "Percent of flats (%):",
+            "Property in block of flats:",
+            "Avg max outdoor space area (m2):",
+            "In city centre:",
+            "In HN zone:",
+            "Most suitable solution:",
+        ],
+        localize=True,
+        labels=True,
+        style="background-color: white;",
+    )
+
     # 3. Add polygons using the color col
     folium.GeoJson(
         lad_gdf,
@@ -918,10 +1029,15 @@ for lad in gdf_gm_default_hn["LAD23NM"].unique():
             "color": feature["properties"]["color"],
             "fillOpacity": 1,  # Opacity
         },
+        popup=popup,
     ).add_to(map_gm_default_hn)
 
     map_gm_default_hn.save(
-        f"greater_manchester_lad_{lad}_default_hnz_most_suitable_tech_per_building.html"
+        os.path.join(
+            "asf_heat_pump_suitability",
+            "outputs",
+            f"greater_manchester_lad_{lad}_default_hnz_most_suitable_tech_per_building.html",
+        )
     )
 
 # %% [markdown]

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python=3.10
+  - python=3.12
   - llvm-openmp
   - gdal
   # Only put dependencies that are NOT available with pip here (e.g. graph-tool)

--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python=3.12
+  - python=3.10
   - llvm-openmp
   - gdal
   # Only put dependencies that are NOT available with pip here (e.g. graph-tool)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ scipy
 pyarrow
 simplekml
 smart-open~=7.3
-git+https://github.com/OrdnanceSurvey/osbng-py.git
+osbng

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,5 @@ seaborn
 scipy
 pyarrow
 simplekml
-smart-open~=7.3
+smart-open~=7.3.0
 osbng


### PR DESCRIPTION
---

# Description

The main aim of this PR was to get the most suitable low carbon heating tech for Greater Manchester. To do that I have changed the existing code so that it can now be ran for any local authority (LA) or list of LAs. Before this, it was only straightforward to run the code for Plymouth.

Changes to the code in this PR include:
- `base.yaml`: changed how we import grid squares/LA data to enable running pipelines for other LAs/CAs beyond Plymouth
- `add_features.py`, `heat_network_city_centres.py`, `heat_network_zones.py`, `uprns.py`: changes to enable running pipelines for other LAs beyond Plymouth

Also added a new notebook:
- `asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py`: with code from PRs #207 and #206. This still needs to be refacotored.

Fixes #209 #212 

Read this if you don't know what a grid square is: https://www.ordnancesurvey.co.uk/documents/resources/guide-to-nationalgrid.pdf

# Instructions for Reviewer

Hey @simran-dave,

Because this is your first time reviewing a PR in this repository please follow the instructions below:
- Clone the repo with `git clone git@github.com:nestauk/asf_heat_pump_suitability.git`
- Navigate to your local repo folder in the terminal/through the Visual studio terminal
- Run `direnv allow`

To get the changes from this specific PR do:
- Fetch latest from origin`git fetch origin`
- Select the specific `git checkout 209_manchester_workshop`
- Run `make install` to configure the development environment
- Run `conda activate asf_heat_pump_suitability`

Let us know if you run into any problem with the above & we can help.

**Instructions for reviewing the code:**
- @simran-dave and @crispy-wonton: Please review the changes in `base.yaml`, `add_features.py`, `heat_network_city_centres.py`, `heat_network_zones.py`, `uprns.py` to check the logic is correct.

- @simran-dave please check the scripts run in test mode for Greater Manchester. To do so run the following on your command line:
     - `python asf_heat_pump_suitability/pipeline/transform/uprns.py --local_authorities greater_manchester_las --test_mode`
     - `python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_residential_uprns.parquet --test_mode`
     - `python asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py --uprns s3://asf-heat-pump-suitability/local_heat_planning/outputs/greater_manchester_las_residential_uprns.parquet --test_mode`
    
- @crispy-wonton please check the scripts still run in test mode for Plymouth

     - `python asf_heat_pump_suitability/pipeline/transform/uprns.py --local_authorities plymouth --test_mode`
     - `python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet --test_mode`
     - `python asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py --uprnss3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet --test_mode`

- @crispy-wonton: Please pay special attention to the notebook. Is anything wrong on how we build the features/apply the blocks of flats model? You can also review the notebook @simran-dave , but it might feel a little bit out of context since it uses code from two other PRs which are open. Once I refactor this notebook into a Python script it will be easier to review. 
    - @simran-dave to run the notebook you need to do the following:
    - `pip install jupytext`
    - `jupytext --to notebook asf_heat_pump_suitability/research/exploratory/decision_tree_categorisation/manchester_applying_decision_tree.py`

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
