### PR TITLE
214 apply block classification model to dataset

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -65,7 +65,8 @@ constant:
   target_crs: 27700 # British National Grid
 output:
   save_as:
-    block_of_flats_model: "s3://asf-heat-pump-suitability/local_heat_planning/outputs/models/block_of_flats_building_classifier.pkl"
+    model:
+      block_of_flats_model: "s3://asf-heat-pump-suitability/local_heat_planning/outputs/models/block_of_flats_building_classifier.pkl"
 
 data_source:
   gb_ons_postcode_dir_url: "https://www.arcgis.com/sharing/rest/content/items/487a5ba62c8b4da08f01eb3c08e304f6/data" # Aug 2023 data

--- a/asf_heat_pump_suitability/getters/base_getters.py
+++ b/asf_heat_pump_suitability/getters/base_getters.py
@@ -11,6 +11,9 @@ import geojson
 import geopandas as gpd
 from fnmatch import fnmatch
 import polars as pl
+import pickle
+import fsspec
+from typing import Any
 
 
 def load_df_from_s3(uri: str, **kwargs) -> pl.DataFrame:
@@ -231,3 +234,18 @@ def get_df_from_parquet(path: str, is_s3: bool = False, **kwargs) -> pl.DataFram
     else:
         # Read directly from local file system
         return pl.read_parquet(path, **kwargs)
+
+
+def load_pickle(path: str) -> Any:
+    """
+    Load the content of a pickle file.
+
+    Args:
+        path (str): path to pickle file
+
+    Returns:
+        Any: contents of pickle file
+    """
+    fs = s3fs.S3FileSystem()
+    with fs.open(path, "rb") as file:
+        return pickle.load(file)

--- a/asf_heat_pump_suitability/pipeline/impute/property_type.py
+++ b/asf_heat_pump_suitability/pipeline/impute/property_type.py
@@ -20,6 +20,6 @@ def impute_set_flat_properties(uprns_gdf: gpd.GeoDataFrame) -> set:
     # Filter the GeoDataFrame to only those geometries
     flats = set(uprns_gdf[uprns_gdf["geometry"].isin(duplicate_geoms)]["UPRN"])
     print(
-        f"{len(flats)} flats found in UPRN dataset, N={len(uprns_gdf)}, {round(len(flats)/len(uprns_gdf)*100, 2)}%"
+        f"{len(flats)} flats found in UPRN dataset, N={len(uprns_gdf)}, {round(len(flats)/len(uprns_gdf)*100, 2)}% of all UPRNs"
     )
     return flats

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py
@@ -21,6 +21,7 @@ def generate_df_features(
     Return:
         pl.DataFrame: all features for each building ID
     """
+    print("Generating features required for block of flats classifier...")
     buildings_w_uprns_gdf = buildings_gdf.sjoin(
         uprns_gdf, how="inner", predicate="contains"
     )

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py
@@ -23,11 +23,11 @@ def generate_df_features(
     """
     print("Generating features required for block of flats classifier...")
     buildings_w_uprns_gdf = buildings_gdf.sjoin(
-        uprns_gdf, how="inner", predicate="contains"
-    )
+        uprns_gdf, how="inner", predicate="intersects"
+    ).dropna(subset=id_col)
     uprns_w_buildings_gdf = uprns_gdf.sjoin(
-        buildings_gdf, how="inner", predicate="within"
-    )
+        buildings_gdf, how="inner", predicate="intersects"
+    ).dropna(subset="UPRN")
 
     features_dfs = [
         _generate_df_building_features(buildings_w_uprns_gdf, id_col),

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
@@ -165,7 +165,7 @@ def predict_class_block_of_flats(
     concat_dfs = []
     labelled_ids = labelled_df[id_col].unique()
     X_df = (
-        features_df.filter(pl.col("n_flats") > 0, pl.col(id_col).is_in(labelled_ids))
+        features_df.filter(pl.col("n_flats") > 0, ~pl.col(id_col).is_in(labelled_ids))
         .to_pandas()
         .set_index(id_col)[FEATURES]
     )

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
@@ -27,6 +27,7 @@ from sklearn.model_selection import (
 from sklearn.model_selection._search import BaseSearchCV
 from sklearn.metrics import f1_score
 import argparse
+from asf_heat_pump_suitability.pipeline.transform import uprns
 
 # Set random state int and RandomState instance
 RANDOM_STATE = 8
@@ -140,6 +141,85 @@ def train_block_of_flats_classifier(
     return final_model
 
 
+def predict_class_block_of_flats(
+    model: RandomForestClassifier,
+    features_df: pl.DataFrame,
+    labelled_df: pl.DataFrame,
+    id_col: str,
+) -> pl.DataFrame:
+    """
+    Args:
+        model (RandomForestClassifier): trained model for binary classification of buildings into blocks of flats or not
+        features_df (pl.DataFrame): buildings to predict classes on with engineered features for model
+        labelled_df (pl.DataFrame): labelled training data with features and target variable
+        id_col (str): name of ID column in both `features_df` and `labelled_df` (must be the same).
+    """
+    print(
+        "Predicting classes (block of flats / not) and class probability of buildings..."
+    )
+    concat_dfs = []
+    labelled_ids = labelled_df[id_col].unique()
+    X_df = (
+        features_df.filter(pl.col("n_flats") > 0, pl.col(id_col).is_in(labelled_ids))
+        .to_pandas()
+        .set_index(id_col)[FEATURES]
+    )
+    predictions_df = X_df.copy()
+    predictions_df["block_of_flats"] = model.predict(X_df)
+
+    # Add probability of predictions
+    predictions_df[f"block_of_flats_proba_{model.classes_[0]}"] = model.predict_proba(
+        X_df
+    )[:, 0]
+    predictions_df[f"block_of_flats_proba_{model.classes_[1]}"] = model.predict_proba(
+        X_df
+    )[:, 1]
+
+    # Combine into one probability label
+    concat_dfs.append(
+        pl.from_pandas(predictions_df, include_index=True).with_columns(
+            pl.when(pl.col("block_of_flats"))
+            .then(pl.col("block_of_flats_proba_True"))
+            .when(~pl.col("block_of_flats"))
+            .then(pl.col("block_of_flats_proba_False"))
+            .alias("block_of_flats_label_proba")
+        )
+    )
+
+    # Set manually labelled block probability to 1
+    concat_dfs.append(
+        labelled_df.filter(pl.col(id_col).is_in(labelled_ids)).with_columns(
+            pl.lit(1.0).alias("block_of_flats_label_proba")
+        )
+    )
+
+    # Add required columns to buildings which do not contain flats for concatenation
+    concat_dfs.append(
+        features_df.filter(pl.col("n_flats") == 0).with_columns(
+            pl.lit(False).alias("block_of_flats"),
+            pl.lit(None).alias("block_of_flats_label_proba"),
+        )
+    )
+
+    cols = [id_col, "block_of_flats", "block_of_flats_label_proba"]
+
+    return pl.concat([df.select(cols) for df in concat_dfs])
+
+
+def extend_df_in_block_of_flats_label(
+    uprns_df: pl.DataFrame, mapping: dict, predictions_df: pl.DataFrame, id_col: str
+) -> pl.DataFrame:
+    """ """
+    print("Adding `in_block_of_flats` label to UPRNs...")
+    return (
+        uprns_df.with_columns(
+            pl.col("UPRN").replace(mapping, default=None).alias(id_col)
+        )
+        .join(predictions_df, how="left", on=id_col)
+        .rename({"block_of_flats": "in_block_of_flats"})
+    )
+
+
 def parse_arguments() -> argparse.Namespace:
     """
     Create ArgumentParser and parse.
@@ -222,5 +302,5 @@ if __name__ == "__main__":
         param_search="default",
     )
 
-    save_as = config["output"]["save_as"]["block_of_flats_model"]
+    save_as = config["output"]["save_as"]["model"]["block_of_flats_model"]
     save_utils.save_model_to_pkl_s3(model, save_as)

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
@@ -12,6 +12,8 @@ Set the required parameters:
 `labelled_data` takes a path to a parquet file containing labelled data. Requires a boolean 'block_of_flats' column and a building
 ID column with one row per building.
 `uprns` must contain all domestic UPRNs within the area(s) that `labelled_data` samples from.
+
+`labelled_data` takes a path to labelled data to train binary classification model on in parquet file format. Building ID required.
 """
 
 import numpy as np
@@ -78,7 +80,7 @@ def train_block_of_flats_classifier(
         df (pl.DataFrame): engineered features with labelled target variable
         id_col (str): name of ID column
         features (Iterable[str]): features used to train the model
-        target (str): name of target variable,
+        target (str): name of target variable
         param_search (Type[BaseSearchCV]): a class (not an instance) of `BaseSearchCV`, e.g. `HalvingRandomSearchCV` or `HalvingGridSearchCV` etc.
         Defaults to using `HalvingRandomSearchCV` which will create an instance of this class with selected custom arguments for `param_distributions`, `factor`, `cv`,
         and `n_jobs`, using F1 `scoring` metric. If using something other than the default option, kwargs for the selected `BaseSearchCV` class must be given, including param_distributions.
@@ -148,7 +150,18 @@ def predict_class_block_of_flats(
     id_col: str,
 ) -> pl.DataFrame:
     """
-    Predict binary class (block of flats / not) on buildings using trained Random Forest Classifier model.
+    Predict binary class (block of flats / not) on buildings using trained Random Forest Classifier model. Features required:
+        - n_UPRNs
+        - n_flats
+        - building_area_m2
+        - building_perimeter_m
+        - proportion_flats
+        - UPRNs_per_building_m2
+        - concave_hull_area_m2
+        - uprns_per_hull_area_m2
+        - flats_per_hull_area_m2
+        - avg_n_stacked_uprns
+        - std_n_stacked_uprns
 
     Args:
         model (RandomForestClassifier): trained model for binary classification of buildings into blocks of flats or not
@@ -180,7 +193,7 @@ def predict_class_block_of_flats(
         X_df
     )[:, 1]
 
-    # Combine into one probability label
+    # Combine into one probability label - final probability label indicates probability of the class assigned
     concat_dfs.append(
         pl.from_pandas(predictions_df, include_index=True).with_columns(
             pl.when(pl.col("block_of_flats"))
@@ -229,9 +242,14 @@ def extend_df_in_block_of_flats_label(
     print("Adding `in_block_of_flats` label to UPRNs...")
     return (
         uprns_df.with_columns(
-            pl.col("UPRN").replace(mapping, default=None).alias(id_col)
+            # Map building IDs to the UPRNs they contain
+            pl.col("UPRN")
+            .replace(mapping, default=None)
+            .alias(id_col)
         )
+        # Join the predicted block of flats label to the UPRNs via the building ID
         .join(predictions_df, how="left", on=id_col)
+        # Rename class for UPRN-level data
         .rename({"block_of_flats": "in_block_of_flats"})
     )
 
@@ -254,7 +272,7 @@ def parse_arguments() -> argparse.Namespace:
 
     parser.add_argument(
         "--labelled_data",
-        help="Labelled data to train binary classification model on in parquet file format. Building ID required.",
+        help="Path to labelled data to train binary classification model on in parquet file format. Building ID required.",
         type=str,
         required=True,
     )

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py
@@ -1,5 +1,5 @@
 """
-Functions to train a random forest binary classifier model.
+Functions to train and apply a random forest binary classifier model.
 
 Contains script to train a random forest classifier to identify buildings as blocks of flats or not, given features derived
 from building footprint and UPRN geospatial information.
@@ -148,11 +148,16 @@ def predict_class_block_of_flats(
     id_col: str,
 ) -> pl.DataFrame:
     """
+    Predict binary class (block of flats / not) on buildings using trained Random Forest Classifier model.
+
     Args:
         model (RandomForestClassifier): trained model for binary classification of buildings into blocks of flats or not
         features_df (pl.DataFrame): buildings to predict classes on with engineered features for model
         labelled_df (pl.DataFrame): labelled training data with features and target variable
-        id_col (str): name of ID column in both `features_df` and `labelled_df` (must be the same).
+        id_col (str): name of building ID column in both `features_df` and `labelled_df` (must be the same)
+
+    Returns:
+        pl.DataFrame: one row per building with predicted class and probability of predicted class
     """
     print(
         "Predicting classes (block of flats / not) and class probability of buildings..."
@@ -209,7 +214,18 @@ def predict_class_block_of_flats(
 def extend_df_in_block_of_flats_label(
     uprns_df: pl.DataFrame, mapping: dict, predictions_df: pl.DataFrame, id_col: str
 ) -> pl.DataFrame:
-    """ """
+    """
+    Join predicted building class (block of flats / not) to the corresponding UPRNs located within.
+
+    Args:
+        uprns_df (pl.DataFrame): dataset with UPRN column
+        mapping (dict): mapping of UPRNs (keys) to building IDs (values), where the building ID represents the building the UPRN is located within
+        predictions_df (pl.DataFrame): one row per building with predicted class and probability of predicted class
+        id_col (str): name of building ID column in `predictions_df`
+
+    Returns:
+        pl.DataFrame: one row per UPRN with `in_block_of_flats` label indicating the class of building the UPRN is located within
+    """
     print("Adding `in_block_of_flats` label to UPRNs...")
     return (
         uprns_df.with_columns(

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -1,6 +1,7 @@
 """
 Script to add features to UPRNs:
 - flat / apartment property type boolean flag
+-
 - estimated max contiguous and total outdoor space (m2)
 
 Run:
@@ -35,9 +36,14 @@ if __name__ == "__main__":
     import polars as pl
     import geopandas as gpd
 
+    from asf_heat_pump_suitability import config
     from asf_heat_pump_suitability.utils import save_utils
-    from asf_heat_pump_suitability.getters import load_tree_input
+    from asf_heat_pump_suitability.getters import load_tree_input, base_getters
     from asf_heat_pump_suitability.pipeline.impute import property_type
+    from asf_heat_pump_suitability.pipeline.model.block_of_flats import (
+        feature_engineering,
+        train_model,
+    )
     from asf_heat_pump_suitability.pipeline.transform import uprns, outdoor_space
 
     args = parse_arguments()
@@ -60,14 +66,49 @@ if __name__ == "__main__":
     )
 
     # ------------------------ #
+    # PREDICT BLOCK OF FLATS CLASSIFICATION
+    # Load building footprint data
+    # TODO scale beyond sampling areas
+    building_footprints_gdf = load_tree_input.load_gdf_os_openmap_local_layer(
+        layer="building", grid_squares="SX"
+    )
+
+    uprn_building_id_dict = uprns.map_dict_uprns_to_building_id(
+        uprns_gdf=uprns_gdf, buildings_gdf=building_footprints_gdf, id_col="ID"
+    )
+
+    uprns_gdf["property_type_flat"] = uprns_gdf["UPRN"].isin(flat_uprns)
+    building_features_df = feature_engineering.generate_df_features(
+        buildings_gdf=building_footprints_gdf,
+        uprns_gdf=uprns_gdf,
+        id_col="ID",
+    )
+
+    # TODO make this robust by loading same labelled data used to train model
+    labelled_df = pl.read_parquet(
+        "s3://asf-heat-pump-suitability/local_heat_planning/inputs/processed/manually_labelled_block_of_flats.parquet"
+    )
+    rfc = base_getters.load_pickle(
+        config["output"]["save_as"]["model"]["block_of_flats_model"]
+    )
+    features_df = train_model.extend_df_in_block_of_flats_label(
+        uprns_df=features_df,
+        mapping=uprn_building_id_dict,
+        predictions_df=train_model.predict_class_block_of_flats(
+            model=rfc,
+            features_df=building_features_df,
+            labelled_df=labelled_df,
+            id_col="ID",
+        ),
+        id_col="ID",
+    )
+
+    # ------------------------ #
     # ESTIMATE OUTDOOR SPACE
     # TODO scale beyond Plymouth
     print("Loading land registry data...")
     land_parcels_gdf = gpd.read_file(
         "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/Plymouth_Land_Registry_Cadastral_Parcels.gml"
-    )
-    building_footprints_gdf = load_tree_input.load_gdf_os_openmap_local_layer(
-        layer="building", grid_squares="SX"
     )
 
     # Get intersection of building footprint polygons and land polygons

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -1,7 +1,7 @@
 """
 Script to add features to UPRNs:
 - flat / apartment property type boolean flag
--
+- boolean flag to indicate whether UPRN is in a block of flats
 - estimated max contiguous and total outdoor space (m2)
 
 Run:
@@ -73,29 +73,32 @@ if __name__ == "__main__":
         layer="building", grid_squares="SX"
     )
 
+    # Map UPRNs to the ID of the building they're in
     uprn_building_id_dict = uprns.map_dict_uprns_to_building_id(
         uprns_gdf=uprns_gdf, buildings_gdf=building_footprints_gdf, id_col="ID"
     )
 
     uprns_gdf["property_type_flat"] = uprns_gdf["UPRN"].isin(flat_uprns)
+    # Generate features for block of flats classification model
     building_features_df = feature_engineering.generate_df_features(
         buildings_gdf=building_footprints_gdf,
         uprns_gdf=uprns_gdf,
         id_col="ID",
     )
 
-    # TODO make this robust by loading same labelled data used to train model
+    # TODO make this robust by automatically loading same labelled data used to train model
     labelled_df = pl.read_parquet(
         "s3://asf-heat-pump-suitability/local_heat_planning/inputs/processed/manually_labelled_block_of_flats.parquet"
     )
-    rfc = base_getters.load_pickle(
+    # Load trained block of flats classifier model
+    clf = base_getters.load_pickle(
         config["output"]["save_as"]["model"]["block_of_flats_model"]
     )
     features_df = train_model.extend_df_in_block_of_flats_label(
         uprns_df=features_df,
         mapping=uprn_building_id_dict,
         predictions_df=train_model.predict_class_block_of_flats(
-            model=rfc,
+            model=clf,
             features_df=building_features_df,
             labelled_df=labelled_df,
             id_col="ID",

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -22,6 +22,7 @@ import logging
 import argparse
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.getters import base_getters
+from asf_heat_pump_suitability.utils import geo_utils
 
 
 def generate_gdf_uprn_coords(
@@ -143,7 +144,20 @@ def filter_gdf_residential_uprns(
 def map_dict_uprns_to_building_id(
     uprns_gdf: gpd.GeoDataFrame, buildings_gdf: gpd.GeoDataFrame, id_col: str
 ) -> dict:
-    """ """
+    """
+    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within.
+
+    Args:
+        uprns_gdf (gpd.GeoDataFrame): UPRNs with geospatial point data
+        buildings_gdf (gpd.GeoDataFrame): building footprints
+        id_col (str): name of building ID column in `buildings_gdf`
+
+    Returns:
+        dict: mapping of UPRNs to building IDs
+    """
+    uprns_gdf = geo_utils.verify_gdf_crs(uprns_gdf)
+    buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
+
     return (
         uprns_gdf.sjoin(buildings_gdf, how="inner", predicate="within")
         .set_index("UPRN")

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -142,15 +142,20 @@ def filter_gdf_residential_uprns(
 
 
 def map_dict_uprns_to_building_id(
-    uprns_gdf: gpd.GeoDataFrame, buildings_gdf: gpd.GeoDataFrame, id_col: str
+    uprns_gdf: gpd.GeoDataFrame,
+    buildings_gdf: gpd.GeoDataFrame,
+    id_col: str,
+    predicate: str = "intersects",
 ) -> dict:
     """
-    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within.
+    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within or intersect with.
 
     Args:
         uprns_gdf (gpd.GeoDataFrame): UPRNs with geospatial point data
         buildings_gdf (gpd.GeoDataFrame): building footprints
         id_col (str): name of building ID column in `buildings_gdf`
+        predicate (str): how to join buildings and UPRNs, of `intersects` which joins UPRNs with building footprints
+        they intersect with, or `within` which joins UPRNs to building footprints they are located within. Default `intersects`.
 
     Returns:
         dict: mapping of UPRNs to building IDs
@@ -159,7 +164,7 @@ def map_dict_uprns_to_building_id(
     buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
 
     return (
-        uprns_gdf.sjoin(buildings_gdf, how="inner", predicate="within")
+        uprns_gdf.sjoin(buildings_gdf, how="inner", predicate=predicate)
         .set_index("UPRN")
         .to_dict()[id_col]
     )

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -154,7 +154,7 @@ def map_dict_uprns_to_building_id(
         uprns_gdf (gpd.GeoDataFrame): UPRNs with geospatial point data
         buildings_gdf (gpd.GeoDataFrame): building footprints
         id_col (str): name of building ID column in `buildings_gdf`
-        predicate (str): how to join buildings and UPRNs, of `intersects` which joins UPRNs with building footprints
+        predicate (str): how to join buildings and UPRNs. Can be one of: `intersects`, which joins UPRNs with building footprints
         they intersect with, or `within` which joins UPRNs to building footprints they are located within. Default `intersects`.
 
     Returns:

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -140,6 +140,17 @@ def filter_gdf_residential_uprns(
     ]
 
 
+def map_dict_uprns_to_building_id(
+    uprns_gdf: gpd.GeoDataFrame, buildings_gdf: gpd.GeoDataFrame, id_col: str
+) -> dict:
+    """ """
+    return (
+        uprns_gdf.sjoin(buildings_gdf, how="inner", predicate="within")
+        .set_index("UPRN")
+        .to_dict()[id_col]
+    )
+
+
 def parse_arguments() -> argparse.Namespace:
     """
     Create ArgumentParser and parse.

--- a/asf_heat_pump_suitability/utils/geo_utils.py
+++ b/asf_heat_pump_suitability/utils/geo_utils.py
@@ -7,6 +7,7 @@ import shapely
 
 from shapely.geometry.base import BaseGeometry
 from shapely import wkb
+from asf_heat_pump_suitability import config
 
 
 def transform_gdf_drop_duplicates(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -71,3 +72,23 @@ def parse_binary_geometry(
         return wkb.loads(binary_data, hex=True)
     else:
         return None
+
+
+def verify_gdf_crs(
+    gdf: gpd.GeoDataFrame, target_crs: str | int = config["constant"]["target_crs"]
+) -> gpd.GeoDataFrame:
+    """
+    Verify GeoDataFrame uses the defined target CRS. If not, convert to target CRS.
+
+    Args:
+        gdf (gpd.GeoDataFrame): geodataset to check CRS of
+        target_crs (str|int): target CRS. Defaults to target CRS defined in config base.yaml
+
+    Returns:
+        gpd.GeoDataFrame: geodataset in target CRS
+    """
+    if gdf.crs != target_crs:
+        print(f"Converting GeoDataFrame to target CRS: {target_crs}")
+        return gdf.to_crs(target_crs)
+    else:
+        return gdf


### PR DESCRIPTION
Fixes #214 

# Description

Apply the trained random forest classifier model to unlabelled data to predict class of building (block of flats / not). Note, when PR #210 has been merged, we can merge the scaling of the `add_features.py` script to other selected LAs here.

Modified files:
- `asf_heat_pump_suitability/config/base.yaml` - update config path to a specific variable
- `asf_heat_pump_suitability/getters/base_getters.py` - add function to load pickle files 
- `asf_heat_pump_suitability/pipeline/impute/property_type.py` - update a print statement
- `asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py` - add a print statement
- `asf_heat_pump_suitability/pipeline/model/block_of_flats/train_model.py` - add functions to apply trained model to unlabelled data
- `asf_heat_pump_suitability/pipeline/run/add_features.py` - call trained model in script to add features to UPRNs and use it to add the `in_block_of_flats` feature
- `asf_heat_pump_suitability/pipeline/transform/uprns.p`y - create new function to map UPRNs to their buildings 
- `asf_heat_pump_suitability/utils/geo_utils.py` - add function to verify the CRS of a geodataframe and convert to target CRS if not in it already

# Instructions for Reviewer

In order to test the code in this PR you need to ...
Run the following piece of code from the terminal to run the updated `add_features.py` script:
`python asf_heat_pump_suitability/pipeline/run/add_features.py --uprns s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet`

Please pay special attention to ...
- The output data of the pipeline in relation to the two new features added: `in_block_of_flats` and `block_of_flats_label_proba`. I had a look at it myself and compared it to the outputs of my original notebook in #207 . The results look the same for UPRNs which are common across both datasets (the original notebook covers the full 6 sampling areas, whereas the script covers Plymouth only). Do you see anything weird or unexpected about the results?
- Do the updated predicates on the sjoins make sense? Is there a reason we shouldn't use `intersects`? I thought that it could create cases where a UPRN gets joined to multiple buildings, but in testing it on Plymouth, I saw that didn't seem to happen.

Fyi there are a small number of UPRNs (1.5% of Plymouth data) which don't receive a label. I investigated this to see if it was caused by a bug. It's caused by our domestic filtering methodology - not a bug but seems to be a data quality issue. Basically, the domestic filtering retains all UPRNs which are in the domestic EPC register. A small number of these seem to not get sjoined to a building - this could be because (a) the UPRN is very old and so there no longer is a valid building, (b) the UPRN is wrong, or (c) the UPRN is located just outside the building due to small mapping errors. These UPRNs will not receive any label for block of flats, and therefore will not receive a tech type from decision tree. I suggest we exclude these for now, and then see if it's a big percentage / count of the data when scaling up. We could then try to remediate issue (c).

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
