### PR TITLE
fix: replace assert with ValueError for validation checks (#230)

### DIFF
--- a/asf_heat_pump_suitability/pipeline/prepare_features/boundaries.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/boundaries.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
+
 from asf_heat_pump_suitability.getters import get_datasets
 
 
@@ -11,11 +12,14 @@ def load_transform_gdf_lsoa_dz_boundaries() -> gpd.GeoDataFrame:
     Returns:
         gpd.GeoDataFrame: boundary polygons for 2021 LSOAs / 2011 DataZones
     """
-    lsoa_gdf = get_datasets.load_gdf_ons_lsoa_bounds(
-        columns=["LSOA21CD", "geometry"]
-    ).rename(columns={"LSOA21CD": "lsoa"})
-    dz_gdf = get_datasets.load_gdf_scotgov_data_zone_bounds(
-        columns=["DataZone", "geometry"]
-    ).rename(columns={"DataZone": "lsoa"})
-    assert lsoa_gdf.crs == dz_gdf.crs
+    lsoa_gdf = get_datasets.load_gdf_ons_lsoa_bounds(columns=["LSOA21CD", "geometry"]).rename(
+        columns={"LSOA21CD": "lsoa"}
+    )
+    dz_gdf = get_datasets.load_gdf_scotgov_data_zone_bounds(columns=["DataZone", "geometry"]).rename(
+        columns={"DataZone": "lsoa"}
+    )
+    if lsoa_gdf.crs != dz_gdf.crs:
+        raise ValueError(
+            f"LSOA and Data Zone GeoDataFrames must share the same CRS, got {lsoa_gdf.crs} and {dz_gdf.crs}"
+        )
     return pd.concat([lsoa_gdf, dz_gdf])

--- a/asf_heat_pump_suitability/pipeline/prepare_features/grid_capacity.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/grid_capacity.py
@@ -3,20 +3,16 @@ This can be run as a standalone script to calculate grid capacity per LSOA/DataZ
 Outputs will be saved to `outputs/reports/grid_capacity.csv` unless otherwise specified.
 """
 
+import argparse
+import logging
 import re
 from typing import Any
-import logging
-import argparse
 
+import geopandas as gpd
 import numpy as np
 import pandas as pd
-import geopandas as gpd
 import polars as pl
 
-from asf_heat_pump_suitability.pipeline.prepare_features import (
-    boundaries,
-    household_count,
-)
 from asf_heat_pump_suitability.getters.get_dno_datasets import (
     generate_enw_gdf,
     generate_npg_gdf,
@@ -25,17 +21,19 @@ from asf_heat_pump_suitability.getters.get_dno_datasets import (
     generate_ukpn_gdf,
     generate_wpd_gdf,
 )
+from asf_heat_pump_suitability.pipeline.prepare_features import (
+    boundaries,
+    household_count,
+)
 
 # Constants
 CRS = "EPSG:4326"  # Geometry coordinate reference system - standard longitude/latitude projection
 POWER_PER_HEATPUMP = 8  # Power rating per heat pump in kW
-COEFFICIENT_OF_PERFORMANCE = (
-    2.5  # Heat output (heat pump rating) / electricity consumed
-)
+COEFFICIENT_OF_PERFORMANCE = 2.5  # Heat output (heat pump rating) / electricity consumed
 SUBSTATION_SCALING_FACTOR = 1.0  # Factor to scale substation power rating (MVA) by
 
 
-def _parse_capacity(value: Any) -> float:
+def _parse_capacity(value: Any) -> float:  # noqa: ANN401
     """
     Parse complex capacity strings and return total capacity as float.
 
@@ -103,14 +101,12 @@ def generate_substations_gdf() -> gpd.GeoDataFrame:
         ]
     )
 
-    assert set(substations_gdf["operator"]) == {
-        "ENW",
-        "NPg",
-        "SPEN",
-        "SSEN",
-        "UKPN",
-        "WPD",
-    }
+    expected_operators = {"ENW", "NPg", "SPEN", "SSEN", "UKPN", "WPD"}
+    actual_operators = set(substations_gdf["operator"])
+    if actual_operators != expected_operators:
+        missing = expected_operators - actual_operators
+        extra = actual_operators - expected_operators
+        raise ValueError(f"Unexpected operator set in substations data. Missing: {missing}, unexpected: {extra}")
 
     return substations_gdf
 
@@ -135,17 +131,13 @@ def distribute_substation_headroom(
     lsoa_with_households = lsoa_gdf.merge(households_df, on="lsoa", how="left")
 
     # Perform spatial join between LSOAs and substations
-    joined = gpd.sjoin(
-        lsoa_with_households, substations_gdf, how="inner", predicate="intersects"
-    ).rename(columns={"id": "substation_id"})
+    joined = gpd.sjoin(lsoa_with_households, substations_gdf, how="inner", predicate="intersects").rename(
+        columns={"id": "substation_id"}
+    )
 
     # Calculate total households served by each substation
-    substation_total_households = (
-        joined.groupby("substation_id")["households_count"].sum().reset_index()
-    )
-    substation_total_households = substation_total_households.rename(
-        columns={"households_count": "total_households"}
-    )
+    substation_total_households = joined.groupby("substation_id")["households_count"].sum().reset_index()
+    substation_total_households = substation_total_households.rename(columns={"households_count": "total_households"})
 
     # Merge total households back to joined dataframe
     joined = joined.merge(substation_total_households, on="substation_id")
@@ -162,9 +154,7 @@ def distribute_substation_headroom(
     return lsoa_headroom
 
 
-def calculate_headroom_per_household(
-    lsoa_headroom: pd.DataFrame, households_df: pd.DataFrame
-) -> pd.DataFrame:
+def calculate_headroom_per_household(lsoa_headroom: pd.DataFrame, households_df: pd.DataFrame) -> pd.DataFrame:
     """
     Calculate headroom per household for each LSOA/DataZone.
 
@@ -176,9 +166,7 @@ def calculate_headroom_per_household(
         DataFrame with LSOA/DataZone codes, distributed headroom, household counts, and headroom per household.
     """
     merged = pd.merge(lsoa_headroom, households_df, on="lsoa", how="left")
-    merged["headroom_per_household"] = (
-        merged["distributed_headroom"] / merged["households_count"]
-    )
+    merged["headroom_per_household"] = merged["distributed_headroom"] / merged["households_count"]
     return merged[
         [
             "lsoa",
@@ -205,9 +193,7 @@ def process_substation_lsoa_data(
     Returns:
         DataFrame with processed data including distributed headroom per household.
     """
-    lsoa_headroom = distribute_substation_headroom(
-        substations_gdf, lsoa_gdf, households_df
-    )
+    lsoa_headroom = distribute_substation_headroom(substations_gdf, lsoa_gdf, households_df)
     return calculate_headroom_per_household(lsoa_headroom, households_df)
 
 
@@ -259,22 +245,14 @@ def calculate_grid_capacity() -> pl.DataFrame:
     """
     # Generate and process substation data
     substations = generate_substations_gdf().drop_duplicates(subset="id")
-    substations["firm_capacity_mva"] = substations["firm_capacity_mva"].apply(
-        _parse_capacity
-    )
-    substations["peak_demand_mva"] = substations["peak_demand_mva"].apply(
-        _parse_capacity
-    )
+    substations["firm_capacity_mva"] = substations["firm_capacity_mva"].apply(_parse_capacity)
+    substations["peak_demand_mva"] = substations["peak_demand_mva"].apply(_parse_capacity)
 
     # Apply substation rating scaling factor
-    substations["firm_capacity_mva"] = (
-        substations["firm_capacity_mva"] * SUBSTATION_SCALING_FACTOR
-    )
+    substations["firm_capacity_mva"] = substations["firm_capacity_mva"] * SUBSTATION_SCALING_FACTOR
 
     # Calculate headroom per substation
-    substations["headroom_mva"] = (
-        substations["firm_capacity_mva"] - substations["peak_demand_mva"]
-    )
+    substations["headroom_mva"] = substations["firm_capacity_mva"] - substations["peak_demand_mva"]
 
     # Load and process LSOA/DataZone boundary data
     lsoa_gdf = boundaries.load_transform_gdf_lsoa_dz_boundaries().to_crs(CRS)

--- a/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
+++ b/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
@@ -56,19 +56,17 @@ def generate_gdf_non_residential_buildings(
         gpd.GeoDataFrame: geometries of buildings which are unlikely to contain residential properties
     """
     print("Creating non-residential buildings dataset...")
-    # Assert all gdfs have the same CRS
-    assert (
-        len(
-            {
-                important_building_gdf.crs,
-                railway_station_gdf.crs,
-                poi_gdf.crs,
-                building_gdf.crs,
-                uprns_gdf.crs,
-            }
-        )
-        == 1
-    ), "All GeoDataFrame inputs must have the same CRS"
+    # Validate that all inputs share the same CRS
+    crss = {
+        important_building_gdf.crs,
+        railway_station_gdf.crs,
+        poi_gdf.crs,
+        building_gdf.crs,
+        uprns_gdf.crs,
+    }
+    if len(crss) != 1:
+        crs_list = ", ".join(str(c) for c in crss)
+        raise ValueError(f"All GeoDataFrame inputs must have the same CRS, got: {crs_list}")
 
     # Find important building classification column name
     col = None
@@ -88,9 +86,7 @@ def generate_gdf_non_residential_buildings(
     poi_buildings_gdf = building_gdf.sjoin(poi_gdf, how="inner", predicate="contains")
 
     # Get buildings which are railway stations (railway stations are only given as point geometries)
-    railway_station_gdf = railway_station_gdf.sjoin(
-        building_gdf, how="inner", predicate="within"
-    )
+    railway_station_gdf = railway_station_gdf.sjoin(building_gdf, how="inner", predicate="within")
 
     exclude_buildings_gdf = pd.concat(
         [
@@ -110,9 +106,9 @@ def generate_gdf_non_residential_buildings(
     )
 
     # Filter to buildings that don't contain a domestic UPRN
-    exclude_buildings_gdf = exclude_buildings_gdf[
-        exclude_buildings_gdf["UPRN"].isnull()
-    ].drop(columns=["UPRN", "index_right"])
+    exclude_buildings_gdf = exclude_buildings_gdf[exclude_buildings_gdf["UPRN"].isnull()].drop(
+        columns=["UPRN", "index_right"]
+    )
 
     # Normalize to drop duplicate building footprints
     exclude_buildings_gdf["geometry"] = exclude_buildings_gdf.normalize()


### PR DESCRIPTION
## Summary

Closes #230

Python `assert` statements are silently removed when running with the `-O` flag, making them unreliable as production guards. This PR replaces all three `assert`-based validation blocks with explicit `ValueError` raises that include descriptive error messages:

| File | Old | New |
|---|---|---|
| `pipeline/transform/non_residential_entities.py` | `assert len({crs1, crs2, ...}) == 1` | `raise ValueError(f"...got: {crs_list}")` |
| `pipeline/prepare_features/boundaries.py` | `assert lsoa_gdf.crs == dz_gdf.crs` | `raise ValueError(f"...got {lsoa_gdf.crs} and {dz_gdf.crs}")` |
| `pipeline/prepare_features/grid_capacity.py` | `assert set(...) == {...}` | `raise ValueError(f"Missing: {missing}, unexpected: {extra}")` |

Also fixes pre-existing isort violations in `boundaries.py` and `grid_capacity.py` that ruff flagged when touching those files.

## Test plan

- [ ] `uv run pytest tests/` passes
- [ ] Passing wrong-CRS data to `generate_gdf_non_residential_buildings()` raises `ValueError` (not `AssertionError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)