### PR TITLE
feat: route output paths through get_path() in CLI scripts (#224)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: jupytext-enforce-pairing
       - id: jupytext-smart-sync
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/asf_heat_pump_suitability/pipeline/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/add_features.py
@@ -18,12 +18,12 @@ import os
 import geopandas as gpd
 import polars as pl
 
-from asf_heat_pump_suitability import config
+from asf_heat_pump_suitability.config.settings import load_settings
 from asf_heat_pump_suitability.getters import load_tree_input
 from asf_heat_pump_suitability.pipeline.impute import property_type
 from asf_heat_pump_suitability.pipeline.transform import outdoor_space, uprns
 from asf_heat_pump_suitability.utils import save_utils
-from asf_heat_pump_suitability.utils.storage import mock_aws_if_local
+from asf_heat_pump_suitability.utils.storage import get_path, mock_aws_if_local
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +50,10 @@ def run(uprns_path: str) -> None:
     Args:
         uprns_path: Path (S3 URI or local) to the domestic UPRNs parquet file.
     """
+    settings = load_settings()
     output_stem = os.path.basename(uprns_path).split(".")[0]
-    output_path = config["output"]["features_template"].format(uprns_stem=output_stem)
+    s3_output = settings.output.features_template.format(uprns_stem=output_stem)
+    output_path = get_path(s3_output, settings)
 
     # Load UPRN data
     logger.info(f"Loading domestic UPRNs from: {uprns_path}")

--- a/asf_heat_pump_suitability/pipeline/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/uprns.py
@@ -22,10 +22,11 @@ import logging
 import polars as pl
 
 from asf_heat_pump_suitability import config
+from asf_heat_pump_suitability.config.settings import load_settings
 from asf_heat_pump_suitability.getters import load_boundaries, load_geodata, load_tree_input
 from asf_heat_pump_suitability.pipeline.transform import non_residential_entities, poi, uprns
 from asf_heat_pump_suitability.utils import save_utils
-from asf_heat_pump_suitability.utils.storage import mock_aws_if_local
+from asf_heat_pump_suitability.utils.storage import get_path, mock_aws_if_local
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,9 @@ def run(area: str = "plymouth") -> None:
         area: Geographic area identifier. One of 'plymouth', 'plymouth_similar',
             'sampling', or 'gb'.
     """
-    output_path = config["output"]["residential_uprns_template"].format(area=area)
+    settings = load_settings()
+    s3_output = settings.output.residential_uprns_template.format(area=area)
+    output_path = get_path(s3_output, settings)
 
     # Load all UPRNs
     uprns_df = load_geodata.load_df_osopen_uprn()

--- a/asf_heat_pump_suitability/utils/save_utils.py
+++ b/asf_heat_pump_suitability/utils/save_utils.py
@@ -21,30 +21,35 @@ def save_model_to_pkl_s3(model: BaseEstimator, path: str) -> None:
 
 
 def save_to_s3(df: pl.DataFrame, path: str) -> None:
-    """
-    Save dataframe as parquet file to S3.
+    """Save a dataframe to S3 or the local filesystem.
+
+    Accepts any path returned by ``utils.storage.get_path()``: an S3 URI
+    (``s3://...``) is written via s3fs; any other path is written directly to
+    the local filesystem using Polars native I/O.
 
     Args:
-        df (pl.DataFrame): dataframe
-        path (str): path to S3 destination
-
-    Returns:
-        None
+        df: DataFrame to save.
+        path: Destination path — either an S3 URI or a local file path.
     """
     logging.info(f"Saving file to {path}")
     file_type = path.split(".")[-1]
-    fs = get_s3fs()
-    if file_type == "parquet":
-        with fs.open(path=path, mode="wb") as f:
-            df.write_parquet(f)
-    elif file_type == "csv":
-        with fs.open(path=path, mode="wb") as f:
-            df.write_csv(f)
-    else:
+    if file_type not in {"parquet", "csv"}:
         raise ValueError(
-            "Save to S3 can only save .parquet or .csv file types."
+            "save_to_s3 can only save .parquet or .csv file types. "
             "Please ensure the `path` argument contains one of these file types."
         )
+    if path.startswith("s3://"):
+        fs = get_s3fs()
+        with fs.open(path=path, mode="wb") as f:
+            if file_type == "parquet":
+                df.write_parquet(f)
+            else:
+                df.write_csv(f)
+    else:
+        if file_type == "parquet":
+            df.write_parquet(path)
+        else:
+            df.write_csv(path)
 
 
 def upload_file_to_s3(

--- a/asf_heat_pump_suitability/utils/storage.py
+++ b/asf_heat_pump_suitability/utils/storage.py
@@ -1,13 +1,35 @@
 """Storage utilities for the pipeline.
 
-All pipeline S3 I/O should obtain s3fs filesystems and boto3 clients through
-this module. This ensures that the AWS_ENDPOINT_URL environment variable is
-respected, which is required for moto-based testing and localstack-based local
-development.
+Two complementary mechanisms handle local development and testing:
 
-All pipeline S3 I/O obtains paths through this module so that switching
-between real S3 and a local filesystem (DATA_MODE=local) requires no changes
-in pipeline code.
+1. ``get_path()`` — path-string routing
+   Converts an S3 URI into a local ``outputs/`` path when ``DATA_MODE=local``.
+   ``save_utils.save_to_s3()`` detects the local path and writes directly via
+   Polars, bypassing S3 entirely.  This is the primary mechanism for **output
+   writes** during local development.
+
+   Limitation: input paths (data sources read by the pipeline) are still
+   hardcoded S3 URIs and are not yet routed through ``get_path()``, so the
+   pipeline cannot run end-to-end in local mode without real or mocked S3 data.
+
+2. ``mock_aws_if_local()`` — botocore-level interception
+   Activates moto when ``DATA_MODE != 's3'``, patching botocore globally so
+   all boto3/s3fs calls hit an in-memory fake S3 rather than real AWS.  This
+   acts as a safety net against accidental writes to the real bucket during
+   local development.
+
+   In the **test suite** (``tests/conftest.py``), ``mock_aws()`` is used
+   directly (not via this helper) and fixture files are pre-loaded into the
+   mock bucket, so pipeline reads also succeed.  ``mock_aws_if_local()`` is
+   never invoked during tests because ``DATA_MODE`` is not set to ``local``
+   there.
+
+   For local development runs, ``mock_aws_if_local()`` intercepts any stray
+   S3 calls, but reads of input data will fail with ``NoSuchKey`` unless the
+   moto bucket has been pre-populated separately.
+
+All S3 clients and filesystems must be obtained through ``get_s3fs()`` and
+``get_boto3_client()`` so that both mechanisms work correctly.
 """
 
 import os
@@ -52,12 +74,20 @@ def get_boto3_client(service: str) -> boto3.client:
 def mock_aws_if_local() -> Generator[None, None, None]:
     """Activate a moto S3 mock when DATA_MODE is not 's3'.
 
-    Pipeline entry scripts should wrap their ``run()`` call with this context
-    manager. When ``DATA_MODE=local`` (or any non-s3 value), all boto3 and
-    s3fs calls are intercepted by moto so no real AWS credentials are required.
+    When ``DATA_MODE=local``, patches botocore globally so all boto3/s3fs
+    calls hit an in-memory fake S3 rather than real AWS.  This prevents
+    accidental writes to the real S3 bucket during local development.
+
     When ``DATA_MODE=s3`` (the default for cloud runs), this is a no-op.
 
-    Example usage in a pipeline entry script::
+    Note: this is **not** used by the test suite.  Tests activate moto
+    directly via the ``s3_bucket`` fixture in ``tests/conftest.py``, which
+    also pre-populates the mock bucket with fixture data so that pipeline
+    reads succeed.  ``mock_aws_if_local()`` leaves the moto bucket empty, so
+    pipeline reads of input data will still fail in local mode unless the
+    bucket is pre-populated separately.
+
+    Example::
 
         if __name__ == "__main__":
             with mock_aws_if_local():
@@ -76,17 +106,22 @@ def mock_aws_if_local() -> Generator[None, None, None]:
 
 
 def get_path(key: str, config: "Settings") -> str:  # noqa: F821
-    """Return the appropriate path for a data key.
+    """Return the appropriate path for an S3 URI.
 
-    When DATA_MODE=local, returns a local filesystem path under outputs/.
-    When DATA_MODE=s3 (default), returns the configured S3 URI.
+    When ``DATA_MODE=local``, strips the ``s3://asf-heat-pump-suitability/``
+    prefix and returns a path under ``outputs/`` on the local filesystem,
+    creating parent directories as needed.  ``save_utils.save_to_s3()``
+    detects the local path and writes via Polars native I/O, so no S3
+    connection is required for output writes.
+
+    When ``DATA_MODE=s3`` (default), returns ``key`` unchanged.
 
     Args:
-        key: Dot-separated key into the config output paths, or a raw S3 URI.
+        key: S3 URI (``s3://asf-heat-pump-suitability/...``).
         config: Loaded Settings instance.
 
     Returns:
-        str: Path string suitable for use with polars, geopandas, or s3fs.
+        str: S3 URI (cloud mode) or local ``outputs/...`` path (local mode).
     """
     if getattr(config, "data_mode", "s3") == "local":
         local_key = key.replace("s3://asf-heat-pump-suitability/", "")


### PR DESCRIPTION
## Summary

- Output paths in both pipeline entry scripts (`pipeline/uprns.py`, `pipeline/add_features.py`) are now resolved through `get_path(s3_uri, settings)` instead of being written as bare S3 strings. `load_settings()` is called once at the top of each `run()` function to provide the `Settings` object.
- When `DATA_MODE=local`, `get_path()` strips the `s3://` prefix and returns a path under `outputs/` on the local filesystem. When `DATA_MODE=s3` (the default for cloud runs), behaviour is completely unchanged.
- `utils/save_utils.save_to_s3()` is updated to dispatch on path prefix: S3 URIs continue to use s3fs; local paths use Polars native I/O directly.

## Files changed

| File | Change |
|---|---|
| `asf_heat_pump_suitability/pipeline/uprns.py` | `load_settings()` + `get_path()` for output path |
| `asf_heat_pump_suitability/pipeline/add_features.py` | Same; drop now-unused raw `config` dict import |
| `asf_heat_pump_suitability/utils/save_utils.py` | Dispatch on `s3://` prefix — local paths use Polars I/O |

## Test plan

- [ ] `uv run pytest tests/` passes (no regression)
- [ ] `DATA_MODE=local uv run ahps-uprns --area plymouth` writes output to `outputs/local_heat_planning/outputs/` without hitting S3
- [ ] `DATA_MODE=s3 uv run ahps-uprns --area plymouth` writes to S3 as before

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)