### PR TITLE
refactor: replace print() with logging throughout pipeline and getters (#229)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: jupytext-enforce-pairing
       - id: jupytext-smart-sync
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/asf_heat_pump_suitability/getters/base_getters.py
+++ b/asf_heat_pump_suitability/getters/base_getters.py
@@ -14,6 +14,8 @@ import requests
 
 from asf_heat_pump_suitability.utils.storage import get_s3fs
 
+logger = logging.getLogger(__name__)
+
 
 def load_df_from_s3(uri: str, **kwargs) -> pl.DataFrame:
     """
@@ -79,7 +81,7 @@ def get_df_from_zip_csv_s3(path: str, extract_file: str, **kwargs) -> pl.DataFra
     Returns:
         pl.DataFrame: dataset from ZIP file
     """
-    print(f"Loading file from path: {path}")
+    logger.info(f"Loading file from path: {path}")
     content = BytesIO(get_content_from_s3_path(path))
     df = pl.read_csv(ZipFile(content).open(name=extract_file), **kwargs)
 

--- a/asf_heat_pump_suitability/getters/load_boundaries.py
+++ b/asf_heat_pump_suitability/getters/load_boundaries.py
@@ -2,11 +2,14 @@
 Functions to load raw census geography boundaries, like Local Authority; ward; output areas, etc. No/minimal preprocessing occurs in these functions.
 """
 
+import logging
 from typing import List
 
 import geopandas as gpd
 
 from asf_heat_pump_suitability import config
+
+logger = logging.getLogger(__name__)
 
 
 def load_gdf_local_authority_boundaries(
@@ -25,10 +28,10 @@ def load_gdf_local_authority_boundaries(
     la_boundaries_gdf = gpd.read_file(config["data"]["geodata"]["boundaries"]["UK_ons_lad_bounds"])
 
     if not select_las:
-        print("Loading Local Authority boundaries for UK...")
+        logger.info("Loading Local Authority boundaries for UK...")
         return la_boundaries_gdf
     elif isinstance(select_las, str):
-        print(f"Loading Local Authority boundaries for {select_las}...")
+        logger.info(f"Loading Local Authority boundaries for {select_las}...")
         la_boundaries_gdf = la_boundaries_gdf[la_boundaries_gdf["LAD23NM"].str.contains(select_las.title())]
         # Raise exception if boundaries are not found for LA specified by select_las
         if len(la_boundaries_gdf) == 0:
@@ -36,7 +39,7 @@ def load_gdf_local_authority_boundaries(
         else:
             return la_boundaries_gdf
     else:
-        print(f"Loading Local Authority boundaries for {select_las}...")
+        logger.info(f"Loading Local Authority boundaries for {select_las}...")
         la_boundaries_gdf = la_boundaries_gdf[
             # Filter to exact LA name matches, case insensitive
             la_boundaries_gdf["LAD23NM"].str.fullmatch("|".join(select_las), case=False)

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -1,11 +1,14 @@
-import polars as pl
-import geopandas as gpd
+import logging
 import os
 
+import geopandas as gpd
+import polars as pl
 from osbng import grids
 
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.getters import base_getters
+
+logger = logging.getLogger(__name__)
 
 
 def load_df_osopen_uprn(**kwargs) -> pl.DataFrame:
@@ -19,7 +22,7 @@ def load_df_osopen_uprn(**kwargs) -> pl.DataFrame:
     Returns:
         pl.DataFrame: raw OS Open UPRN dataset with lat/lon and x/y coordinates for every UPRN
     """
-    print("Loading OSOpen UPRNs...")
+    logger.info("Loading OSOpen UPRNs...")
     path = config["data"]["geodata"]["uk_osopen_uprn"]
     filename = os.path.basename(path).split("_csv")[0]
     df = base_getters.get_df_from_zip_csv_s3(
@@ -55,24 +58,18 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
     local_authority = local_authority.lower()
 
     if local_authority not in config["data"]["geodata"]["heat_network_zones"].keys():
-        raise ValueError(
-            f"No path found for heat network zone geodata in Local Authority: {local_authority}"
-        )
+        raise ValueError(f"No path found for heat network zone geodata in Local Authority: {local_authority}")
 
     gdf = base_getters.get_gdf_from_gpkg_s3_path(
         path=config["data"]["geodata"]["heat_network_zones"][local_authority],
         **kwargs,
     )
 
-    print(
-        f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
-    )
+    logger.info("Heat network zone geodataframe successfully loaded for %s with CRS %s.", local_authority, gdf.crs)
     return gdf
 
 
-def load_gdf_spatial_signatures_gb(
-    detail_level: str = "full", **kwargs
-) -> gpd.GeoDataFrame:
+def load_gdf_spatial_signatures_gb(detail_level: str = "full", **kwargs) -> gpd.GeoDataFrame:
     """
     Load GeoDataFrame with polygons in GB from the Spatial Signatures Framework  classified by their
     Spatial Signature type. CRS British National Grid (27700). (Source: https://doi.org/10.6084/m9.figshare.16691575).
@@ -101,17 +98,13 @@ def load_gdf_spatial_signatures_gb(
     """
 
     if detail_level not in {"full", "simplified"}:
-        raise ValueError(
-            f"detail_level must be 'full' or 'simplified', not {detail_level}"
-        )
+        raise ValueError(f"detail_level must be 'full' or 'simplified', not {detail_level}")
 
     gdf = base_getters.get_gdf_from_gpkg_s3_path(
         path=config["data"]["geodata"]["gb_spatial_signatures"][detail_level],
         **kwargs,
     )
 
-    print(
-        f"Spatial signatures {detail_level} geodataframe successfully loaded with CRS {gdf.crs}."
-    )
+    logger.info("Spatial signatures %s geodataframe successfully loaded with CRS %s.", detail_level, gdf.crs)
 
     return gdf

--- a/asf_heat_pump_suitability/getters/load_tree_input.py
+++ b/asf_heat_pump_suitability/getters/load_tree_input.py
@@ -2,15 +2,18 @@
 Functions to load specific raw datasets used in decision tree pipeline using base getters and sources in config. No/minimal preprocessing occurs in these functions.
 """
 
+import logging
+from typing import List, Optional
+
 import geopandas as gpd
 import pandas as pd
-from typing import Optional, List
+
 from asf_heat_pump_suitability import config
 
+logger = logging.getLogger(__name__)
 
-def load_gdf_os_openmap_local_layer(
-    layer: str, grid_squares: Optional[List[str]] = None, **kwargs
-) -> gpd.GeoDataFrame:
+
+def load_gdf_os_openmap_local_layer(layer: str, grid_squares: Optional[List[str]] = None, **kwargs) -> gpd.GeoDataFrame:
     """
     Load specified OS OpenMap Local layer for Great Britain or optionally for a specific grid square. CRS British National Grid (27700).
 
@@ -47,7 +50,7 @@ def load_gdf_os_openmap_local_layer(
         gpd.GeoDataFrame: OS OpenMap Local geometries for specified layer
     """
     if not grid_squares:
-        print(f"Loading OS OpenMap Local - {layer.title()}...")
+        logger.info(f"Loading OS OpenMap Local - {layer.title()}...")
         return gpd.read_file(
             filename=config["data"]["geodata"]["gb_os_openmap_local"],
             layer=layer,
@@ -65,7 +68,7 @@ def load_gdf_os_openmap_local_layer(
         gdfs = []
 
         for file in files:
-            print(f"\nLoading OS OpenMap Local - {layer.title()} file: {file}")
+            logger.info(f"Loading OS OpenMap Local - {layer.title()} file: {file}")
             gdfs.append(gpd.read_file(file, **kwargs))
 
         return pd.concat(gdfs).drop_duplicates(subset="ID")
@@ -81,7 +84,7 @@ def load_gdf_poi() -> gpd.GeoDataFrame:
     Raises:
         ValueError: If required columns are missing
     """
-    print("Loading POI data...")
+    logger.info("Loading POI data...")
 
     required_columns = [
         "id",
@@ -95,5 +98,5 @@ def load_gdf_poi() -> gpd.GeoDataFrame:
         columns=required_columns,
         layer="poi_uk",
     ).to_crs("EPSG:4326")
-    print(f"POI CRS: {poi.crs}")
+    logger.info(f"POI CRS: {poi.crs}")
     return poi

--- a/asf_heat_pump_suitability/pipeline/impute/property_type.py
+++ b/asf_heat_pump_suitability/pipeline/impute/property_type.py
@@ -1,4 +1,8 @@
+import logging
+
 import geopandas as gpd
+
+logger = logging.getLogger(__name__)
 
 
 def impute_set_flat_properties(uprns_gdf: gpd.GeoDataFrame) -> set:
@@ -19,7 +23,7 @@ def impute_set_flat_properties(uprns_gdf: gpd.GeoDataFrame) -> set:
 
     # Filter the GeoDataFrame to only those geometries
     flats = set(uprns_gdf[uprns_gdf["geometry"].isin(duplicate_geoms)]["UPRN"])
-    print(
-        f"{len(flats)} flats found in UPRN dataset, N={len(uprns_gdf)}, {round(len(flats)/len(uprns_gdf)*100, 2)}%"
+    logger.info(
+        f"{len(flats)} flats found in UPRN dataset, N={len(uprns_gdf)}, {round(len(flats) / len(uprns_gdf) * 100, 2)}%"
     )
     return flats

--- a/asf_heat_pump_suitability/pipeline/prepare_features/grid_capacity.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/grid_capacity.py
@@ -26,6 +26,8 @@ from asf_heat_pump_suitability.pipeline.prepare_features import (
     household_count,
 )
 
+logger = logging.getLogger(__name__)
+
 # Constants
 CRS = "EPSG:4326"  # Geometry coordinate reference system - standard longitude/latitude projection
 POWER_PER_HEATPUMP = 8  # Power rating per heat pump in kW
@@ -296,11 +298,11 @@ if __name__ == "__main__":
     args = parse_arguments()
 
     grid_capacity_results = calculate_grid_capacity()
-    print(grid_capacity_results.head())
-    print(f"Total LSOAs/DataZones assessed: {len(grid_capacity_results)}")
-    print(
-        "Average LSOA/DataZone installation percentage: "
-        + str(grid_capacity_results["heatpump_installation_percentage"].mean())
+    logger.info("Grid capacity results (head):\n%s", grid_capacity_results.head())
+    logger.info("Total LSOAs/DataZones assessed: %d", len(grid_capacity_results))
+    logger.info(
+        "Average LSOA/DataZone installation percentage: %s",
+        grid_capacity_results["heatpump_installation_percentage"].mean(),
     )
 
     if args.save_as:

--- a/asf_heat_pump_suitability/pipeline/prepare_features/lat_lon.py
+++ b/asf_heat_pump_suitability/pipeline/prepare_features/lat_lon.py
@@ -1,6 +1,11 @@
-import polars as pl
+import logging
+
 import geopandas as gpd
+import polars as pl
+
 from asf_heat_pump_suitability.getters import load_geodata
+
+logger = logging.getLogger(__name__)
 
 
 def transform_df_osopen_uprn_latlon() -> pl.DataFrame:
@@ -36,7 +41,7 @@ def generate_gdf_uprn_coords(
     Returns:
         gpd.GeoDataFrame: UPRNs with BNG coordinate point geometries
     """
-    print("Generating point geometries from coordinates...")
+    logger.info("Generating point geometries from coordinates...")
     if not usecols:
         usecols = ["*"]
     else:

--- a/asf_heat_pump_suitability/pipeline/transform/city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/transform/city_centres.py
@@ -2,10 +2,14 @@
 Functions to label UPRNs within city centre areas.
 """
 
+import logging
+
 import geopandas as gpd
 import polars as pl
 
 from asf_heat_pump_suitability import config
+
+logger = logging.getLogger(__name__)
 
 CITY_CENTRE_TYPES = [  # TODO: confirm types with scaling
     "Hyper concentrated urbanity",
@@ -46,11 +50,11 @@ def label_gdf_city_centre_spatial_signatures_uprns(
 
     if uprn_gdf.crs != target_crs:
         uprn_gdf = uprn_gdf.to_crs(target_crs)
-        print(f"uprn_gdf reprojected to target CRS: {target_crs}")
+        logger.info(f"uprn_gdf reprojected to target CRS: {target_crs}")
 
     if spatial_signatures_gdf.crs != target_crs:
         spatial_signatures_gdf = spatial_signatures_gdf.to_crs(target_crs)
-        print(f"spatial_signatures_gdf reprojected to target CRS: {target_crs}")
+        logger.info(f"spatial_signatures_gdf reprojected to target CRS: {target_crs}")
 
     # Spatial join for labelling UPRN with signature type
     labelled_uprn_gdf = uprn_gdf.sjoin(
@@ -68,7 +72,7 @@ def label_gdf_city_centre_spatial_signatures_uprns(
         labelled_uprn_gdf.groupby("UPRN", as_index=False)
         .agg(
             {
-                **{col: "first" for col in uprn_columns},  # keep original UPRN columns
+                **dict.fromkeys(uprn_columns, "first"),  # keep original UPRN columns
                 "geometry": "first",  # keep the point geometry
                 "type": list,  # combine types into a list
                 "in_city_centre": sum,  # sums >0 indicate UPRN in a city centre signature
@@ -80,13 +84,11 @@ def label_gdf_city_centre_spatial_signatures_uprns(
 
     # UPRNs with no spatial signature match are ultimately classified as not in city centre
     # TODO: consider if unassigned UPRNs should be handled differently in the future
-    labelled_uprn_gdf["in_city_centre"] = labelled_uprn_gdf["in_city_centre"].fillna(
-        False
-    )
+    labelled_uprn_gdf["in_city_centre"] = labelled_uprn_gdf["in_city_centre"].fillna(False)
 
     # Return as polars df without geometry
-    labelled_uprn_df = pl.from_pandas(
-        labelled_uprn_gdf.drop(columns="geometry")
-    ).rename({"type": "spatial_signature_types"})
+    labelled_uprn_df = pl.from_pandas(labelled_uprn_gdf.drop(columns="geometry")).rename(
+        {"type": "spatial_signature_types"}
+    )
 
     return labelled_uprn_df

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -2,10 +2,14 @@
 Functions to label UPRNs within official existing, potential or planned heat network zones.
 """
 
+import logging
+
 import geopandas as gpd
 import polars as pl
 
 from asf_heat_pump_suitability import config
+
+logger = logging.getLogger(__name__)
 
 
 def label_gdf_heat_network_zone_uprns(
@@ -31,11 +35,11 @@ def label_gdf_heat_network_zone_uprns(
 
     if uprn_gdf.crs != target_crs:
         uprn_gdf = uprn_gdf.to_crs(target_crs)
-        print(f"uprn_gdf reprojected to target CRS: {target_crs}")
+        logger.info(f"uprn_gdf reprojected to target CRS: {target_crs}")
 
     if hn_zone_gdf.crs != target_crs:
         hn_zone_gdf = hn_zone_gdf.to_crs(target_crs)
-        print(f"hn_zone_gdf reprojected to target CRS: {target_crs}")
+        logger.info(f"hn_zone_gdf reprojected to target CRS: {target_crs}")
 
     # If usecols specified, filter columns in hn_zone_gdf
     if usecols:

--- a/asf_heat_pump_suitability/pipeline/transform/poi.py
+++ b/asf_heat_pump_suitability/pipeline/transform/poi.py
@@ -2,12 +2,15 @@
 Functions to preprocess Points of Interest (POI) data for Great Britain.
 """
 
-import geopandas as gpd
+import logging
 from typing import Iterable
-import csv
+
+import geopandas as gpd
 import smart_open
 
 from asf_heat_pump_suitability import config
+
+logger = logging.getLogger(__name__)
 
 
 def transform_gdf_poi(
@@ -34,8 +37,8 @@ def transform_gdf_poi(
         poi = poi[poi.main_category.isin(filter_categories)]
     poi = poi.to_crs(target_crs)
 
-    print(f"Found {len(poi)} points of interest")
-    print(f'POI CRS converted to: {config["constant"]["target_crs"]}')
+    logger.info(f"Found {len(poi)} points of interest")
+    logger.info(f"POI CRS converted to: {config['constant']['target_crs']}")
     return poi
 
 
@@ -46,8 +49,6 @@ def load_set_non_domestic_poi_categories() -> set:
     Returns:
         set: non-domestic POI categories
     """
-    with smart_open.open(
-        config["data"]["processed"]["non_domestic_poi_categories"], "r"
-    ) as f:
+    with smart_open.open(config["data"]["processed"]["non_domestic_poi_categories"], "r") as f:
         categories = [line.strip() for line in f]
     return set(categories)

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -25,6 +25,8 @@ import polars as pl
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.getters import base_getters
 
+logger = logging.getLogger(__name__)
+
 
 def generate_gdf_uprn_coords(
     df: pl.DataFrame,
@@ -75,7 +77,7 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
     Returns:
         set: valid UPRNs from specified EPC dataset
     """
-    print(f"Loading UPRNs from {epc_type} EPC register...")
+    logger.info(f"Loading UPRNs from {epc_type} EPC register...")
     df = base_getters.load_df_from_s3(config["data"]["epc"][epc_type], columns="UPRN")
     before = len(df)
     df = df.with_columns(
@@ -109,7 +111,7 @@ def filter_gdf_residential_uprns(
     Returns:
         gpd.GeoDataFrame: UPRNs which are assumed to represent residential properties with their point geometries
     """
-    print("Filtering to residential UPRNs...")
+    logger.info("Filtering to residential UPRNs...")
     # Find UPRNs which are in the non-residential buildings
     non_residential_uprns = set(uprn_gdf.sjoin(non_residential_buildings_gdf, how="inner", predicate="within")["UPRN"])
 
@@ -173,7 +175,7 @@ if __name__ == "__main__":
 
     # TODO I expect this to be simplified at some point but the if/else block allows us to sample from certain areas for now
     if args.local_authorities.lower() == "plymouth":
-        print("Creating residential UPRN dataset for Plymouth Local Authority...")
+        logger.info("Creating residential UPRN dataset for Plymouth Local Authority...")
         grid_squares = config["constant"]["grid_squares"]["plymouth"]
         la_boundaries_gdf = load_boundaries.load_gdf_local_authority_boundaries(select_las="Plymouth")
         uprns_gdf = uprns_gdf.sjoin(
@@ -183,7 +185,7 @@ if __name__ == "__main__":
         ).drop(columns="index_right")
 
     elif args.local_authorities.lower() == "plymouth_similar":
-        print(
+        logger.info(
             "Creating residential UPRN dataset for Plymouth, Portsmouth, Southampton, Swansea, and Liverpool Local Authorities..."
         )
         grid_squares = config["constant"]["grid_squares"]["plymouth_similar_cities"]
@@ -197,7 +199,7 @@ if __name__ == "__main__":
         ).drop(columns="index_right")
 
     elif args.local_authorities.lower() == "sampling_areas":
-        print(
+        logger.info(
             "Creating residential UPRN dataset for Bath, Bradford, Glasgow, Manchester, Nottingham, and Plymouth Local Authorities..."
         )
         grid_squares = config["constant"]["grid_squares"]["sampling_areas"]
@@ -213,7 +215,7 @@ if __name__ == "__main__":
     else:  # All of GB
         # TODO this may not work due to scaling and may require chunking of datasets.
         # TODO Adding here as placeholder to assist scaling later
-        print("Creating residential UPRN dataset for all of GB...")
+        logger.info("Creating residential UPRN dataset for all of GB...")
         grid_squares = None
 
     poi_gdf = load_tree_input.load_gdf_poi()


### PR DESCRIPTION
## Summary

- Adds `logger = logging.getLogger(__name__)` to 11 files that were missing it
- Replaces all `print()` calls with `logging.info()` across getters and pipeline modules
- Two files deferred to their own PRs: `non_residential_entities.py` (#231) and `heat_network_city_centres.py` (#235)
- Also fixes two pre-existing ruff warnings surfaced by the ruff v0.15.2 upgrade: C420 in `city_centres.py` and unused `csv` import in `poi.py`

## Files changed

`getters/base_getters.py`, `getters/load_boundaries.py`, `getters/load_geodata.py`, `getters/load_tree_input.py`, `pipeline/impute/property_type.py`, `pipeline/prepare_features/grid_capacity.py`, `pipeline/prepare_features/lat_lon.py`, `pipeline/transform/city_centres.py`, `pipeline/transform/heat_network_zones.py`, `pipeline/transform/poi.py`, `pipeline/transform/uprns.py`

## Test plan

- [ ] `uv run pytest tests/` passes
- [ ] No `print()` calls remain in library code (excluding deferred files)

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)