### PR TITLE
Move non_residential_building_types from code into base.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: jupytext-enforce-pairing
       - id: jupytext-smart-sync
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -69,6 +69,30 @@ constant:
     - "Nottingham"
     - "Plymouth"
   target_crs: 27700 # British National Grid
+  # Building types from OS OpenMap Local important_building layer which are assumed to have no residential overlap.
+  # See pipeline/transform/non_residential_entities.py
+  non_residential_building_types:
+    - "Port Consisting of Docks and Nautical Berthing"
+    - "Fire Station"
+    - "Hospital"
+    - "Non State Secondary Education"
+    - "Secondary Education"
+    - "Higher or University Education"
+    - "Primary Education"
+    - "Place Of Worship"
+    - "Medical Care Accommodation"
+    - "Museum"
+    - "Special Needs Education"
+    - "Further Education"
+    - "Non State Primary Education"
+    - "Coach Station"
+    - "Police Station"
+    - "Sports And Leisure Centre"
+    - "Vehicular Ferry Terminal"
+    - "Hospice"
+    - "Bus Station"
+    - "Road User Services"
+    - "Passenger Ferry Terminal"
 
 data_source:
   gb_ons_postcode_dir_url: "https://www.arcgis.com/sharing/rest/content/items/487a5ba62c8b4da08f01eb3c08e304f6/data" # Aug 2023 data

--- a/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
+++ b/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
@@ -2,35 +2,15 @@
 Functions to transform data related to identifying non-domestic buildings.
 """
 
+import logging
+
 import geopandas as gpd
 import pandas as pd
 
+from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.pipeline.transform import uprns
 
-# TODO these may need refinement for large cities where overlap with residential is possible
-NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES = [
-    "Port Consisting of Docks and Nautical Berthing",
-    "Fire Station",
-    "Hospital",
-    "Non State Secondary Education",
-    "Secondary Education",
-    "Higher or University Education",
-    "Primary Education",
-    "Place Of Worship",
-    "Medical Care Accommodation",
-    "Museum",
-    "Special Needs Education",
-    "Further Education",
-    "Non State Primary Education",
-    "Coach Station",
-    "Police Station",
-    "Sports And Leisure Centre",
-    "Vehicular Ferry Terminal",
-    "Hospice",
-    "Bus Station",
-    "Road User Services",
-    "Passenger Ferry Terminal",
-]
+logger = logging.getLogger(__name__)
 
 
 def generate_gdf_non_residential_buildings(
@@ -55,7 +35,7 @@ def generate_gdf_non_residential_buildings(
     Returns:
         gpd.GeoDataFrame: geometries of buildings which are unlikely to contain residential properties
     """
-    print("Creating non-residential buildings dataset...")
+    logger.info("Creating non-residential buildings dataset...")
     # Validate that all inputs share the same CRS
     crss = {
         important_building_gdf.crs,
@@ -81,7 +61,7 @@ def generate_gdf_non_residential_buildings(
 
     # Get buildings which are unlikely to have residential overlap
     exclude_buildings_gdf = important_building_gdf[
-        important_building_gdf[col].isin(NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES)
+        important_building_gdf[col].isin(config["constant"]["non_residential_building_types"])
     ]
     poi_buildings_gdf = building_gdf.sjoin(poi_gdf, how="inner", predicate="contains")
 


### PR DESCRIPTION
## Summary

- Moves the `NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES` list from a hardcoded module-level constant in `non_residential_entities.py` into `base.yaml` under `constant.non_residential_building_types`
- `generate_gdf_non_residential_buildings()` now reads the list from `config["constant"]["non_residential_building_types"]`
- Replaces the `print()` call in that function with `logger.info()`

Closes #231

## Test plan

- [ ] Verify `config["constant"]["non_residential_building_types"]` returns the expected 21-item list
- [ ] Run `pipeline/uprns.py` (Plymouth) end-to-end and confirm residential UPRN output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)