### PR TITLE
Document magic-number thresholds as named module-level constants

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: jupytext-enforce-pairing
       - id: jupytext-smart-sync
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py
+++ b/asf_heat_pump_suitability/pipeline/model/block_of_flats/feature_engineering.py
@@ -6,6 +6,13 @@ Generates per-building features from building footprint and UPRN geodata.
 import geopandas as gpd
 import polars as pl
 
+# Sentinel value used in place of infinity when all UPRNs in a building share the same
+# (X, Y) coordinate, which causes the concave hull to degenerate to a point (area = 0)
+# and yields infinite per-area ratios.  -1 is chosen because it is outside the valid
+# range of the features (which are always >= 0) and is therefore unambiguous to downstream
+# model code.
+INFINITE_HULL_SENTINEL: int = -1
+
 
 def generate_df_features(
     buildings_gdf: gpd.GeoDataFrame,
@@ -127,11 +134,11 @@ def _generate_df_concave_hull_features(gdf: gpd.GeoDataFrame, id_col: str) -> pl
         )
         .with_columns(
             pl.when(pl.col("uprns_per_hull_area_m2").is_infinite())
-            .then(-1)
+            .then(INFINITE_HULL_SENTINEL)
             .otherwise(pl.col("uprns_per_hull_area_m2"))
             .alias("uprns_per_hull_area_m2"),
             pl.when(pl.col("flats_per_hull_area_m2").is_infinite())
-            .then(-1)
+            .then(INFINITE_HULL_SENTINEL)
             .otherwise(pl.col("flats_per_hull_area_m2"))
             .alias("flats_per_hull_area_m2"),
         )

--- a/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
+++ b/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
@@ -2,10 +2,26 @@
 Functions to calculate outdoor space estimates from building footprints and land extents.
 """
 
-import geopandas as gpd
 import logging
+
+import geopandas as gpd
 import pandas as pd
 import polars as pl
+
+# Maximum footprint area (m²) at which a building is treated as an outbuilding
+# (e.g. garage, shed).  30 m² is approximately the floor area of a large double garage.
+OUTBUILDING_SIZE_M2: int = 30
+
+# For buildings whose total area <= OUTBUILDING_SIZE_M2 we keep the intersection only if
+# the intersecting slice is at least this proportion of the building's area.
+# 0.45 avoids retaining a tiny corner sliver while still capturing outbuildings that
+# straddle a parcel boundary.
+SMALL_BUILDING_MIN_OVERLAP_PROPORTION: float = 0.45
+
+# For buildings whose total area > OUTBUILDING_SIZE_M2 we keep the intersection only if
+# its area is at least this many m².  15 m² is roughly the footprint of a small shed and
+# is large enough to rule out coordinate-tolerance slivers at parcel boundaries.
+MIN_INTERSECTION_AREA_M2: float = 15
 
 
 def match_series_files_land_building(
@@ -24,9 +40,7 @@ def match_series_files_land_building(
     """
     logging.info("Mapping building footprint files to INSPIRE land registry files")
     gdf = land_files_gdf.sjoin(building_files_gdf, how="inner", predicate="intersects")
-    file_matches = pd.Series(
-        gdf["ms_url"].values, index=gdf["inspire_file_name"]
-    ).sort_index()
+    file_matches = pd.Series(gdf["ms_url"].values, index=gdf["inspire_file_name"]).sort_index()
 
     return file_matches
 
@@ -34,9 +48,9 @@ def match_series_files_land_building(
 def generate_gdf_building_intersections(
     land_parcels_gdf: gpd.GeoDataFrame,
     building_footprints_gdf: gpd.GeoDataFrame,
-    outbuilding_size: int = 30,
-    s_building_prop: float = 0.45,
-    min_intersection: float = 15,
+    outbuilding_size: int = OUTBUILDING_SIZE_M2,
+    s_building_prop: float = SMALL_BUILDING_MIN_OVERLAP_PROPORTION,
+    min_intersection: float = MIN_INTERSECTION_AREA_M2,
 ) -> gpd.GeoDataFrame:
     """
     Generate intersections between land parcel polygons and building footprint polygons, with rules applied to remove
@@ -76,15 +90,9 @@ def generate_gdf_building_intersections(
     gdf = gdf[
         (
             (gdf["building_area_m2"] <= outbuilding_size)
-            & (
-                gdf["building_intersection_area_m2"]
-                >= gdf["min_size_of_small_building"]
-            )
+            & (gdf["building_intersection_area_m2"] >= gdf["min_size_of_small_building"])
         )
-        | (
-            (gdf["building_area_m2"] > outbuilding_size)
-            & (gdf["building_intersection_area_m2"] >= min_intersection)
-        )
+        | ((gdf["building_area_m2"] > outbuilding_size) & (gdf["building_intersection_area_m2"] >= min_intersection))
     ]
 
     # Drop intersecting geometries which are Points or LineStrings
@@ -117,9 +125,7 @@ def generate_gdf_outdoor_space(
 
     # Explode multi-part geometries into single part geometries to get largest piece
     land_minus_buildings_parts = land_minus_buildings.explode(index_parts=False)
-    land_minus_buildings_parts["outdoor_space_area_m2"] = (
-        land_minus_buildings_parts.geometry.area
-    )
+    land_minus_buildings_parts["outdoor_space_area_m2"] = land_minus_buildings_parts.geometry.area
 
     # Keep max size and total outdoor area
     outdoor_space_df = (
@@ -161,27 +167,20 @@ def deduplicate_df_outdoor_space(df: pl.DataFrame) -> pl.DataFrame:
 
     _deduplicated_df = (
         df.filter(pl.col("UPRN_duplicated"))
-        .with_columns(
-            min_total=pl.col("total_outdoor_space_area_m2").min().over("UPRN")
-        )
+        .with_columns(min_total=pl.col("total_outdoor_space_area_m2").min().over("UPRN"))
         .filter(
             # Get smallest outdoor space
-            pl.col("total_outdoor_space_area_m2")
-            == pl.col("min_total")
+            pl.col("total_outdoor_space_area_m2") == pl.col("min_total")
             # Deduplicate - any duplicates will now (most likely) have the same total outdoor space
         )
         .unique(subset="UPRN")
         .drop("min_total")
     )
 
-    return pl.concat([df.filter(~pl.col("UPRN_duplicated")), _deduplicated_df]).drop(
-        "UPRN_duplicated"
-    )
+    return pl.concat([df.filter(~pl.col("UPRN_duplicated")), _deduplicated_df]).drop("UPRN_duplicated")
 
 
-def sjoin_df_uprn_to_outdoor_space(
-    uprns_gdf: gpd.GeoDataFrame, outdoor_space_gdf: gpd.GeoDataFrame
-) -> pl.DataFrame:
+def sjoin_df_uprn_to_outdoor_space(uprns_gdf: gpd.GeoDataFrame, outdoor_space_gdf: gpd.GeoDataFrame) -> pl.DataFrame:
     """
     Join outdoor space estimates to UPRNs. UPRNs will be assigned the outdoor space calculated for the land extent parcel
     that they are contained within.
@@ -194,7 +193,5 @@ def sjoin_df_uprn_to_outdoor_space(
         pl.DataFrame: UPRNs with estimated outdoor space (m2)
     """
     return pl.from_pandas(
-        uprns_gdf.sjoin(outdoor_space_gdf, how="left", predicate="within").drop(
-            columns=["geometry", "index_right"]
-        )
+        uprns_gdf.sjoin(outdoor_space_gdf, how="left", predicate="within").drop(columns=["geometry", "index_right"])
     )


### PR DESCRIPTION
## Summary

- **`outdoor_space.py`**: Extracts three threshold defaults to named module-level constants with explanatory comments:
  - `OUTBUILDING_SIZE_M2 = 30` — ~floor area of a large double garage; buildings ≤ this are treated as outbuildings
  - `SMALL_BUILDING_MIN_OVERLAP_PROPORTION = 0.45` — minimum overlap fraction to keep a small-building intersection (avoids boundary slivers)
  - `MIN_INTERSECTION_AREA_M2 = 15` — minimum intersection area for larger buildings to be considered a genuine hit
- **`feature_engineering.py`**: Names the `-1` sentinel as `INFINITE_HULL_SENTINEL` with a comment explaining when and why it is used (degenerate concave hull when all UPRNs share the same coordinate)

Constants are wired in as default parameter values, preserving the existing API.

Closes #233

## Test plan

- [ ] `generate_gdf_building_intersections()` called without explicit arguments uses the same values as before (30, 0.45, 15)
- [ ] `_generate_df_concave_hull_features()` returns -1 (not inf) for a building where all UPRNs are co-located

🤖 Generated with [Claude Code](https://claude.com/claude-code)