### PR TITLE
Make heat_network_city_centres.py area-agnostic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: jupytext-enforce-pairing
       - id: jupytext-smart-sync
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.2
     hooks:
       - id: ruff-format
       - id: ruff-check

--- a/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
+++ b/asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
@@ -6,14 +6,17 @@ Contains script to add boolean flags to label residential UPRNs indicating wheth
 To run the script:
 python asf_heat_pump_suitability/pipeline/run/heat_network_city_centres.py
 
-Set the optional `local_authorities` parameter to `plymouth`, `plymouth_similar`, or `sampling_areas`.
-Set to `plymouth` to run for Plymouth Local Authority; `plymouth_similar` to run for Plymouth plus four other similar
-Local Authorities (Liverpool, Portsmouth, Southampton, Swansea); 'sampling_areas' to run for Plymouth plus five other
-Local Authorities for sampling buildings (Bath, Bradford, Glasgow, Manchester, Nottingham); or do not use to run for all
-of Great Britain.
+Set the optional `--area` parameter to `plymouth` (default), `plymouth_similar`, `sampling`,
+or `gb` to select the geographic scope.  Heat network zone data is currently only available
+for Plymouth; UPRNs in other areas will receive ``in_hn_zone = False``.
 """
 
 import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+AREA_CHOICES = ["plymouth", "plymouth_similar", "sampling", "gb"]
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -25,12 +28,17 @@ def parse_arguments() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser()
 
-    # Placeholder - this arg is to look up correct paths for residential UPRNs and heat network dataset
     parser.add_argument(
-        "--local_authorities",
-        help="Run script for either all of Great Britain; Plymouth only {plymouth}; or Plymouth and 4 similar local authorities {plymouth_similar}; or Plymouth and 5 different local authorities {sampling_areas}. Default to all of GB",
+        "--area",
+        help=(
+            "Geographic area to label UPRNs for. "
+            "'plymouth' (default), 'plymouth_similar', 'sampling', or 'gb' (full Great Britain). "
+            "Heat network zone data is only available for 'plymouth'; other areas will have "
+            "in_hn_zone=False for all UPRNs."
+        ),
         type=str,
-        default="GB",
+        choices=AREA_CHOICES,
+        default="plymouth",
         required=False,
     )
 
@@ -38,72 +46,75 @@ def parse_arguments() -> argparse.Namespace:
 
 
 if __name__ == "__main__":
+    import geopandas as gpd
+
     from asf_heat_pump_suitability import config
     from asf_heat_pump_suitability.getters import base_getters, load_geodata
-    from asf_heat_pump_suitability.pipeline.transform import uprns
-    from asf_heat_pump_suitability.pipeline.transform import (
-        heat_network_zones,
-        city_centres,
-    )
+    from asf_heat_pump_suitability.pipeline.transform import city_centres, heat_network_zones, uprns
     from asf_heat_pump_suitability.utils import save_utils
+    from asf_heat_pump_suitability.utils.storage import mock_aws_if_local
 
+    logging.basicConfig(level=logging.INFO)
     args = parse_arguments()
+    area = args.area
 
-    if args.local_authorities.lower() == "plymouth":
-
-        # Load residential OS UPRNs in Plymouth
-        print("Loading residential UPRN dataset for Plymouth Local Authority...")
-        uprn_df = base_getters.load_df_from_s3(
-            config["data"]["processed"]["plymouth_residential_uprns"]
-        )
+    with mock_aws_if_local():
+        # Load residential UPRNs for the specified area using the shared path template
+        uprns_path = config["output"]["residential_uprns_template"].format(area=area)
+        logger.info(f"Loading residential UPRN dataset for area: {area!r}...")
+        uprn_df = base_getters.load_df_from_s3(uprns_path)
         uprn_gdf = uprns.generate_gdf_uprn_coords(uprn_df)
 
-        """ Existing heat network zones """
+        # Load heat network zones for the area if available; fall back to empty GeoDataFrame
+        # so that all UPRNs receive in_hn_zone=False without raising an error.
+        try:
+            hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(local_authority=area)
+            logger.info(f"Loaded heat network zone data for {area!r}")
+        except ValueError:
+            logger.info(f"No heat network zone data available for {area!r}; all UPRNs will have in_hn_zone=False")
+            hn_zones_gdf = gpd.GeoDataFrame(
+                columns=["geometry", "ZoneID"],
+                geometry="geometry",
+                crs=config["constant"]["target_crs"],
+            )
 
-        # Load Plymouth existing heat network zone polygons
-        print("Loading heat network zone data for Plymouth Local Authority...")
-        plymouth_hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
-            local_authority="plymouth"
-        )
-
-        # Label UPRNs in existing, potential and planned heat network zones
-        print(
-            "Identifying residential UPRNs in heat network zones for Plymouth Local Authority..."
-        )
+        # Label UPRNs in heat network zones
         hn_zone_uprn_df = heat_network_zones.label_gdf_heat_network_zone_uprns(
             uprn_gdf=uprn_gdf,
-            hn_zone_gdf=plymouth_hn_zones_gdf,
-            usecols=[
-                "ZoneID",  # zone unique identifier
-            ],
+            hn_zone_gdf=hn_zones_gdf,
+            usecols=["ZoneID"],
         )
 
-        # Clean up columns
-        hn_zone_uprn_df = hn_zone_uprn_df.select(
-            ["UPRN", "LAD23NM", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", "ZoneID"]
-        ).rename({"ZoneID": "HNZoneID"})
+        # Keep LAD columns only when they exist (not present for gb area)
+        base_cols = ["UPRN", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", "ZoneID"]
+        if "LAD23NM" in hn_zone_uprn_df.columns:
+            base_cols = ["UPRN", "LAD23NM", "X_COORDINATE", "Y_COORDINATE", "in_hn_zone", "ZoneID"]
+        hn_zone_uprn_df = hn_zone_uprn_df.select(base_cols).rename({"ZoneID": "HNZoneID"})
 
-        """ City centre areas """
-
-        # Load spatial signature polygons
-        print("Loading spatial signatures dataset...")
-        spatial_signatures_gb_simplified_gdf = (
-            load_geodata.load_gdf_spatial_signatures_gb(detail_level="full")
-        )
+        # Load spatial signatures (GB-scale, no area filtering needed)
+        logger.info("Loading spatial signatures dataset...")
+        spatial_signatures_gb_gdf = load_geodata.load_gdf_spatial_signatures_gb(detail_level="full")
 
         # Label UPRNs in city centres
-        print(
-            "Identifying residential UPRNs in city centre areas for Plymouth Local Authority..."
-        )
+        logger.info(f"Identifying residential UPRNs in city centre areas for {area!r}...")
         hn_zone_uprn_gdf = uprns.generate_gdf_uprn_coords(hn_zone_uprn_df)
         hn_zone_city_centre_uprn_df = city_centres.label_gdf_city_centre_spatial_signatures_uprns(
-            uprn_gdf=hn_zone_uprn_gdf,  # add city centre labels to gdf with hnz labels
-            spatial_signatures_gdf=spatial_signatures_gb_simplified_gdf,
+            uprn_gdf=hn_zone_uprn_gdf,
+            spatial_signatures_gdf=spatial_signatures_gb_gdf,
         )
 
-        # Clean up columns
-        hn_zone_city_centre_uprn_df = hn_zone_city_centre_uprn_df.select(
-            [
+        # Final column selection
+        final_cols = [
+            "UPRN",
+            "X_COORDINATE",
+            "Y_COORDINATE",
+            "HNZoneID",
+            "in_hn_zone",
+            "spatial_signature_types",
+            "in_city_centre",
+        ]
+        if "LAD23NM" in hn_zone_city_centre_uprn_df.columns:
+            final_cols = [
                 "UPRN",
                 "LAD23NM",
                 "X_COORDINATE",
@@ -113,20 +124,9 @@ if __name__ == "__main__":
                 "spatial_signature_types",
                 "in_city_centre",
             ]
-        )
+        hn_zone_city_centre_uprn_df = hn_zone_city_centre_uprn_df.select(final_cols)
 
-    elif args.local_authorities.lower() in ["plymouth_similar", "sampling_areas"]:
-        # Placeholder for future implementation (subject to heat network zone data availability)
-        raise NotImplementedError(
-            f"Processing for {args.local_authorities} is not yet supported."
-        )
-
-    else:  # all GB
-        # Placeholder for future implementation
-        raise NotImplementedError("Processing for all of GB is not yet supported.")
-
-    # Save residential UPRNs with existing heat network zone and city centre labels to S3
-    save_utils.save_to_s3(
-        hn_zone_city_centre_uprn_df,
-        f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{args.local_authorities}_residential_uprns_with_hn_zones_city_centres.parquet",
-    )
+        # Save residential UPRNs with heat network zone and city centre labels to S3
+        output_path = f"s3://asf-heat-pump-suitability/local_heat_planning/outputs/{area}_residential_uprns_with_hn_zones_city_centres.parquet"
+        save_utils.save_to_s3(hn_zone_city_centre_uprn_df, output_path)
+        logger.info(f"Saved output to {output_path}")


### PR DESCRIPTION
## Summary

- Replaces `--local_authorities` with `--area` (accepting the same canonical values as `pipeline/uprns.py`: `plymouth`, `plymouth_similar`, `sampling`, `gb`)
- Loads residential UPRNs from `config["output"]["residential_uprns_template"].format(area=area)` instead of the hardcoded Plymouth path
- Attempts to load HN zone data for the area; gracefully falls back to an empty `GeoDataFrame` (with `ZoneID` column) when no data exists — so all UPRNs receive `in_hn_zone=False` instead of raising `NotImplementedError`
- Spatial signatures loading is unchanged (already GB-scale, no area filtering needed)
- Replaces `print()` with `logger.info()`
- Handles the optional `LAD23NM` column that is absent for the `gb` area
- Wraps `__main__` execution in `mock_aws_if_local()` for local dev consistency

Heat network zone data is currently only available for Plymouth (`base.yaml → data.geodata.heat_network_zones.plymouth`). Adding zone data for additional areas only requires adding a new entry in `base.yaml`.

Closes #235

## Test plan

- [ ] `python pipeline/run/heat_network_city_centres.py --area plymouth` produces output with expected `in_hn_zone` values
- [ ] `python pipeline/run/heat_network_city_centres.py --area plymouth_similar` completes without error; all `in_hn_zone = False`
- [ ] `python pipeline/run/heat_network_city_centres.py --area gb` completes without error; all `in_hn_zone = False`
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)