### PR TITLE
Fix NameError: re-add missing config import in add_features.py

### DIFF
--- a/asf_heat_pump_suitability/pipeline/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/add_features.py
@@ -18,6 +18,7 @@ import os
 import geopandas as gpd
 import polars as pl
 
+from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.config.settings import load_settings
 from asf_heat_pump_suitability.getters import load_tree_input
 from asf_heat_pump_suitability.pipeline.impute import property_type


### PR DESCRIPTION
## Summary

Restores the missing ``from asf_heat_pump_suitability import config`` import in ``pipeline/add_features.py``.

PR #239 removed it when switching the output path to ``load_settings()``. PR #245 then added ``config["data"]["geodata"]["inspire_land_registry"].get(area)`` without restoring the import, leaving every execution of ``add_features.py`` crashing immediately with:

```
NameError: name 'config' is not defined
```

Fixes #250

## Test plan
- [ ] ``uv run ruff check asf_heat_pump_suitability/pipeline/add_features.py`` passes (no F821)
- [ ] ``python pipeline/add_features.py --uprns <path> --area plymouth`` reaches the outdoor-space step without crashing
🤖 Generated with [Claude Code](https://claude.com/claude-code)