### PR TITLE
Remove stale config import from pipeline/uprns.py

### DIFF
--- a/asf_heat_pump_suitability/pipeline/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/uprns.py
@@ -21,7 +21,6 @@ import logging
 
 import polars as pl
 
-from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.config.settings import load_settings
 from asf_heat_pump_suitability.getters import load_boundaries, load_geodata, load_tree_input
 from asf_heat_pump_suitability.pipeline.transform import non_residential_entities, poi, uprns


### PR DESCRIPTION
## Summary

Removes the unused ``from asf_heat_pump_suitability import config`` import from ``pipeline/uprns.py``.

PR #239 switched the output path from ``config["output"]["residential_uprns_template"]`` to ``settings.output.residential_uprns_template``, leaving the raw dict import with nothing to do. Ruff flags it as F401, which would cause a pre-commit failure on any future PR that touches this file.

Fixes #251

## Test plan
- [ ] ``uv run ruff check asf_heat_pump_suitability/pipeline/uprns.py`` passes (no F401)
- [ ] ``python pipeline/uprns.py --area plymouth`` completes without ImportError

🤖 Generated with [Claude Code](https://claude.com/claude-code)