### PR TITLE
fix(#223): use settings instead of raw config in add_features.py

### DIFF
--- a/asf_heat_pump_suitability/config/settings.py
+++ b/asf_heat_pump_suitability/config/settings.py
@@ -24,6 +24,7 @@ class GeoDataPaths(BaseSettings):
     boundaries: dict
     heat_network_zones: dict
     gb_spatial_signatures: dict
+    inspire_land_registry: dict = Field(default_factory=dict)
 
     model_config = {"extra": "allow"}
 

--- a/asf_heat_pump_suitability/pipeline/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/add_features.py
@@ -18,7 +18,6 @@ import os
 import geopandas as gpd
 import polars as pl
 
-from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.config.settings import load_settings
 from asf_heat_pump_suitability.getters import load_tree_input
 from asf_heat_pump_suitability.pipeline.impute import property_type
@@ -76,7 +75,7 @@ def run(uprns_path: str, area: str = "plymouth") -> None:
 
     # Derive grid squares and INSPIRE path from area config
     grid_squares, _ = get_area_config(area)
-    inspire_path = config["data"]["geodata"]["inspire_land_registry"].get(area)
+    inspire_path = settings.data.geodata.inspire_land_registry.get(area)
 
     # Load UPRN data
     logger.info(f"Loading domestic UPRNs from: {uprns_path}")


### PR DESCRIPTION
## Summary

- Adds `inspire_land_registry: dict = Field(default_factory=dict)` as a typed field to `GeoDataPaths` in `config/settings.py`
- Replaces the last remaining raw `config["data"]["geodata"]["inspire_land_registry"].get(area)` access in `pipeline/add_features.py` with `settings.data.geodata.inspire_land_registry.get(area)`
- Removes `from asf_heat_pump_suitability import config` from `add_features.py` — both pipeline entry-point scripts now use only `Settings`

Closes #223.

## Test plan

- [ ] Pre-commit passes (ruff, prettier)
- [ ] `settings.data.geodata.inspire_land_registry` resolves correctly from `base.yaml` for area `"plymouth"` (and returns `{}` for areas without INSPIRE data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)