### PR TITLE
fix(#234): reduce Polars↔pandas↔GeoDataFrame round-trips in add_features

### DIFF
--- a/asf_heat_pump_suitability/pipeline/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/add_features.py
@@ -18,7 +18,6 @@ import os
 import geopandas as gpd
 import polars as pl
 
-from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.config.settings import load_settings
 from asf_heat_pump_suitability.getters import load_tree_input
 from asf_heat_pump_suitability.pipeline.impute import property_type
@@ -63,6 +62,11 @@ def parse_arguments() -> argparse.Namespace:
 def run(uprns_path: str, area: str = "plymouth") -> None:
     """Add features to domestic UPRNs and write enriched dataset to S3.
 
+    Data types at each stage:
+        Input   — pl.DataFrame    (pl.read_parquet; efficient columnar reader)
+        Spatial — gpd.GeoDataFrame (one conversion at the top; all spatial ops stay here)
+        Output  — pl.DataFrame    (one pl.from_pandas() conversion before writing)
+
     Args:
         uprns_path: Path (S3 URI or local) to the domestic UPRNs parquet file.
         area: Geographic area identifier used to look up INSPIRE land-registry parcels
@@ -76,20 +80,20 @@ def run(uprns_path: str, area: str = "plymouth") -> None:
 
     # Derive grid squares and INSPIRE path from area config
     grid_squares, _ = get_area_config(area)
-    inspire_path = config["data"]["geodata"]["inspire_land_registry"].get(area)
+    inspire_path = settings.data.geodata.inspire_land_registry.get(area)
 
-    # Load UPRN data
+    # ── Input (Polars) ────────────────────────────────────────────────────────
     logger.info(f"Loading domestic UPRNs from: {uprns_path}")
     uprns_df = pl.read_parquet(uprns_path, columns=["UPRN", "X_COORDINATE", "Y_COORDINATE"])
 
-    # Convert to GeoDataFrame with BNG point geometries
+    # ── Spatial processing (GeoDataFrame throughout) ──────────────────────────
     uprns_gdf = uprns.generate_gdf_uprn_coords(df=uprns_df)
 
-    # ── Flat / apartment imputation ──────────────────────────────────────────
     flat_uprns = property_type.impute_set_flat_properties(uprns_gdf=uprns_gdf)
-    features_df = uprns_df.with_columns(pl.col("UPRN").is_in(flat_uprns).alias("property_type_flat"))
+    uprns_gdf["property_type_flat"] = uprns_gdf["UPRN"].isin(flat_uprns)
 
-    # ── Outdoor space estimation ─────────────────────────────────────────────
+    keep_cols = ["UPRN", "X_COORDINATE", "Y_COORDINATE", "property_type_flat"]
+
     if inspire_path is None:
         logger.warning(
             f"No INSPIRE land-registry data configured for area {area!r}; "
@@ -110,26 +114,19 @@ def run(uprns_path: str, area: str = "plymouth") -> None:
             building_intersections_gdf=intersection_gdf,
             land_parcels_gdf=land_parcels_gdf,
         )
-        uprns_space_df = outdoor_space.sjoin_df_uprn_to_outdoor_space(
+        uprns_gdf = outdoor_space.sjoin_df_uprn_to_outdoor_space(
             uprns_gdf=uprns_gdf,
             outdoor_space_gdf=outdoor_space_gdf,
         )
-        uprns_space_df = outdoor_space.deduplicate_df_outdoor_space(uprns_space_df)
+        uprns_gdf = outdoor_space.deduplicate_df_outdoor_space(uprns_gdf)
+        keep_cols += [
+            "NATIONALCADASTRALREFERENCE",
+            "max_contiguous_outdoor_space_area_m2",
+            "total_outdoor_space_area_m2",
+        ]
 
-        features_df = features_df.join(
-            uprns_space_df.select(
-                [
-                    "UPRN",
-                    "NATIONALCADASTRALREFERENCE",
-                    "max_contiguous_outdoor_space_area_m2",
-                    "total_outdoor_space_area_m2",
-                ]
-            ),
-            how="left",
-            on="UPRN",
-        )
-
-    # ── Save outputs ─────────────────────────────────────────────────────────
+    # ── Output: convert once to Polars before writing ─────────────────────────
+    features_df = pl.from_pandas(uprns_gdf[keep_cols])
     save_utils.save_to_s3(features_df, output_path)
     logger.info(f"Saved features for {len(features_df)} UPRNs to {output_path}")
 

--- a/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
+++ b/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
@@ -6,7 +6,6 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-import polars as pl
 
 # Maximum footprint area (m²) at which a building is treated as an outbuilding
 # (e.g. garage, shed).  30 m² is approximately the floor area of a large double garage.
@@ -153,34 +152,30 @@ def generate_gdf_outdoor_space(
     return outdoor_space_gdf
 
 
-def deduplicate_df_outdoor_space(df: pl.DataFrame) -> pl.DataFrame:
+def deduplicate_df_outdoor_space(df: pd.DataFrame) -> pd.DataFrame:
     """
     Deduplicate UPRNs matched to multiple land extents by keeping the one with the smallest total outdoor space area.
 
     Args:
-        df (pl.DataFrame): UPRNs with outdoor space estimates
+        df (pd.DataFrame): UPRNs with outdoor space estimates (may be a GeoDataFrame)
 
     Returns:
-        pl.DataFrame: deduplicated UPRNs with outdoor space estimates
+        pd.DataFrame: deduplicated UPRNs with outdoor space estimates
     """
-    df = df.with_columns(pl.col("UPRN").is_duplicated().alias("UPRN_duplicated"))
+    is_dup = df["UPRN"].duplicated(keep=False)
+    non_dup = df[~is_dup]
 
-    _deduplicated_df = (
-        df.filter(pl.col("UPRN_duplicated"))
-        .with_columns(min_total=pl.col("total_outdoor_space_area_m2").min().over("UPRN"))
-        .filter(
-            # Get smallest outdoor space
-            pl.col("total_outdoor_space_area_m2") == pl.col("min_total")
-            # Deduplicate - any duplicates will now (most likely) have the same total outdoor space
-        )
-        .unique(subset="UPRN")
-        .drop("min_total")
-    )
+    dup = df[is_dup].copy()
+    dup["_min_total"] = dup.groupby("UPRN")["total_outdoor_space_area_m2"].transform("min")
+    dup = dup[dup["total_outdoor_space_area_m2"] == dup["_min_total"]].drop(columns="_min_total")
+    dup = dup.drop_duplicates(subset="UPRN")
 
-    return pl.concat([df.filter(~pl.col("UPRN_duplicated")), _deduplicated_df]).drop("UPRN_duplicated")
+    return pd.concat([non_dup, dup], ignore_index=True)
 
 
-def sjoin_df_uprn_to_outdoor_space(uprns_gdf: gpd.GeoDataFrame, outdoor_space_gdf: gpd.GeoDataFrame) -> pl.DataFrame:
+def sjoin_df_uprn_to_outdoor_space(
+    uprns_gdf: gpd.GeoDataFrame, outdoor_space_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
     """
     Join outdoor space estimates to UPRNs. UPRNs will be assigned the outdoor space calculated for the land extent parcel
     that they are contained within.
@@ -190,8 +185,6 @@ def sjoin_df_uprn_to_outdoor_space(uprns_gdf: gpd.GeoDataFrame, outdoor_space_gd
         outdoor_space_gdf (gpd.GeoDataFrame): original land parcel polygons with calculated total and max contiguous outdoor space area (m2)
 
     Returns:
-        pl.DataFrame: UPRNs with estimated outdoor space (m2)
+        gpd.GeoDataFrame: UPRNs with estimated outdoor space (m2); geometry is the UPRN point geometry
     """
-    return pl.from_pandas(
-        uprns_gdf.sjoin(outdoor_space_gdf, how="left", predicate="within").drop(columns=["geometry", "index_right"])
-    )
+    return uprns_gdf.sjoin(outdoor_space_gdf, how="left", predicate="within").drop(columns="index_right")

--- a/tests/unit/test_transform_outdoor_space.py
+++ b/tests/unit/test_transform_outdoor_space.py
@@ -1,7 +1,7 @@
 """Unit tests for asf_heat_pump_suitability.pipeline.transform.outdoor_space."""
 
 import geopandas as gpd
-import polars as pl
+import pandas as pd
 import pytest
 from shapely.geometry import Point, box
 
@@ -59,7 +59,7 @@ def test_generate_gdf_outdoor_space_calculates_remaining_area(
 
 def test_deduplicate_df_outdoor_space_keeps_smallest_total() -> None:
     """When a UPRN matches multiple parcels, keep the one with smallest total area."""
-    df = pl.DataFrame(
+    df = pd.DataFrame(
         {
             "UPRN": [1, 1, 2],
             "NATIONALCADASTRALREFERENCE": ["A1", "B1", "C1"],
@@ -68,9 +68,10 @@ def test_deduplicate_df_outdoor_space_keeps_smallest_total() -> None:
         }
     )
     result = deduplicate_df_outdoor_space(df)
+    assert isinstance(result, pd.DataFrame)
     assert len(result) == 2
-    uprn_1_row = result.filter(pl.col("UPRN") == 1)
-    assert uprn_1_row["NATIONALCADASTRALREFERENCE"][0] == "B1"
+    uprn_1_row = result[result["UPRN"] == 1]
+    assert uprn_1_row["NATIONALCADASTRALREFERENCE"].iloc[0] == "B1"
 
 
 def test_sjoin_df_uprn_to_outdoor_space() -> None:
@@ -90,6 +91,6 @@ def test_sjoin_df_uprn_to_outdoor_space() -> None:
         crs="EPSG:27700",
     )
     result = sjoin_df_uprn_to_outdoor_space(uprns_gdf, outdoor_space_gdf)
-    assert isinstance(result, pl.DataFrame)
-    assert result.filter(pl.col("UPRN") == 1)["NATIONALCADASTRALREFERENCE"][0] == "A1"
-    assert result.filter(pl.col("UPRN") == 2)["NATIONALCADASTRALREFERENCE"][0] == "B1"
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert result[result["UPRN"] == 1]["NATIONALCADASTRALREFERENCE"].iloc[0] == "A1"
+    assert result[result["UPRN"] == 2]["NATIONALCADASTRALREFERENCE"].iloc[0] == "B1"


### PR DESCRIPTION
## Summary

Eliminates unnecessary format conversions in the `add_features` pipeline, as specified in #234.

**`outdoor_space.py`**
- `sjoin_df_uprn_to_outdoor_space` now returns `gpd.GeoDataFrame` instead of `pl.DataFrame` (removes the intermediate `pl.from_pandas()` wrapper).
- `deduplicate_df_outdoor_space` accepts `pd.DataFrame` (a GeoDataFrame subclass) and is rewritten with equivalent pandas operations, removing its `polars` dependency.
- `import polars as pl` removed (no longer used).

**`add_features.py`**
- A docstring note in `run()` documents the data type at each pipeline stage (Input → Spatial → Output).
- `property_type_flat` is added directly to `uprns_gdf` as a pandas column instead of forking a parallel Polars DataFrame.
- The entire spatial section (flat detection + outdoor space sjoin + dedup) stays in `gpd.GeoDataFrame`.
- A single `pl.from_pandas(uprns_gdf[keep_cols])` at the end converts to Polars for writing.
- Stale `from asf_heat_pump_suitability import config` import removed (also fixes #223 on this base).

**`tests/unit/test_transform_outdoor_space.py`**
- `test_deduplicate_df_outdoor_space_keeps_smallest_total`: uses `pd.DataFrame` input and pandas-style assertions.
- `test_sjoin_df_uprn_to_outdoor_space`: asserts `isinstance(result, gpd.GeoDataFrame)`.

## Test plan

- [x] `tests/unit/test_transform_outdoor_space.py` — all 4 tests pass
- [ ] Pre-commit (ruff, prettier) — passes

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)