### PR TITLE
282 implement additions domestic filtering

### DIFF
--- a/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
+++ b/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
@@ -6,6 +6,7 @@ import geopandas as gpd
 import pandas as pd
 
 from asf_heat_pump_suitability.pipeline.transform import uprns
+from asf_heat_pump_suitability import config
 
 # TODO these may need refinement for large cities where overlap with residential is possible
 NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES = [
@@ -33,7 +34,7 @@ NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES = [
 ]
 
 
-def generate_gdf_all_uprns_non_res(
+def _generate_gdf_fully_commercial_buildings(
     important_building_gdf: gpd.GeoDataFrame,
     poi_gdf: gpd.GeoDataFrame,
     uprns_gdf: gpd.GeoDataFrame,
@@ -50,31 +51,58 @@ def generate_gdf_all_uprns_non_res(
         gpd.GeoDataFrame: geometries of buildings which are in the important buildings list and have 1 UPRN in them, or in the POI list and have same number of UPRNs and POI
     """
     # join POI data to building footprints
-    poi_gdf = building_gdf.sjoin(poi_gdf, how="inner", predicate="contains").drop(
-        "index_right", axis=1
-    )
+    poi_buildings_gdf = building_gdf.sjoin(
+        poi_gdf, how="inner", predicate="contains"
+    ).drop("index_right", axis=1)
 
-    # count instances where multiple POI are located inside a building
-    poi_gdf = poi_gdf.groupby("geometry").size().reset_index(name="POI_count")
+    # count instances where multiple POI are located inside a building and convert result to gdf
+    poi_buildings_df = (
+        poi_buildings_gdf.groupby("ID")
+        .agg(POI_count=("ID", "count"), geometry=("geometry", "first"))
+        .reset_index()
+    )
+    poi_buildings_gdf = gpd.GeoDataFrame(
+        poi_buildings_df,
+        geometry=poi_buildings_df["geometry"],
+        crs=config["constant"]["target_crs"],
+    )
 
     # join important buildings and POI with all UPRNs
     important_building_gdf = important_building_gdf.sjoin(
         uprns_gdf, how="left", predicate="contains"
     ).drop("index_right", axis=1)
 
-    poi_gdf = poi_gdf.sjoin(uprns_gdf, how="left", predicate="contains").drop(
-        "index_right", axis=1
+    poi_buildings_gdf = poi_buildings_gdf.sjoin(
+        uprns_gdf, how="left", predicate="contains"
+    ).drop("index_right", axis=1)
+
+    # find number of UPRNs per building for important buildings and convert result to gdf
+    important_building_df = (
+        important_building_gdf.groupby("ID")
+        .agg(UPRN_count=("UPRN", "count"), geometry=("geometry", "first"))
+        .reset_index()
+    )
+    important_building_gdf = gpd.GeoDataFrame(
+        important_building_df,
+        geometry=important_building_df["geometry"],
+        crs=config["constant"]["target_crs"],
     )
 
-    # find number of UPRNs per building for important buildings
-    important_building_gdf = (
-        important_building_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
+    # find number of UPRNs per building for POI buildings and convert result to gdf
+    poi_buildings_df = (
+        poi_buildings_gdf.groupby("ID")
+        .agg(
+            UPRN_count=("UPRN", "count"),
+            POI_count=("POI_count", "first"),
+            geometry=("geometry", "first"),
+        )
+        .reset_index()
     )
-    # find number of UPRNs per building for POI buildings
-    uprn_counts = poi_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
-
-    # join uprn counts as a column to POI dataframe
-    poi_gdf = poi_gdf.sjoin(uprn_counts, how="left", predicate="intersects")
+    poi_buildings_gdf = gpd.GeoDataFrame(
+        poi_buildings_df,
+        geometry=poi_buildings_df["geometry"],
+        crs=config["constant"]["target_crs"],
+    )
 
     # select building footprints from important building data where UPRN count = 1
     important_building_gdf = important_building_gdf.loc[
@@ -82,11 +110,16 @@ def generate_gdf_all_uprns_non_res(
     ]
 
     # select building footprints from POI data where UPRN count = POI count
-    poi_gdf = poi_gdf.loc[poi_gdf["UPRN_count"] == poi_gdf["POI_count"]]
+    poi_buildings_gdf = poi_buildings_gdf.loc[
+        poi_buildings_gdf["UPRN_count"] == poi_buildings_gdf["POI_count"]
+    ]
 
-    non_res_uprns = pd.concat([important_building_gdf, poi_gdf])
+    # concat gdfs and keep only geometry column
+    non_domestic_buildings_gdf = pd.concat(
+        [important_building_gdf[["geometry"]], poi_buildings_gdf[["geometry"]]]
+    )
 
-    return non_res_uprns
+    return non_domestic_buildings_gdf
 
 
 def generate_gdf_non_residential_buildings(
@@ -153,11 +186,12 @@ def generate_gdf_non_residential_buildings(
         building_gdf, how="inner", predicate="within"
     )
 
-    # creating list of buildings from all important buildings and POI data with exactly 1 UPRN in them
-    all_uprns_non_res_gdf = generate_gdf_all_uprns_non_res(
+    # creating list of buildings from all important buildings and POI data with exactly 1 UPRN in them- these are likely to be fully commercial units
+    fully_commercial_buildings_gdf = _generate_gdf_fully_commercial_buildings(
         important_building_gdf=important_building_gdf,
         poi_gdf=poi_gdf,
         uprns_gdf=uprns_gdf,
+        building_gdf=building_gdf,
     )
 
     # add this to list of buildings to exclude
@@ -166,7 +200,7 @@ def generate_gdf_non_residential_buildings(
             exclude_buildings_gdf[["geometry"]],
             railway_station_gdf[["geometry"]],
             non_domestic_poi_gdf[["geometry"]],
-            all_uprns_non_res_gdf[["geometry"]],
+            fully_commercial_buildings_gdf[["geometry"]],
         ]
     )
 

--- a/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
+++ b/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
@@ -6,7 +6,6 @@ import geopandas as gpd
 import pandas as pd
 
 from asf_heat_pump_suitability.pipeline.transform import uprns
-from asf_heat_pump_suitability import config
 
 # TODO these may need refinement for large cities where overlap with residential is possible
 NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES = [
@@ -34,7 +33,7 @@ NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES = [
 ]
 
 
-def _generate_gdf_fully_commercial_buildings(
+def _generate_gdf_fully_non_domestic_buildings(
     important_building_gdf: gpd.GeoDataFrame,
     poi_gdf: gpd.GeoDataFrame,
     uprns_gdf: gpd.GeoDataFrame,
@@ -45,7 +44,7 @@ def _generate_gdf_fully_commercial_buildings(
     Args:
         important_building_gdf (gpd.GeoDataFrame): OS OpenMap Local important building footprints in area of interest
         poi_gdf (gpd.GeoDataFrame): All Points of Interest geopoints in area of interest
-        uprns_gdf (gpd.GeoDataFrame): UPRNs with point geometries in area of interest
+        uprns_gdf (gpd.GeoDataFrame): all UPRNs with point geometries in area of interest
         building_gdf (gpd.GeoDataFrame): all building footprints in area of interest
     Returns:
         gpd.GeoDataFrame: geometries of buildings which are in the important buildings list and have 1 UPRN in them, or in the POI list and have same number of UPRNs and POI
@@ -64,7 +63,7 @@ def _generate_gdf_fully_commercial_buildings(
     poi_buildings_gdf = gpd.GeoDataFrame(
         poi_buildings_df,
         geometry=poi_buildings_df["geometry"],
-        crs=config["constant"]["target_crs"],
+        crs=poi_buildings_gdf.crs,
     )
 
     # join important buildings and POI with all UPRNs
@@ -85,7 +84,7 @@ def _generate_gdf_fully_commercial_buildings(
     important_building_gdf = gpd.GeoDataFrame(
         important_building_df,
         geometry=important_building_df["geometry"],
-        crs=config["constant"]["target_crs"],
+        crs=important_building_gdf.crs,
     )
 
     # find number of UPRNs per building for POI buildings and convert result to gdf
@@ -101,7 +100,7 @@ def _generate_gdf_fully_commercial_buildings(
     poi_buildings_gdf = gpd.GeoDataFrame(
         poi_buildings_df,
         geometry=poi_buildings_df["geometry"],
-        crs=config["constant"]["target_crs"],
+        crs=poi_buildings_gdf.crs,
     )
 
     # select building footprints from important building data where UPRN count = 1
@@ -111,7 +110,7 @@ def _generate_gdf_fully_commercial_buildings(
 
     # select building footprints from POI data where UPRN count = POI count
     poi_buildings_gdf = poi_buildings_gdf.loc[
-        poi_buildings_gdf["UPRN_count"] == poi_buildings_gdf["POI_count"]
+        poi_buildings_gdf["UPRN_count"] <= poi_buildings_gdf["POI_count"]
     ]
 
     # concat gdfs and keep only geometry column
@@ -141,7 +140,7 @@ def generate_gdf_non_residential_buildings(
         non_domestic_poi_gdf (gpd.GeoDataFrame): non-domestic Points of Interest geopoints in area of interest, unlikely to be in mixed-use buildings
         poi_gdf (gpd.GeoDataFrame): All Points of Interest geopoints in area of interest
         building_gdf (gpd.GeoDataFrame): all building footprints in area of interest
-        uprns_gdf (gpd.GeoDataFrame): UPRNs with point geometries in area of interest
+        uprns_gdf (gpd.GeoDataFrame): all UPRNs with point geometries in area of interest
 
     Returns:
         gpd.GeoDataFrame: geometries of buildings which are unlikely to contain residential properties
@@ -187,7 +186,7 @@ def generate_gdf_non_residential_buildings(
     )
 
     # creating list of buildings from all important buildings and POI data with exactly 1 UPRN in them- these are likely to be fully commercial units
-    fully_commercial_buildings_gdf = _generate_gdf_fully_commercial_buildings(
+    fully_non_domestic_buildings_gdf = _generate_gdf_fully_non_domestic_buildings(
         important_building_gdf=important_building_gdf,
         poi_gdf=poi_gdf,
         uprns_gdf=uprns_gdf,
@@ -200,7 +199,7 @@ def generate_gdf_non_residential_buildings(
             exclude_buildings_gdf[["geometry"]],
             railway_station_gdf[["geometry"]],
             non_domestic_poi_gdf[["geometry"]],
-            fully_commercial_buildings_gdf[["geometry"]],
+            fully_non_domestic_buildings_gdf[["geometry"]],
         ]
     )
 

--- a/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
+++ b/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
@@ -37,6 +37,7 @@ def generate_gdf_non_residential_buildings(
     important_building_gdf: gpd.GeoDataFrame,
     railway_station_gdf: gpd.GeoDataFrame,
     poi_gdf: gpd.GeoDataFrame,
+    poi_unfiltered_gdf: gpd.GeoDataFrame,
     building_gdf: gpd.GeoDataFrame,
     uprns_gdf: gpd.GeoDataFrame,
 ) -> gpd.GeoDataFrame:
@@ -49,6 +50,7 @@ def generate_gdf_non_residential_buildings(
         important_building_gdf (gpd.GeoDataFrame): OS OpenMap Local important building footprints in area of interest
         railway_station_gdf (gpd.GeoDataFrame): OS OpenMap Local railway station point geometries in area of interest
         poi_gdf (gpd.GeoDataFrame): non-domestic Points of Interest geopoints in area of interest
+        poi_unfiltered_gdf (gpd.GeoDataFrame): All Points of Interest geopoints in area of interest
         building_gdf (gpd.GeoDataFrame): all building footprints in area of interest
         uprns_gdf (gpd.GeoDataFrame): UPRNs with point geometries in area of interest
 
@@ -63,6 +65,7 @@ def generate_gdf_non_residential_buildings(
                 important_building_gdf.crs,
                 railway_station_gdf.crs,
                 poi_gdf.crs,
+                poi_unfiltered_gdf.crs,
                 building_gdf.crs,
                 uprns_gdf.crs,
             }
@@ -86,6 +89,9 @@ def generate_gdf_non_residential_buildings(
         important_building_gdf[col].isin(NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES)
     ]
     poi_buildings_gdf = building_gdf.sjoin(poi_gdf, how="inner", predicate="contains")
+    poi_unfiltered_gdf = building_gdf.sjoin(
+        poi_unfiltered_gdf, how="inner", predicate="contains"
+    ).drop("index_right", axis=1)
 
     # Get buildings which are railway stations (railway stations are only given as point geometries)
     railway_station_gdf = railway_station_gdf.sjoin(
@@ -97,6 +103,39 @@ def generate_gdf_non_residential_buildings(
             exclude_buildings_gdf[["geometry"]],
             railway_station_gdf[["geometry"]],
             poi_buildings_gdf[["geometry"]],
+        ]
+    )
+
+    # creating list of buildings from all important buildings and POI data with exactly 1 UPRN in them
+
+    # join unfiltered important buildings and POI with all UPRNs
+    important_building_gdf = important_building_gdf.sjoin(
+        uprns_gdf, how="left", predicate="contains"
+    ).drop("index_right", axis=1)
+    poi_unfiltered_gdf = poi_unfiltered_gdf.sjoin(
+        uprns_gdf, how="left", predicate="contains"
+    ).drop("index_right", axis=1)
+
+    # find number of UPRNs per building
+    important_building_gdf = (
+        important_building_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
+    )
+    poi_unfiltered_gdf = (
+        poi_unfiltered_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
+    )
+
+    # select buildings with 1 UPRN
+    important_building_gdf = important_building_gdf.loc[
+        important_building_gdf["UPRN_count"] == 1
+    ]
+    poi_unfiltered_gdf = poi_unfiltered_gdf.loc[poi_unfiltered_gdf["UPRN_count"] == 1]
+
+    # add this to list of buildings to exclude
+    exclude_buildings_gdf = pd.concat(
+        [
+            exclude_buildings_gdf[["geometry"]],
+            important_building_gdf[["geometry"]],
+            poi_unfiltered_gdf[["geometry"]],
         ]
     )
 

--- a/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
+++ b/asf_heat_pump_suitability/pipeline/transform/non_residential_entities.py
@@ -33,11 +33,67 @@ NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES = [
 ]
 
 
+def generate_gdf_all_uprns_non_res(
+    important_building_gdf: gpd.GeoDataFrame,
+    poi_gdf: gpd.GeoDataFrame,
+    uprns_gdf: gpd.GeoDataFrame,
+    building_gdf: gpd.GeoDataFrame,
+) -> gpd.GeoDataFrame:
+    """
+    Function to create dataframe of buildings from the important buildings with exactly 1 UPRN in them, and buildings from POI data with equal number of POI and UPRNs. These are unlikely to be residential buildings
+    Args:
+        important_building_gdf (gpd.GeoDataFrame): OS OpenMap Local important building footprints in area of interest
+        poi_gdf (gpd.GeoDataFrame): All Points of Interest geopoints in area of interest
+        uprns_gdf (gpd.GeoDataFrame): UPRNs with point geometries in area of interest
+        building_gdf (gpd.GeoDataFrame): all building footprints in area of interest
+    Returns:
+        gpd.GeoDataFrame: geometries of buildings which are in the important buildings list and have 1 UPRN in them, or in the POI list and have same number of UPRNs and POI
+    """
+    # join POI data to building footprints
+    poi_gdf = building_gdf.sjoin(poi_gdf, how="inner", predicate="contains").drop(
+        "index_right", axis=1
+    )
+
+    # count instances where multiple POI are located inside a building
+    poi_gdf = poi_gdf.groupby("geometry").size().reset_index(name="POI_count")
+
+    # join important buildings and POI with all UPRNs
+    important_building_gdf = important_building_gdf.sjoin(
+        uprns_gdf, how="left", predicate="contains"
+    ).drop("index_right", axis=1)
+
+    poi_gdf = poi_gdf.sjoin(uprns_gdf, how="left", predicate="contains").drop(
+        "index_right", axis=1
+    )
+
+    # find number of UPRNs per building for important buildings
+    important_building_gdf = (
+        important_building_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
+    )
+    # find number of UPRNs per building for POI buildings
+    uprn_counts = poi_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
+
+    # join uprn counts as a column to POI dataframe
+    poi_gdf = poi_gdf.sjoin(uprn_counts, how="left", predicate="intersects")
+
+    # select building footprints from important building data where UPRN count = 1
+    important_building_gdf = important_building_gdf.loc[
+        important_building_gdf["UPRN_count"] == 1
+    ]
+
+    # select building footprints from POI data where UPRN count = POI count
+    poi_gdf = poi_gdf.loc[poi_gdf["UPRN_count"] == poi_gdf["POI_count"]]
+
+    non_res_uprns = pd.concat([important_building_gdf, poi_gdf])
+
+    return non_res_uprns
+
+
 def generate_gdf_non_residential_buildings(
     important_building_gdf: gpd.GeoDataFrame,
     railway_station_gdf: gpd.GeoDataFrame,
+    non_domestic_poi_gdf: gpd.GeoDataFrame,
     poi_gdf: gpd.GeoDataFrame,
-    poi_unfiltered_gdf: gpd.GeoDataFrame,
     building_gdf: gpd.GeoDataFrame,
     uprns_gdf: gpd.GeoDataFrame,
 ) -> gpd.GeoDataFrame:
@@ -49,8 +105,8 @@ def generate_gdf_non_residential_buildings(
     Args:
         important_building_gdf (gpd.GeoDataFrame): OS OpenMap Local important building footprints in area of interest
         railway_station_gdf (gpd.GeoDataFrame): OS OpenMap Local railway station point geometries in area of interest
-        poi_gdf (gpd.GeoDataFrame): non-domestic Points of Interest geopoints in area of interest
-        poi_unfiltered_gdf (gpd.GeoDataFrame): All Points of Interest geopoints in area of interest
+        non_domestic_poi_gdf (gpd.GeoDataFrame): non-domestic Points of Interest geopoints in area of interest, unlikely to be in mixed-use buildings
+        poi_gdf (gpd.GeoDataFrame): All Points of Interest geopoints in area of interest
         building_gdf (gpd.GeoDataFrame): all building footprints in area of interest
         uprns_gdf (gpd.GeoDataFrame): UPRNs with point geometries in area of interest
 
@@ -64,8 +120,8 @@ def generate_gdf_non_residential_buildings(
             {
                 important_building_gdf.crs,
                 railway_station_gdf.crs,
+                non_domestic_poi_gdf.crs,
                 poi_gdf.crs,
-                poi_unfiltered_gdf.crs,
                 building_gdf.crs,
                 uprns_gdf.crs,
             }
@@ -88,56 +144,35 @@ def generate_gdf_non_residential_buildings(
     exclude_buildings_gdf = important_building_gdf[
         important_building_gdf[col].isin(NO_RESIDENTIAL_OVERLAP_BUILDING_TYPES)
     ]
-    poi_buildings_gdf = building_gdf.sjoin(poi_gdf, how="inner", predicate="contains")
-    poi_unfiltered_gdf = building_gdf.sjoin(
-        poi_unfiltered_gdf, how="inner", predicate="contains"
-    ).drop("index_right", axis=1)
+    non_domestic_poi_gdf = building_gdf.sjoin(
+        non_domestic_poi_gdf, how="inner", predicate="contains"
+    )
 
     # Get buildings which are railway stations (railway stations are only given as point geometries)
     railway_station_gdf = railway_station_gdf.sjoin(
         building_gdf, how="inner", predicate="within"
     )
 
-    exclude_buildings_gdf = pd.concat(
-        [
-            exclude_buildings_gdf[["geometry"]],
-            railway_station_gdf[["geometry"]],
-            poi_buildings_gdf[["geometry"]],
-        ]
-    )
-
     # creating list of buildings from all important buildings and POI data with exactly 1 UPRN in them
-
-    # join unfiltered important buildings and POI with all UPRNs
-    important_building_gdf = important_building_gdf.sjoin(
-        uprns_gdf, how="left", predicate="contains"
-    ).drop("index_right", axis=1)
-    poi_unfiltered_gdf = poi_unfiltered_gdf.sjoin(
-        uprns_gdf, how="left", predicate="contains"
-    ).drop("index_right", axis=1)
-
-    # find number of UPRNs per building
-    important_building_gdf = (
-        important_building_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
+    all_uprns_non_res_gdf = generate_gdf_all_uprns_non_res(
+        important_building_gdf=important_building_gdf,
+        poi_gdf=poi_gdf,
+        uprns_gdf=uprns_gdf,
     )
-    poi_unfiltered_gdf = (
-        poi_unfiltered_gdf.groupby("geometry").size().reset_index(name="UPRN_count")
-    )
-
-    # select buildings with 1 UPRN
-    important_building_gdf = important_building_gdf.loc[
-        important_building_gdf["UPRN_count"] == 1
-    ]
-    poi_unfiltered_gdf = poi_unfiltered_gdf.loc[poi_unfiltered_gdf["UPRN_count"] == 1]
 
     # add this to list of buildings to exclude
     exclude_buildings_gdf = pd.concat(
         [
             exclude_buildings_gdf[["geometry"]],
-            important_building_gdf[["geometry"]],
-            poi_unfiltered_gdf[["geometry"]],
+            railway_station_gdf[["geometry"]],
+            non_domestic_poi_gdf[["geometry"]],
+            all_uprns_non_res_gdf[["geometry"]],
         ]
     )
+
+    # Normalize to drop duplicate building footprints
+    exclude_buildings_gdf["geometry"] = exclude_buildings_gdf.normalize()
+    exclude_buildings_gdf = exclude_buildings_gdf.drop_duplicates(subset=["geometry"])
 
     # Get locations of UPRNs in domestic EPC
     include_uprns = uprns.load_set_valid_epc_uprns(epc_type="domestic")
@@ -153,6 +188,4 @@ def generate_gdf_non_residential_buildings(
         exclude_buildings_gdf["UPRN"].isnull()
     ].drop(columns=["UPRN", "index_right"])
 
-    # Normalize to drop duplicate building footprints
-    exclude_buildings_gdf["geometry"] = exclude_buildings_gdf.normalize()
-    return exclude_buildings_gdf.drop_duplicates()
+    return exclude_buildings_gdf

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -23,6 +23,7 @@ Set --save to save the outputs to S3. By default, outputs are not saved.
 """
 
 import geopandas as gpd
+import pandas as pd
 import polars as pl
 import logging
 import argparse
@@ -152,6 +153,7 @@ def map_dict_uprns_to_building_id(
     buildings_gdf: gpd.GeoDataFrame,
     id_col: str,
     predicate: str = "intersects",
+    max_distance: float = 1,
 ) -> dict:
     """
     Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within or intersect with.
@@ -162,17 +164,37 @@ def map_dict_uprns_to_building_id(
         id_col (str): name of building ID column in `buildings_gdf`
         predicate (str): how to join buildings and UPRNs. Can be one of: `intersects`, which joins UPRNs with building footprints
         they intersect with, or `within` which joins UPRNs to building footprints they are located within. Default `intersects`.
+        max_distance (float): max distance (metres) from which to join EPC UPRNs to a building footprint. Default 1m.
 
     Returns:
         dict: mapping of UPRNs to building IDs
     """
-    uprns_gdf = geo_utils.verify_gdf_crs(uprns_gdf)
-    buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
+    # uprns_gdf = geo_utils.verify_gdf_crs(uprns_gdf)
+    epc_residential_uprns = load_set_valid_epc_uprns(epc_type="domestic")
 
-    return (
-        uprns_gdf.sjoin(buildings_gdf, how="inner", predicate=predicate)
+    # set of residential UPRNs not in the domestic epc list
+    uprns_non_epc_gdf = uprns_gdf[~(uprns_gdf["UPRN"].isin(epc_residential_uprns))]
+
+    # set of residential UPRNs in the domestic epc list
+    epc_gdf = uprns_gdf[(uprns_gdf["UPRN"].isin(epc_residential_uprns))]
+
+    # join non-epc domestic UPRNs to building footprints if they are located within them
+    uprns_non_epc_gdf = (
+        uprns_non_epc_gdf.sjoin(buildings_gdf, how="inner", predicate=predicate)
         .set_index("UPRN")
         .to_dict()[id_col]
+    )
+
+    # join epc domestic UPRNs to nearest building footprint < max_distance (default 1m) away. They are usually inside a building
+    epc_gdf = (
+        epc_gdf.sjoin_nearest(buildings_gdf, how="inner", max_distance=max_distance)
+        .set_index("UPRN")
+        .to_dict()[id_col]
+    )
+    buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
+
+    return gpd.GeoDataFrame(
+        pd.concat([uprns_non_epc_gdf, epc_gdf]), crs=config["constant"]["target_crs"]
     )
 
 

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -169,7 +169,9 @@ def map_dict_uprns_to_building_id(
     Returns:
         dict: mapping of UPRNs to building IDs
     """
-    # uprns_gdf = geo_utils.verify_gdf_crs(uprns_gdf)
+    uprns_gdf = geo_utils.verify_gdf_crs(uprns_gdf)
+    buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
+
     epc_residential_uprns = load_set_valid_epc_uprns(epc_type="domestic")
 
     # set of residential UPRNs not in the domestic epc list
@@ -191,7 +193,6 @@ def map_dict_uprns_to_building_id(
         .set_index("UPRN")
         .to_dict()[id_col]
     )
-    buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
 
     return gpd.GeoDataFrame(
         pd.concat([uprns_non_epc_gdf, epc_gdf]), crs=config["constant"]["target_crs"]

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -240,6 +240,10 @@ if __name__ == "__main__":
         ).drop(columns="index_right")
 
     poi_gdf = load_tree_input.load_gdf_poi()
+    poi_unfiltered_gdf = poi.transform_gdf_poi(
+        poi_gdf,
+        filter_categories=None,
+    )
     poi_gdf = poi.transform_gdf_poi(
         poi_gdf,
         filter_categories=poi.load_set_non_domestic_poi_categories(),
@@ -256,7 +260,10 @@ if __name__ == "__main__":
     # Identify assumed non-residential buildings
     non_residential_buildings_gdf = (
         non_residential_entities.generate_gdf_non_residential_buildings(
-            **layers, poi_gdf=poi_gdf, uprns_gdf=uprns_gdf
+            **layers,
+            poi_gdf=poi_gdf,
+            poi_unfiltered_gdf=poi_unfiltered_gdf,
+            uprns_gdf=uprns_gdf,
         )
     )
 

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -180,7 +180,7 @@ def map_dict_uprns_to_building_id(
     )
 
     # find domestic UPRNs not joined to a buildings.
-    unmatched_uprns = uprns_gdf[~uprns_gdf.index.isin(uprns_inside_buildings.index)]
+    unmatched_uprns = uprns_gdf[~uprns_gdf["UPRN"].isin(uprns_inside_buildings)]
 
     # for these UPRNs only, find nearest building footprint < max_distance (m) away
     nearest_buildings_uprns = unmatched_uprns.sjoin_nearest(

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -156,7 +156,7 @@ def map_dict_uprns_to_building_id(
     max_distance: float = 1,
 ) -> dict:
     """
-    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within or intersect with.
+    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within or intersect with, or the nearest building < 1m away if not located within a building.
 
     Args:
         uprns_gdf (gpd.GeoDataFrame): UPRNs with geospatial point data
@@ -164,7 +164,7 @@ def map_dict_uprns_to_building_id(
         id_col (str): name of building ID column in `buildings_gdf`
         predicate (str): how to join buildings and UPRNs. Can be one of: `intersects`, which joins UPRNs with building footprints
         they intersect with, or `within` which joins UPRNs to building footprints they are located within. Default `intersects`.
-        max_distance (float): max distance (metres) from which to join EPC UPRNs to a building footprint. Default 1m.
+        max_distance (float): max distance (metres) from which to join UPRNs to a building footprint. Default 1m.
 
     Returns:
         dict: mapping of UPRNs to building IDs
@@ -172,31 +172,29 @@ def map_dict_uprns_to_building_id(
     uprns_gdf = geo_utils.verify_gdf_crs(uprns_gdf)
     buildings_gdf = geo_utils.verify_gdf_crs(buildings_gdf)
 
-    epc_residential_uprns = load_set_valid_epc_uprns(epc_type="domestic")
+    # join domestic UPRNs to either the building footprint they are located within or building < max_distance (default 1m) away. They are usually inside a building.
 
-    # set of residential UPRNs not in the domestic epc list
-    uprns_non_epc_gdf = uprns_gdf[~(uprns_gdf["UPRN"].isin(epc_residential_uprns))]
+    # first find domestic UPRNs inside buildings to speed up computation time.
+    uprns_inside_buildings = uprns_gdf.sjoin(
+        buildings_gdf, how="inner", predicate="intersects"
+    )
 
-    # set of residential UPRNs in the domestic epc list
-    epc_gdf = uprns_gdf[(uprns_gdf["UPRN"].isin(epc_residential_uprns))]
+    # find domestic UPRNs not joined to a buildings.
+    unmatched_uprns = uprns_gdf[~uprns_gdf.index.isin(uprns_inside_buildings.index)]
 
-    # join non-epc domestic UPRNs to building footprints if they are located within them
-    uprns_non_epc_gdf = (
-        uprns_non_epc_gdf.sjoin(buildings_gdf, how="inner", predicate=predicate)
+    # for these UPRNs only, find nearest building footprint < max_distance (m) away
+    nearest_buildings_uprns = unmatched_uprns.sjoin_nearest(
+        buildings_gdf, how="inner", max_distance=max_distance
+    )
+
+    # combine the two gdfs and turn into a dictionary
+    uprns_building_dict = (
+        (pd.concat([uprns_inside_buildings, nearest_buildings_uprns]))
         .set_index("UPRN")
         .to_dict()[id_col]
     )
 
-    # join epc domestic UPRNs to nearest building footprint < max_distance (default 1m) away. They are usually inside a building
-    epc_gdf = (
-        epc_gdf.sjoin_nearest(buildings_gdf, how="inner", max_distance=max_distance)
-        .set_index("UPRN")
-        .to_dict()[id_col]
-    )
-
-    return gpd.GeoDataFrame(
-        pd.concat([uprns_non_epc_gdf, epc_gdf]), crs=config["constant"]["target_crs"]
-    )
+    return uprns_building_dict
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -263,11 +261,11 @@ if __name__ == "__main__":
         ).drop(columns="index_right")
 
     poi_gdf = load_tree_input.load_gdf_poi()
-    poi_unfiltered_gdf = poi.transform_gdf_poi(
+    poi_gdf = poi.transform_gdf_poi(
         poi_gdf,
         filter_categories=None,
     )
-    poi_gdf = poi.transform_gdf_poi(
+    non_domestic_poi_gdf = poi.transform_gdf_poi(
         poi_gdf,
         filter_categories=poi.load_set_non_domestic_poi_categories(),
     )
@@ -284,8 +282,8 @@ if __name__ == "__main__":
     non_residential_buildings_gdf = (
         non_residential_entities.generate_gdf_non_residential_buildings(
             **layers,
+            non_domestic_poi_gdf=non_domestic_poi_gdf,
             poi_gdf=poi_gdf,
-            poi_unfiltered_gdf=poi_unfiltered_gdf,
             uprns_gdf=uprns_gdf,
         )
     )


### PR DESCRIPTION
---

# Description
Implements the following changes to the domestic filtering pipeline:

- Add a step to the domestic filtering that says if building intersects with an important buildings / POI lists (any category) and has exactly 1 UPRN, filter the building out. This happens in `non_residential_entities.py` in the function `generate_gdf_non_residential_buildings`. I take the unfiltered POI and important buildings lists, join them to the UPRNs and find buildings that have 1 UPRN in them. I think add these to the non residential gdf. UPRNs in the domestic EPC data are then removed in the step after. This then gets implemented in `uprns.py`

- After joining EPC domestic properties to building footprints, for any domestic EPC UPRNs which have not been joined to a building, join them to the nearest footprint <1m away. This happens in `uprns.py` in the function `map_dict_uprns_to_building_id`. I've added a step which uses a mask of EPC UPRNs to select domestic UPRNs that are in / not in the EPC list. I then `sjoin` UPRNs not in EPC list to building footprints if they are contained within them. I `sjoin.nearest` the UPRNs in the EPC list to buildings < 1m away. Note for most of them, this should be the building they are contained within. This function is then implemented in `add_features.py` . 

Fixes #282 

# Instructions for Reviewer

In order to test the code in this PR you need to run `uprns.py` and `add_features.py`. 

Please pay special attention to
I think that having the EPC buildings joined to buildings < 1m away in `add_features.py` is the right place to do it but let me know if there is anywhere else in the pipeline this should be implemented

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
