### PR TITLE
297 add uprn density threshold

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -34,6 +34,8 @@ data:
     plymouth_residential_uprns: "s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet"
 
 constant:
+  threshold:
+    m2_per_predicted_UPRN: 261.608136 # Identified by analysis in /research/exploratory/domestic_filtering/domestic_building_identification_threshold_selection.py
   plymouth:
     la_names: "Plymouth"
     grid_squares: "SX"

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -34,8 +34,13 @@ data:
     plymouth_residential_uprns: "s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth_residential_uprns.parquet"
 
 constant:
+  id:
+    building: "ID"
   threshold:
     m2_per_predicted_UPRN: 261.608136 # Identified by analysis in /research/exploratory/domestic_filtering/domestic_building_identification_threshold_selection.py
+    outdoor_space_threshold_m2:
+      within_hn_zone: 70
+      outside_hn_zone: 30
   plymouth:
     la_names: "Plymouth"
     grid_squares: "SX"
@@ -91,9 +96,6 @@ constant:
     la_names: "Cardiff"
     grid_squares: "ST"
   target_crs: 27700 # British National Grid
-  outdoor_space_threshold_m2:
-    within_hn_zone: 70
-    outside_hn_zone: 30
   tech_types:
     individual: "Individual solution"
     networked: "Networked heat pump"

--- a/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
+++ b/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
@@ -32,7 +32,9 @@ from asf_heat_pump_suitability.getters.load_tree_input import (
 )
 from asf_heat_pump_suitability import config
 
-OUTDOOR_SPACE_THRESHOLD_M2 = config["constant"]["outdoor_space_threshold_m2"]
+OUTDOOR_SPACE_THRESHOLD_M2 = config["constant"]["threshold"][
+    "outdoor_space_threshold_m2"
+]
 TECH_TYPES = config["constant"]["tech_types"]
 
 

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -177,7 +177,7 @@ def _generate_gdf_non_domestic_buildings_by_density(
     domestic_uprns_gdf: gpd.GeoDataFrame,
     buildings_gdf: gpd.GeoDataFrame,
     id_col: str,
-    threshold: float = config["threshold"]["m2_per_predicted_UPRN"],
+    threshold: float = config["constant"]["threshold"]["m2_per_predicted_UPRN"],
 ) -> gpd.GeoDataFrame:
     """
     Generate a GeoDataFrame containing footprints of buildings which contain a UPRN predicted to be domestic and have a

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -138,7 +138,7 @@ def filter_gdf_domestic_uprns(
     )
 
     # Get valid residential UPRNs
-    epc_residential_uprns = load_set_valid_epc_uprns(epc_type="domestic")
+    domestic_epc_uprns = load_set_valid_epc_uprns(epc_type="domestic")
 
     domestic_uprn_gdf = uprn_gdf[
         (
@@ -147,7 +147,7 @@ def filter_gdf_domestic_uprns(
             & (uprn_gdf["UPRN"].isin(uprns_in_buildings))
         )
         # Or UPRNs which are in domestic EPC register
-        | (uprn_gdf["UPRN"].isin(epc_residential_uprns))
+        | (uprn_gdf["UPRN"].isin(domestic_epc_uprns))
     ]
 
     # TODO this could be updated to a classification model and scaled
@@ -157,15 +157,16 @@ def filter_gdf_domestic_uprns(
         non_domestic_buildings_gdf = _generate_gdf_non_domestic_buildings_by_density(
             domestic_uprns_gdf=domestic_uprn_gdf,
             buildings_gdf=buildings_gdf,
+            epc_uprns=domestic_epc_uprns,
             id_col=id_col,
         )
 
-        # Remove UPRNs in these buildings from the domestic subset UNLESS they are in the domestic EPC register
+        # Remove UPRNs in these buildings from the domestic subset
         non_domestic_uprns = set(
             uprn_gdf.sjoin(
                 non_domestic_buildings_gdf, how="inner", predicate="intersects"
             )["UPRN"]
-        ).difference(epc_residential_uprns)
+        )
 
         return domestic_uprn_gdf[~domestic_uprn_gdf["UPRN"].isin(non_domestic_uprns)]
 
@@ -176,6 +177,7 @@ def filter_gdf_domestic_uprns(
 def _generate_gdf_non_domestic_buildings_by_density(
     domestic_uprns_gdf: gpd.GeoDataFrame,
     buildings_gdf: gpd.GeoDataFrame,
+    epc_uprns: set,
     id_col: str,
     threshold: float = config["constant"]["threshold"]["m2_per_predicted_UPRN"],
 ) -> gpd.GeoDataFrame:
@@ -189,6 +191,7 @@ def _generate_gdf_non_domestic_buildings_by_density(
     Args:
         domestic_uprns_gdf (gpd.GeoDataFrame): UPRNs which are assumed to represent domestic properties with their point geometries.
         buildings_gdf (gpd.GeoDataFrame): all building footprints in area of interest.
+        epc_uprns (str): UPRNs with a domestic EPC record.
         id_col (str): name of ID column in `buildings_gdf`. Defaults to ID column defined in config.
         threshold (float): threshold for `m2_per_predicted_UPRN` above which a building is considered to be non-domestic.
 
@@ -200,6 +203,9 @@ def _generate_gdf_non_domestic_buildings_by_density(
         domestic_uprns_gdf[["UPRN", "geometry"]], how="inner", predicate="contains"
     ).drop(columns="index_right")
 
+    # Identify EPC UPRNs
+    _buildings_gdf["domestic_epc"] = _buildings_gdf["UPRN"].isin(epc_uprns)
+
     # Get building area
     _buildings_gdf["footprint_area_m2"] = _buildings_gdf.area
 
@@ -207,12 +213,16 @@ def _generate_gdf_non_domestic_buildings_by_density(
     _buildings_gdf = (
         _buildings_gdf.groupby(id_col)
         .agg(
+            contains_epc=("domestic_epc", "max"),
             predicted_UPRN_count=("UPRN", "count"),
             footprint_area_m2=("footprint_area_m2", "first"),
             geometry=("geometry", "first"),
         )
         .reset_index()
     )
+
+    # Remove buildings containing a domestic EPC record
+    _buildings_gdf = _buildings_gdf[~_buildings_gdf["contains_epc"]]
 
     # Calculate density measure
     _buildings_gdf["m2_per_predicted_UPRN"] = (

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -108,7 +108,11 @@ def filter_gdf_domestic_uprns(
     """
     Filter UPRNs to domestic UPRNs only by retaining UPRNs which appear in domestic EPC register, OR are located within
     a building footprint AND are not in the commercial EPC register and / or a building type that is unlikely to contain
-    residential properties, e.g. hospital, train station, museum etc.
+    residential properties, e.g. hospital, train station, museum etc, AND (for Plymouth only) are in a building with
+    `m2_per_predicted_UPRN` below a defined threshold.
+
+    See analysis in /research/exploratory/domestic_filtering/domestic_building_identification_threshold_selection.py for
+    threshold selection for Plymouth.
 
     Args:
         uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be filtered.
@@ -184,12 +188,14 @@ def _generate_gdf_non_domestic_buildings_by_density(
     """
     Generate a GeoDataFrame containing footprints of buildings which contain a UPRN predicted to be domestic and have a
     `m2_per_predicted_UPRN` value above the defined threshold. The aim of this function is to remove some of the true
-    non-domestic buildings mislabelled as domestic by removing those with large building footprints and low UPRN density.
+    non-domestic buildings mislabelled as domestic by removing those with large building footprints and low UPRN density,
+    unless they contain a UPRN with a domestic EPC record.
+
     The threshold selected as default (set in config) was determined through analysis that can be found in
     asf_heat_pump_suitability/research/exploratory/domestic_filtering/domestic_building_identification_threshold_selection.py
 
     Args:
-        domestic_uprns_gdf (gpd.GeoDataFrame): UPRNs which are assumed to represent domestic properties with their point geometries.
+        domestic_uprns_gdf (gpd.GeoDataFrame): UPRNs which are predicted by the pipeline to represent domestic properties with their point geometries.
         buildings_gdf (gpd.GeoDataFrame): all building footprints in area of interest.
         epc_uprns (str): UPRNs with a domestic EPC record.
         id_col (str): name of ID column in `buildings_gdf`. Defaults to ID column defined in config.

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -333,6 +333,7 @@ if __name__ == "__main__":
         uprn_gdf=uprns_gdf,
         buildings_gdf=layers["building_gdf"],
         non_residential_buildings_gdf=non_residential_buildings_gdf,
+        local_authority=args.local_authorities.lower(),
     )
 
     # Save residential UPRNs to S3

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -199,20 +199,31 @@ def _generate_gdf_non_domestic_buildings_by_density(
     _buildings_gdf = buildings_gdf.sjoin(
         domestic_uprns_gdf[["UPRN", "geometry"]], how="inner", predicate="contains"
     ).drop(columns="index_right")
+
     # Get building area
-    _buildings_gdf["building_area_m2"] = _buildings_gdf.area
+    _buildings_gdf["footprint_area_m2"] = _buildings_gdf.area
+
     # Get predicted domestic UPRN count per building
     _buildings_gdf = (
         _buildings_gdf.groupby(id_col)
-        .agg(predicted_UPRN_count=("UPRN", "count"))
+        .agg(
+            predicted_UPRN_count=("UPRN", "count"),
+            footprint_area_m2=("footprint_area_m2", "first"),
+            geometry=("geometry", "first"),
+        )
         .reset_index()
     )
+
     # Calculate density measure
     _buildings_gdf["m2_per_predicted_UPRN"] = (
         _buildings_gdf["footprint_area_m2"] / _buildings_gdf["predicted_UPRN_count"]
     )
     # Return buildings with density measure above threshold
-    return _buildings_gdf[_buildings_gdf["m2_per_predicted_UPRN"] > threshold].copy()
+    return gpd.GeoDataFrame(
+        _buildings_gdf[_buildings_gdf["m2_per_predicted_UPRN"] > threshold].copy(),
+        geometry="geometry",
+        crs=27700,
+    )
 
 
 def map_dict_uprns_to_building_id(

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -98,24 +98,28 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
     return set(df["UPRN"])
 
 
-def filter_gdf_residential_uprns(
+def filter_gdf_domestic_uprns(
     uprn_gdf: gpd.GeoDataFrame,
     buildings_gdf: gpd.GeoDataFrame,
     non_residential_buildings_gdf: gpd.GeoDataFrame,
+    local_authority: str,
+    id_col: str = config["constant"]["id"]["building"],
 ) -> gpd.GeoDataFrame:
     """
-    Filter UPRNs to residential UPRNs only by retaining UPRNs which appear in domestic EPC register, OR are located within
+    Filter UPRNs to domestic UPRNs only by retaining UPRNs which appear in domestic EPC register, OR are located within
     a building footprint AND are not in the commercial EPC register and / or a building type that is unlikely to contain
     residential properties, e.g. hospital, train station, museum etc.
 
     Args:
-        uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be filtered
-        building_gdf (gpd.GeoDataFrame): all building footprints in area of interest
+        uprn_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be filtered.
+        buildings_gdf (gpd.GeoDataFrame): all building footprints in area of interest.
         non_residential_buildings_gdf (gpd.GeoDataFrame): polygons of buildings which are unlikely to contain residential
-        properties
+        properties.
+        local_authority (str): name of local authority the domestic UPRNs are being identified for.
+        id_col (str): name of ID column in `buildings_gdf`. Defaults to ID column defined in config.
 
     Returns:
-        gpd.GeoDataFrame: UPRNs which are assumed to represent residential properties with their point geometries
+        gpd.GeoDataFrame: UPRNs which are assumed to represent domestic properties with their point geometries
     """
     print("Filtering to residential UPRNs...")
     # Find UPRNs which are in the non-residential buildings
@@ -136,7 +140,7 @@ def filter_gdf_residential_uprns(
     # Get valid residential UPRNs
     epc_residential_uprns = load_set_valid_epc_uprns(epc_type="domestic")
 
-    return uprn_gdf[
+    domestic_uprn_gdf = uprn_gdf[
         (
             # Filter to UPRNs which are in buildings AND not in non-residential UPRNs list
             (~uprn_gdf["UPRN"].isin(non_residential_uprns))
@@ -145,6 +149,70 @@ def filter_gdf_residential_uprns(
         # Or UPRNs which are in domestic EPC register
         | (uprn_gdf["UPRN"].isin(epc_residential_uprns))
     ]
+
+    # TODO this could be updated to a classification model and scaled
+    # This triggers for Plymouth only as the threshold density was calculated from Plymouth data only
+    if local_authority.lower() == "plymouth":
+        # Identify large buildings with low UPRN density which will be labelled non-domestic
+        non_domestic_buildings_gdf = _generate_gdf_non_domestic_buildings_by_density(
+            domestic_uprns_gdf=domestic_uprn_gdf,
+            buildings_gdf=buildings_gdf,
+            id_col=id_col,
+        )
+
+        # Remove UPRNs in these buildings from the domestic subset UNLESS they are in the domestic EPC register
+        non_domestic_uprns = set(
+            uprn_gdf.sjoin(
+                non_domestic_buildings_gdf, how="inner", predicate="intersects"
+            )["UPRN"]
+        ).difference(epc_residential_uprns)
+
+        return domestic_uprn_gdf[~domestic_uprn_gdf["UPRN"].isin(non_domestic_uprns)]
+
+    else:
+        return domestic_uprn_gdf
+
+
+def _generate_gdf_non_domestic_buildings_by_density(
+    domestic_uprns_gdf: gpd.GeoDataFrame,
+    buildings_gdf: gpd.GeoDataFrame,
+    id_col: str,
+    threshold: float = config["threshold"]["m2_per_predicted_UPRN"],
+) -> gpd.GeoDataFrame:
+    """
+    Generate a GeoDataFrame containing footprints of buildings which contain a UPRN predicted to be domestic and have a
+    `m2_per_predicted_UPRN` value above the defined threshold. The aim of this function is to remove some of the true
+    non-domestic buildings mislabelled as domestic by removing those with large building footprints and low UPRN density.
+    The threshold selected as default (set in config) was determined through analysis that can be found in
+    asf_heat_pump_suitability/research/exploratory/domestic_filtering/domestic_building_identification_threshold_selection.py
+
+    Args:
+        domestic_uprns_gdf (gpd.GeoDataFrame): UPRNs which are assumed to represent domestic properties with their point geometries.
+        buildings_gdf (gpd.GeoDataFrame): all building footprints in area of interest.
+        id_col (str): name of ID column in `buildings_gdf`. Defaults to ID column defined in config.
+        threshold (float): threshold for `m2_per_predicted_UPRN` above which a building is considered to be non-domestic.
+
+    Returns:
+        gpd.GeoDataFrame: footprints of buildings containing predicted domestic UPRNs but likely to be non-domestic
+    """
+    # Join predicted domestic UPRNs to buildings
+    _buildings_gdf = buildings_gdf.sjoin(
+        domestic_uprns_gdf[["UPRN", "geometry"]], how="inner", predicate="contains"
+    ).drop(columns="index_right")
+    # Get building area
+    _buildings_gdf["building_area_m2"] = _buildings_gdf.area
+    # Get predicted domestic UPRN count per building
+    _buildings_gdf = (
+        _buildings_gdf.groupby(id_col)
+        .agg(predicted_UPRN_count=("UPRN", "count"))
+        .reset_index()
+    )
+    # Calculate density measure
+    _buildings_gdf["m2_per_predicted_UPRN"] = (
+        _buildings_gdf["footprint_area_m2"] / _buildings_gdf["predicted_UPRN_count"]
+    )
+    # Return buildings with density measure above threshold
+    return _buildings_gdf[_buildings_gdf["m2_per_predicted_UPRN"] > threshold].copy()
 
 
 def map_dict_uprns_to_building_id(
@@ -260,8 +328,8 @@ if __name__ == "__main__":
         )
     )
 
-    # Filter UPRNs to assumed residential only
-    residential_uprns_gdf = filter_gdf_residential_uprns(
+    # Filter UPRNs to assumed domestic only
+    domestic_uprns_gdf = filter_gdf_domestic_uprns(
         uprn_gdf=uprns_gdf,
         buildings_gdf=layers["building_gdf"],
         non_residential_buildings_gdf=non_residential_buildings_gdf,
@@ -269,7 +337,7 @@ if __name__ == "__main__":
 
     # Save residential UPRNs to S3
     df = pl.from_pandas(
-        residential_uprns_gdf[
+        domestic_uprns_gdf[
             [
                 "UPRN",
                 "X_COORDINATE",


### PR DESCRIPTION
Fixes #290 

# Description

Based on the analysis in PR #298 , this PR adds a new step to the domestic UPRN identification pipeline which removes buildings not containing domestic EPC records and which have a `m2_per_predicted_UPRN` value above the threshold identified in the analysis. These buildings are thought to be mostly non-domestic.

Modified files:
- asf_heat_pump_suitability/pipeline/transform/uprns.py - add new logic to exclude additional buildings as above.
- asf_heat_pump_suitability/config/base.yaml - add new threshold to config and move existing thresholds into the new `threshold` key.
- asf_heat_pump_suitability/pipeline/transform/decision_tree.py - update existing threshold to use new config key

# Instructions for Reviewer

In order to test the code in this PR you need to ...
run the following line in your terminal:
`python -i asf_heat_pump_suitability/pipeline/transform/uprns.py --local_authorities plymouth`
You can then interact with the output dataframe `df` to inspect it. Please could you take a look and flag if you notice anything strange. You can compare it to the current `dev` outputs of the UPRN filtering:
`original_df = pl.read_parquet("s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth/plymouth_residential_uprns.parquet")`

If you prefer to do it in a notebook instead of interactive mode, you can also load the updated pipeline outputs from this file:
`s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth/plymouth_residential_uprns_test.parquet`

I did my own comparison and will send you the results on slack.

Please pay special attention to ...
- The logic of the newly implemented filtering step. Is it applied correctly and in the right place?

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
