### PR TITLE
302 Reduce cluster file size

### DIFF
--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -249,7 +249,9 @@ def _clip_gdf_voronoi_cells_polygon_buffer(
     """
     # Create a buffered polygon for all polygons
     buffered_gdf = polygon_gdf[[id_col, "geometry"]].copy()
-    buffered_gdf["geometry"] = buffered_gdf.geometry.buffer(buffer)
+    buffered_gdf["geometry"] = buffered_gdf.geometry.buffer(
+        buffer, join_style=2, mitre_limit=2
+    ).simplify(0.001)
 
     # Clip Voronoi cells to the defined buffer area if they are larger than it by calculating intersections
     clipped_gdf = voronoi_gdf.overlay(buffered_gdf, how="intersection")
@@ -320,28 +322,25 @@ def _handle_gdf_fragmented_cells(
     Returns:
         gpd.GeoDataFrame: domestic building cells with overlapping physical barriers removed and cell fragments handled
     """
-    # Reduce the polygons by 1cm to avoid unions of touching cells
-    # Then union cells with building footprints
-    union = pd.concat(
-        [cells_gdf["geometry"].buffer(-0.01), tech_gdf["geometry"].buffer(-0.01)]
-    ).unary_union
+    # Add a temporary ID for each building
+    id_col = "_internal_building_id"
+    tech_gdf[id_col] = np.arange(len(tech_gdf))
+    cols = [id_col, "geometry"]
 
-    # Explode union to get one unionised polygon per building
-    union_gdf = gpd.GeoDataFrame(
-        geometry=gpd.GeoSeries(union).explode(index_parts=False),
-        crs=config["constant"]["target_crs"],
+    # Keep only cell fragments that intersect with a building and label with the ID of the building
+    cells_gdf = cells_gdf.sjoin(
+        tech_gdf[cols], how="inner", predicate="intersects"
+    ).drop(columns=["index_right"])
+
+    # Dissolve building footprints and their cell fragments together
+    union_gdf = (
+        pd.concat([cells_gdf[cols], tech_gdf[cols]])
+        .dissolve(by=id_col)
+        .rename(columns={"geometry": "unionised_geometry"})
     )
-
-    # Add 1cm buffer back so that dissolving works later
-    union_gdf["geometry"] = union_gdf["geometry"].buffer(0.01)
-
-    # Retain original unionised cell geometry - this will be the final geometry per building unless it's missing
-    union_gdf["unionised_geometry"] = union_gdf["geometry"]
 
     # Join unionised cells back to original buildings
-    cells_gdf = tech_gdf.sjoin(union_gdf, how="left", predicate="intersects").drop(
-        columns=["index_right"]
-    )
+    cells_gdf = tech_gdf.merge(union_gdf, how="left", on=id_col)
 
     # If building is missing a Voronoi cell (due to overlay operation), then assign it the building footprint geometry
     # This happens in some edge cases
@@ -351,9 +350,9 @@ def _handle_gdf_fragmented_cells(
 
     # Keep the Voronoi cell geometries, filled with building footprints
     return (
-        cells_gdf.drop(columns="geometry")
+        cells_gdf.drop(columns=["geometry", id_col])
         .rename(columns={"unionised_geometry": "geometry"})
-        .set_geometry("geometry", crs=config["constant"]["target_crs"])
+        .set_geometry("geometry", crs=cells_gdf.crs)
     )
 
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -250,7 +250,11 @@ def _clip_gdf_voronoi_cells_polygon_buffer(
     # Create a buffered polygon for all polygons
     buffered_gdf = polygon_gdf[[id_col, "geometry"]].copy()
     buffered_gdf["geometry"] = buffered_gdf.geometry.buffer(
-        buffer, join_style=2, mitre_limit=2
+        # Use mitre join_style which reduces densification of corner vertices when buffering
+        buffer,
+        join_style=2,
+        mitre_limit=2,
+        # Simplify with a tolerance of 1mm to remove vertices which are extremely close together
     ).simplify(0.001)
 
     # Clip Voronoi cells to the defined buffer area if they are larger than it by calculating intersections


### PR DESCRIPTION
Fixes #302 

# Description

This fixes the file size problem related to the clustering. The new file size with these changes is 48MB.

The issue was caused by a line in the function to handle Voronoi cell fragments that was adding a buffer to the Voronoi polygons of 1cm. This step was approx doubling the total number of vertices in the geodataframe. The buffering process can add loads of points at the corners of a polygon through densification to ensure rounded corners. This can be addressed by using buffer with `join_style=2` which gives mitre corners and by simplifying the resulting buffered polygons with a very low tolerance (e.g. 1mm).

However, I applied a new methodology entirely to remove use of the buffer. As well as size reduction of the final file, the new methodology is simpler and therefore gives significant speed gains.

Modified files:
- `asf_heat_pump_suitability/pipeline/cluster/cluster.py` - update the function to handle cell fragments to use a series of `sjoin`s to handle fragments, rather than a buffer.

# Instructions for Reviewer

In order to test the code in this PR you need to ...
run the following line in your terminal:
`python asf_heat_pump_suitability/pipeline/cluster/cluster.py --local_authorities plymouth`

I have run it and saved the results to s3 and it all worked.

Please could you review the resulting geodataframe and let me know if you see anything strange. I have inspected and plotted it and it looks ok to me but have not plotted with folium to look in detail at the clusters.

```
import geopandas as gpd
clusters_gdf = gpd.read_file("s3://asf-heat-pump-suitability/local_heat_planning/outputs/plymouth/plymouth_clustered_tech_polygons.geojson")
colour_mapping = {
    "Communal solution" : "red",
    "District heat network" : "green",
    "Individual solution" : "blue",
    "Networked heat pump" : "purple",
}
clusters_gdf["colour"] = clusters_gdf["assigned_tech"].map(colour_mapping)
clusters_gdf.plot(color=clusters_gdf['colour'])
```

Please pay special attention to ...
The logic of the new function. Let me know if the purpose of the function is not clear from the documentation and I can explain further what it's supposed to be doing.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
