### PR TITLE
300 Append Heat Network zones to clusters_gdf

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -17,7 +17,7 @@ data:
 
     heat_network_zones:
       # Plymouth Heat Network zones
-      plymouth: "s3://asf-heat-pump-suitability/local_heat_planning/plymouth_inputs/NMR3 Heat Network Zones (Post-Ref).gpkg"
+      plymouth: "s3://asf-heat-pump-suitability/heat_network_desnz_data/heat-network-zone-map-Plymouth.gpkg"
       greater_manchester_las: "s3://asf-heat-pump-suitability/heat_network_desnz_data/heat-network-zone-map-Greater-Manchester.gpkg"
 
     gb_spatial_signatures:

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -50,7 +50,7 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
     Args:
         local_authority (str): Local Authority or Local Authorities to load Heat Network zone polygons for.
         e.g. `plymouth` for Plymouth Local Authority; `greater_manchester_las` for Greater Manchester Combined Authority (all 10 LAs in Greater Manchester).
-        See config/base.yaml for options.
+        See config/base.yaml under the `constant` key for options.
 
         **kwargs for `gpd.read_file()`
 
@@ -58,7 +58,8 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
         gpd.GeoDataFrame: polygons of heat network zones in given Local Authority.
     """
 
-    # TODO: this will currently only work for HN zone files defined in config/base.yaml. We need to change this to make it work for all other HN zone files,
+    # TODO: this will currently only work for HN zone files defined in config/base.yaml.
+    # We need to change this to make it work for all other HN zone files,
     # for example by concatenating all HN zone files and checking if the geometries intersect with the local authority boundary.
 
     gdf = gpd.GeoDataFrame()
@@ -72,17 +73,23 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
             path=config["data"]["geodata"]["heat_network_zones"][local_authority],
             **kwargs,
         )
+        # Assume first column with `ID` substring is the zone ID column
+        # Note original ID column retained in case of erroneous ID assignment
+        id_col = [col for col in gdf.columns if "ID" in col][0]
+        gdf["HNZoneID"] = gdf[id_col]
+        print(f"Using Heat Network Zone {id_col} column as ID")
     except (ValueError, KeyError):
         print(f"No heat network zone geodata found for {local_authority}.")
 
-    # Get list of LAs (e.g. for `greater_manchester_las` this means getting a list of all indivividual LAs) to attempt loading heat network zone geodata for each LA individually if no geodata found for the whole group of LAs.
-    la_names = config["constant"][local_authority]["la_names"]
-    list_las = la_names if isinstance(la_names, list) else [la_names]
-    del la_names
+    # Get list of LAs (e.g. for `greater_manchester_las` this means getting a list of all individual LAs) to attempt
+    # loading heat network zone geodata for each LA individually if no geodata found for the whole group of LAs.
+    list_las = config["constant"][local_authority]["la_names"]
+    list_las = list_las if isinstance(list_las, list) else [list_las]
 
     # If gdf is still empty and `local_authority` represents a group of LAs
     if gdf.empty and len(list_las) > 1:
-        # Check if heat network zone geodata is available for each LA in the list, and if so, load it and concatenate it to a single geodataframe.
+        # Check if heat network zone geodata is available for each LA in the list, and if so, load it and concatenate
+        # it to a single geodataframe.
         for la in list_las:
             try:
                 gdf = pd.concat(
@@ -97,9 +104,10 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
                 )
                 # Deal with different ID column names in different geodataframes by renaming the ID column to "ZoneID"
                 id_col = [col for col in gdf.columns if "ID" in col][0]
-                gdf.rename(columns={id_col: "ZoneID"}, inplace=True)
+                gdf["HNZoneID"] = gdf[id_col]
+                print(f"Using Heat Network Zone {id_col} column as ID")
             except (ValueError, KeyError):
-                print(f"No heat network zone geodata found for individual {la}.")
+                print(f"No heat network zone geodata found for Local Authority: {la}.")
 
     if len(gdf) > 0:
         gdf.set_geometry("geometry", inplace=True)

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -79,41 +79,43 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
         gdf["HNZoneID"] = gdf[id_col]
         print(f"Using Heat Network Zone {id_col} column as ID")
     except (ValueError, KeyError):
-        print(f"No heat network zone geodata found for {local_authority}.")
+        # Get list of LAs (e.g. for `greater_manchester_las` this means getting a list of all individual LAs) to attempt
+        # loading heat network zone geodata for each LA individually if no geodata found for the whole group of LAs.
+        list_las = config["constant"][local_authority]["la_names"]
+        list_las = list_las if isinstance(list_las, list) else [list_las]
 
-    # Get list of LAs (e.g. for `greater_manchester_las` this means getting a list of all individual LAs) to attempt
-    # loading heat network zone geodata for each LA individually if no geodata found for the whole group of LAs.
-    list_las = config["constant"][local_authority]["la_names"]
-    list_las = list_las if isinstance(list_las, list) else [list_las]
-
-    # If gdf is still empty and `local_authority` represents a group of LAs
-    if gdf.empty and len(list_las) > 1:
-        # Check if heat network zone geodata is available for each LA in the list, and if so, load it and concatenate
-        # it to a single geodataframe.
-        for la in list_las:
-            try:
-                gdf = pd.concat(
-                    [
-                        gdf,
-                        base_getters.get_gdf_from_gpkg_s3_path(
-                            path=config["data"]["geodata"]["heat_network_zones"][la],
-                            **kwargs,
-                        ),
-                    ],
-                    ignore_index=True,
-                )
-                # Deal with different ID column names in different geodataframes by renaming the ID column to "ZoneID"
-                id_col = [col for col in gdf.columns if "ID" in col][0]
-                gdf["HNZoneID"] = gdf[id_col]
-                print(f"Using Heat Network Zone {id_col} column as ID")
-            except (ValueError, KeyError):
-                print(f"No heat network zone geodata found for Local Authority: {la}.")
-
-    if len(gdf) > 0:
-        gdf.set_geometry("geometry", inplace=True)
-        print(
-            f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
-        )
+        # If gdf is still empty and `local_authority` represents a group of LAs
+        if gdf.empty and len(list_las) > 1:
+            # Check if heat network zone geodata is available for each LA in the list, and if so, load it and concatenate
+            # it to a single geodataframe.
+            for la in list_las:
+                try:
+                    gdf = pd.concat(
+                        [
+                            gdf,
+                            base_getters.get_gdf_from_gpkg_s3_path(
+                                path=config["data"]["geodata"]["heat_network_zones"][
+                                    la
+                                ],
+                                **kwargs,
+                            ),
+                        ],
+                        ignore_index=True,
+                    )
+                    # Deal with different ID column names in different geodataframes by renaming the ID column to "ZoneID"
+                    id_col = [col for col in gdf.columns if "ID" in col][0]
+                    gdf["HNZoneID"] = gdf[id_col]
+                    print(f"Using Heat Network Zone {id_col} column as ID")
+                except (ValueError, KeyError):
+                    print(
+                        f"No heat network zone geodata found for Local Authority: {la}."
+                    )
+    finally:
+        if len(gdf) > 0:
+            gdf.set_geometry("geometry", inplace=True)
+            print(
+                f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
+            )
     return gdf
 
 

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -75,9 +75,8 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
         )
         # Assume first column with `ID` substring is the zone ID column
         # Note original ID column retained in case of erroneous ID assignment
-        id_col = [col for col in gdf.columns if "ID" in col][0]
-        gdf["HNZoneID"] = gdf[id_col]
-        print(f"Using Heat Network Zone {id_col} column as ID")
+        gdf = _extend_gdf_hn_zone_id(gdf)
+
     except (ValueError, KeyError):
         # Get list of LAs (e.g. for `greater_manchester_las` this means getting a list of all individual LAs) to attempt
         # loading heat network zone geodata for each LA individually if no geodata found for the whole group of LAs.
@@ -103,9 +102,7 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
                         ignore_index=True,
                     )
                     # Deal with different ID column names in different geodataframes by renaming the ID column to "ZoneID"
-                    id_col = [col for col in gdf.columns if "ID" in col][0]
-                    gdf["HNZoneID"] = gdf[id_col]
-                    print(f"Using Heat Network Zone {id_col} column as ID")
+                    gdf = _extend_gdf_hn_zone_id(gdf)
                 except (ValueError, KeyError):
                     print(
                         f"No heat network zone geodata found for Local Authority: {la}."
@@ -116,6 +113,25 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
             print(
                 f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
             )
+    return gdf
+
+
+def _extend_gdf_hn_zone_id(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Add `HNZoneID` column to heat network geodataframe using existing ID columns.
+
+    Args:
+        gdf (gpd.GeoDataFrame): heat network zones
+
+    Returns:
+        gpd.GeoDataFrame: heat network zones with `HNZoneID` column
+    """
+    id_cols = [col for col in gdf.columns if "ID" in col]
+    id_col = id_cols[0]
+    print(f"Using Heat Network Zone {id_col} column as ID. Other options: {id_cols}")
+
+    gdf = gdf.rename(columns={id_col: f"original_{id_col}"})
+    gdf["HNZoneID"] = gdf[id_col]
     return gdf
 
 

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -48,29 +48,64 @@ def load_gdf_heat_network_zones(local_authority: str, **kwargs) -> gpd.GeoDataFr
     Load GeoDataFrame with heat network zone polygons in given Local Authority.
 
     Args:
-        local_authority (str): Local Authority to load Heat Network zone polygons for.
+        local_authority (str): Local Authority or Local Authorities to load Heat Network zone polygons for.
+        e.g. `plymouth` for Plymouth Local Authority; `greater_manchester_las` for Greater Manchester Combined Authority (all 10 LAs in Greater Manchester).
+        See config/base.yaml for options.
+
         **kwargs for `gpd.read_file()`
 
     Returns:
         gpd.GeoDataFrame: polygons of heat network zones in given Local Authority.
     """
 
+    # TODO: this will currently only work for HN zone files defined in config/base.yaml. We need to change this to make it work for all other HN zone files,
+    # for example by concatenating all HN zone files and checking if the geometries intersect with the local authority boundary.
+
+    gdf = gpd.GeoDataFrame()
+
+    # Local authority (e.g. `plymouth`) or group of local authorities (e.g. `greater_manchester_las`)
     local_authority = local_authority.lower()
 
-    if local_authority not in config["data"]["geodata"]["heat_network_zones"].keys():
-        raise ValueError(
-            f"No path found for heat network zone geodata in Local Authority: {local_authority}"
+    # Load heat network zone geodata for the specified local authority or group of local authorities.
+    try:
+        gdf = base_getters.get_gdf_from_gpkg_s3_path(
+            path=config["data"]["geodata"]["heat_network_zones"][local_authority],
+            **kwargs,
         )
+    except (ValueError, KeyError):
+        print(f"No heat network zone geodata found for {local_authority}.")
 
-    print(f"Loading heat network zone data for {local_authority} Local Authority...")
-    gdf = base_getters.get_gdf_from_gpkg_s3_path(
-        path=config["data"]["geodata"]["heat_network_zones"][local_authority],
-        **kwargs,
-    )
+    # Get list of LAs (e.g. for `greater_manchester_las` this means getting a list of all indivividual LAs) to attempt loading heat network zone geodata for each LA individually if no geodata found for the whole group of LAs.
+    la_names = config["constant"][local_authority]["la_names"]
+    list_las = la_names if isinstance(la_names, list) else [la_names]
+    del la_names
 
-    print(
-        f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
-    )
+    # If gdf is still empty and `local_authority` represents a group of LAs
+    if gdf.empty and len(list_las) > 1:
+        # Check if heat network zone geodata is available for each LA in the list, and if so, load it and concatenate it to a single geodataframe.
+        for la in list_las:
+            try:
+                gdf = pd.concat(
+                    [
+                        gdf,
+                        base_getters.get_gdf_from_gpkg_s3_path(
+                            path=config["data"]["geodata"]["heat_network_zones"][la],
+                            **kwargs,
+                        ),
+                    ],
+                    ignore_index=True,
+                )
+                # Deal with different ID column names in different geodataframes by renaming the ID column to "ZoneID"
+                id_col = [col for col in gdf.columns if "ID" in col][0]
+                gdf.rename(columns={id_col: "ZoneID"}, inplace=True)
+            except (ValueError, KeyError):
+                print(f"No heat network zone geodata found for individual {la}.")
+
+    if len(gdf) > 0:
+        gdf.set_geometry("geometry", inplace=True)
+        print(
+            f"Heat network zone geodataframe successfully loaded for {local_authority} with CRS {gdf.crs}."
+        )
     return gdf
 
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -602,19 +602,22 @@ def parse_arguments() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_arguments()
+    local_authorities = args.local_authorities
+    list_las = config["constant"][local_authorities]["la_names"]
+
     tech_gdf = (
         gpd.read_parquet(
             config["output"]["dataset"]["buildings_most_suitable_tech"].format(
-                local_authorities=args.local_authorities
+                local_authorities=local_authorities
             )
         )
         .set_geometry("geometry")
         .to_crs(config["constant"]["target_crs"])
     )
-    grid_squares = config["constant"][args.local_authorities]["grid_squares"]
+    grid_squares = config["constant"][local_authorities]["grid_squares"]
 
     boundary_gdf = load_boundaries.load_gdf_local_authority_boundaries(
-        select_las=config["constant"][args.local_authorities]["la_names"]
+        select_las=config["constant"][local_authorities]["la_names"]
     )
     buildings_gdf = load_geodata.load_gdf_os_openmap_layer(
         layer="building", grid_squares=grid_squares
@@ -638,6 +641,20 @@ if __name__ == "__main__":
         combined_anchor_gdf=combined_anchor_gdf,
         radius=ANCHOR_RADIUS,
     )
+
+    # Add heat network zones to clusters_gdf, if they exist
+    hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
+        local_authority=local_authorities
+    )
+    if len(hn_zones_gdf) > 0:
+        id_col = [col for col in hn_zones_gdf.columns if "ID" in col][0]
+        hn_zones_gdf = hn_zones_gdf.rename(columns={id_col: "cluster_id"}).assign(
+            assigned_tech="DESNZ_HNZ",
+            cluster_id=lambda df: "DESNZ_HNZ_"
+            + df["cluster_id"].astype(str).str.replace("-", "_"),
+        )[["cluster_id", "geometry"]]
+
+        clusters_gdf = pd.concat([clusters_gdf, hn_zones_gdf], ignore_index=True)
 
     if args.save:
         # Simplify geometry for file size to tolerance of 5m

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -576,6 +576,33 @@ def reassign_gdf_near_anchor_properties(
     return tech_gdf
 
 
+def append_gdf_heat_network_zone_layer(
+    clusters_gdf: gpd.GeoDataFrame, hn_zones_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    """
+    Append DESNZ heat network zones to clusters geodataframe, where `assigned_tech` is 'DESNZ_HNZ'. DESNZ heat network
+    zones are also assigned unique cluster IDs by Local Authority.
+
+    Args:
+        clusters_gdf (gpd.GeoDataFrame): clusters with `assigned_tech`, `cluster_id`, and `geometry` columns.
+        hn_zones_gdf (gpd.GeoDataFrame): DESNZ heat network zones with geometries.
+
+    Returns:
+        gpd.GeoDataFrame: cluster and DESNZ heat network zone geometries
+    """
+    if len(hn_zones_gdf) > 0:
+        id_col = [col for col in hn_zones_gdf.columns if "ID" in col][0]
+        hn_zones_gdf = hn_zones_gdf.rename(columns={id_col: "cluster_id"}).assign(
+            assigned_tech="DESNZ_HNZ",
+            cluster_id=lambda df: "DESNZ_HNZ_"
+            + df["cluster_id"].astype(str).str.replace("-", "_"),
+        )[["assigned_tech", "geometry", "cluster_id"]]
+
+        return pd.concat([clusters_gdf, hn_zones_gdf], ignore_index=True)
+    else:
+        return clusters_gdf
+
+
 def parse_arguments() -> argparse.Namespace:
     """
     Create ArgumentParser and parse.
@@ -646,15 +673,9 @@ if __name__ == "__main__":
     hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
         local_authority=local_authorities
     )
-    if len(hn_zones_gdf) > 0:
-        id_col = [col for col in hn_zones_gdf.columns if "ID" in col][0]
-        hn_zones_gdf = hn_zones_gdf.rename(columns={id_col: "cluster_id"}).assign(
-            assigned_tech="DESNZ_HNZ",
-            cluster_id=lambda df: "DESNZ_HNZ_"
-            + df["cluster_id"].astype(str).str.replace("-", "_"),
-        )[["cluster_id", "geometry"]]
-
-        clusters_gdf = pd.concat([clusters_gdf, hn_zones_gdf], ignore_index=True)
+    clusters_gdf = append_gdf_heat_network_zone_layer(
+        clusters_gdf=clusters_gdf, hn_zones_gdf=hn_zones_gdf
+    )
 
     if args.save:
         # Simplify geometry for file size to tolerance of 5m

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -163,38 +163,15 @@ if __name__ == "__main__":
     # ------------------------ #
     # ADD CITY CENTRE AND HEAT NETWORK ZONE BOOLEAN FLAGS
 
-    # Load planned heat network zone polygons
-    hn_zones_gdf = gpd.GeoDataFrame()
-    # Check if heat network zone geodata is available for each LA in the list, and if so, load it and concatenate it to a single geodataframe.
-    for la in list_las:
-        try:
-            # TODO: deal with the potential for different Zone ID column names in different HN zone datasets
-            hn_zones_gdf = pd.concat(
-                [
-                    hn_zones_gdf,
-                    load_geodata.load_gdf_heat_network_zones(local_authority=la),
-                ],
-                ignore_index=True,
-            )
-        except ValueError:
-            print(
-                f"No heat network zone geodata found for {la}. All UPRNs will be labelled as 'outside heat network zone' in this Local Authority."
-            )
-
-        # If hn_zones_gdf is empty after attempting to load for each LA individually, try loading a combined HN zone geodataframe for the whole list of LAs
-        # (this is because for some groups of LAs, e.g. Greater Manchester Combined Authority, there is only a combined HN zone geodataframe and no individual ones).
-        try:
-            hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
-                local_authority=local_authorities
-            )
-        except ValueError:
-            print(
-                f"No heat network zone geodata found for {local_authorities}. All UPRNs will be labelled as 'outside heat network zone' in this group of Local Authorities."
-            )
-
-    features_df = heat_network_zones.extend_df_heat_network_zone_bool(
-        uprns_df=features_df, uprns_gdf=uprns_gdf, hn_zone_gdf=hn_zones_gdf
+    # Load planned heat network zone polygons (if available)
+    hn_zones_gdf = load_geodata.load_gdf_heat_network_zones(
+        local_authority=local_authorities
     )
+
+    if len(hn_zones_gdf) > 0:
+        features_df = heat_network_zones.extend_df_heat_network_zone_bool(
+            uprns_df=features_df, uprns_gdf=uprns_gdf, hn_zone_gdf=hn_zones_gdf
+        )
 
     # Load spatial signature polygons and label UPRNs in city centres
     spatial_signatures_gdf = load_geodata.load_gdf_spatial_signatures_gb(

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -63,19 +63,20 @@ def generate_dict_heat_network_zone_uprns(
         print(f"hn_zone_gdf reprojected to target CRS: {target_crs}")
 
     # Assume first column with `ID` substring is the zone ID column
-    id_col = [col for col in hn_zone_gdf.columns if "ID" in col][0]
-    print(f"Using Heat Network Zone {id_col} column as ID")
+    if "HNZoneID" not in hn_zone_gdf.columns:
+        id_col = [col for col in hn_zone_gdf.columns if "ID" in col][0]
+        print(f"Using Heat Network Zone {id_col} column as ID")
+        hn_zone_gdf = hn_zone_gdf.rename(columns={id_col: "HNZoneID"})
 
     # Spatial join for labelling UPRNs
     labelled_uprn_gdf = (
         uprns_gdf[["UPRN", "geometry"]]
         .sjoin(
-            hn_zone_gdf[[id_col, "geometry"]],
+            hn_zone_gdf[["HNZoneID", "geometry"]],
             how="inner",
             predicate="intersects",  # include properties intersecting heat network zone boundary
         )
         .drop(columns="index_right")
-        .rename(columns={id_col: "HNZoneID"})
     )
 
     return labelled_uprn_gdf.set_index("UPRN").to_dict()["HNZoneID"]

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -45,7 +45,7 @@ def generate_dict_heat_network_zone_uprns(
 
     Args:
         uprns_gdf (gpd.GeoDataFrame): UPRNs with point geometries to be labelled
-        hn_zone_gdf (gpd.GeoDataFrame): polygons of heat network zones
+        hn_zone_gdf (gpd.GeoDataFrame): polygons of heat network zones with `HNZoneID` column.
 
     Returns:
         dict: UPRNs intersecting with heat network zones and their zone IDs
@@ -61,12 +61,6 @@ def generate_dict_heat_network_zone_uprns(
     if hn_zone_gdf.crs != target_crs:
         hn_zone_gdf = hn_zone_gdf.to_crs(target_crs)
         print(f"hn_zone_gdf reprojected to target CRS: {target_crs}")
-
-    # Assume first column with `ID` substring is the zone ID column
-    if "HNZoneID" not in hn_zone_gdf.columns:
-        id_col = [col for col in hn_zone_gdf.columns if "ID" in col][0]
-        print(f"Using Heat Network Zone {id_col} column as ID")
-        hn_zone_gdf = hn_zone_gdf.rename(columns={id_col: "HNZoneID"})
 
     # Spatial join for labelling UPRNs
     labelled_uprn_gdf = (


### PR DESCRIPTION
---

# Description

Append HN zones to clusters_gdf and change the source data for the Plymouth HN zones.

Fixes #300 and #301

Main changes to the codebase include:
- `asf_heat_pump_suitability/config/base.yaml`: source data for Plymouth planned HN zone
- `asf_heat_pump_suitability/getters/load_geodata.py`: I moved some of the code that lived in `add_features.py` to `load_geodata.load_gdf_heat_network_zones()` as I was going to have to repeat it in `cluster.py`. `load_geodata.load_gdf_heat_network_zones()` now allows for loading HN zones for a specific LA, CA or group of LAs.
- `asf_heat_pump_suitability/pipeline/run/add_features.py`: update to this script, to reflect changes in how we load HN zones.
- `asf_heat_pump_suitability/pipeline/cluster/cluster.py`: Appending heat network zones to clusters_gdf, if they exist

I have also run the following:

`add_features.py` for 3 different areas to ensure results still hold:
- `python asf_heat_pump_suitability/pipeline/run/add_features.py --local_authorities "plymouth"`
- `python asf_heat_pump_suitability/pipeline/run/add_features.py --local_authorities "cardiff"`
- `python asf_heat_pump_suitability/pipeline/run/add_features.py --local_authorities "greater_manchester_las" --detail "simplified"`

`cluster.py`:
- python asf_heat_pump_suitability/pipeline/run/add_features.py --local_authorities "plymouth"


# Instructions for Reviewer

The changes ended up being more than just a few lines, due to moving some code to `load_geodata.load_gdf_heat_network_zones()`. Could you please ensure the logic holds up and that the documentation is clear?

Can you also please check I used the correct version of the HN zones for Plymouth?
