### PR TITLE
Add Scotland non-domestic EPC data

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -36,7 +36,9 @@ data:
 
   epc:
     domestic: "s3://asf-daps/lakehouse/2025_Q1/processed/epc/deduplicated/processed_dedupl-0.parquet"
-    commercial: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/v092025_EPC_NonDomestic_EW.csv"
+    commercial:
+      EW: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/v092025_EPC_NonDomestic_EW.csv"
+      S: "s3://asf-heat-pump-suitability/local_heat_planning/inputs/v122025_EPC_NonDomestic_S.csv"
 
   # Preprocessed data
   processed:

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -103,11 +103,12 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
         # Scotland EPC data
         df_S = base_getters.load_df_from_s3(
             config["data"]["epc"][epc_type]["S"], columns="OSG_REFERENCE_NUMBER"
-        )
-        before = len(df_EW) + len(df_S)
+        ).rename({"OSG_REFERENCE_NUMBER": "UPRN"})
 
-        # England and Wales
-        df_EW = df_EW.with_columns(
+        df = pl.concat([df_EW, df_S])
+        before = len(df)
+
+        df = df.with_columns(
             # Remove any invalid UPRNs (i.e. those IDs which are generated in EPC preprocessing generated from concatenating building ref number and address)
             # These are not true UPRNs that can be used in joins across other datasets
             pl.col("UPRN")
@@ -116,21 +117,6 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
             .alias("UPRN")
         ).drop_nulls()
 
-        # Scotland
-        df_S = (
-            df_S.with_columns(
-                # Scotland data UPRN column is called 'OSG_REFERENCE_NUMBER'
-                pl.col("OSG_REFERENCE_NUMBER")
-                .cast(pl.Float64, strict=False)
-                .cast(pl.Int64)
-                .alias("UPRN")
-            )
-            .drop_nulls()
-            .drop("OSG_REFERENCE_NUMBER")
-        )
-
-        # Return England, Wales and Scotland EPC data together
-        df = pl.concat([df_EW, df_S])
     logging.info(
         f"{before - len(df)} invalid UPRNs dropped from {epc_type} EPC register. {len(df)} valid UPRNs remaining"
     )

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -82,16 +82,55 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
         set: valid UPRNs from specified EPC dataset
     """
     print(f"Loading UPRNs from {epc_type} EPC register...")
-    df = base_getters.load_df_from_s3(config["data"]["epc"][epc_type], columns="UPRN")
-    before = len(df)
-    df = df.with_columns(
-        # Remove any invalid UPRNs (i.e. those IDs which are generated in EPC preprocessing generated from concatenating building ref number and address)
-        # These are not true UPRNs that can be used in joins across other datasets
-        pl.col("UPRN")
-        .cast(pl.Float64, strict=False)
-        .cast(pl.Int64)
-        .alias("UPRN")
-    ).drop_nulls()
+    if epc_type == "domestic":
+        df = base_getters.load_df_from_s3(
+            config["data"]["epc"][epc_type], columns="UPRN"
+        )
+        before = len(df)
+        df = df.with_columns(
+            # Remove any invalid UPRNs (i.e. those IDs which are generated in EPC preprocessing generated from concatenating building ref number and address)
+            # These are not true UPRNs that can be used in joins across other datasets
+            pl.col("UPRN")
+            .cast(pl.Float64, strict=False)
+            .cast(pl.Int64)
+            .alias("UPRN")
+        ).drop_nulls()
+    else:
+        # England and Wales EPC data
+        df_EW = base_getters.load_df_from_s3(
+            config["data"]["epc"][epc_type]["EW"], columns="UPRN"
+        )
+        # Scotland EPC data
+        df_S = base_getters.load_df_from_s3(
+            config["data"]["epc"][epc_type]["S"], columns="BUILDING_REFERENCE_NUMBER"
+        )
+        before = len(df_EW) + len(df_S)
+
+        # England and Wales
+        df_EW = df_EW.with_columns(
+            # Remove any invalid UPRNs (i.e. those IDs which are generated in EPC preprocessing generated from concatenating building ref number and address)
+            # These are not true UPRNs that can be used in joins across other datasets
+            pl.col("UPRN")
+            .cast(pl.Float64, strict=False)
+            .cast(pl.Int64)
+            .alias("UPRN")
+        ).drop_nulls()
+
+        # Scotland
+        df_S = (
+            df_S.with_columns(
+                # Scotland data UPRN column is called 'BUILDING REFERENCE NUMBER'
+                pl.col("BUILDING_REFERENCE_NUMBER")
+                .cast(pl.Float64, strict=False)
+                .cast(pl.Int64)
+                .alias("UPRN")
+            )
+            .drop_nulls()
+            .drop("BUILDING_REFERENCE_NUMBER")
+        )
+
+        # Return England, Wales and Scotland EPC data together
+        df = pl.concat([df_EW, df_S])
     logging.info(
         f"{before - len(df)} invalid UPRNs dropped from {epc_type} EPC register. {len(df)} valid UPRNs remaining"
     )

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -102,7 +102,7 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
         )
         # Scotland EPC data
         df_S = base_getters.load_df_from_s3(
-            config["data"]["epc"][epc_type]["S"], columns="BUILDING_REFERENCE_NUMBER"
+            config["data"]["epc"][epc_type]["S"], columns="OSG_REFERENCE_NUMBER"
         )
         before = len(df_EW) + len(df_S)
 
@@ -119,14 +119,14 @@ def load_set_valid_epc_uprns(epc_type: str) -> set:
         # Scotland
         df_S = (
             df_S.with_columns(
-                # Scotland data UPRN column is called 'BUILDING REFERENCE NUMBER'
-                pl.col("BUILDING_REFERENCE_NUMBER")
+                # Scotland data UPRN column is called 'OSG_REFERENCE_NUMBER'
+                pl.col("OSG_REFERENCE_NUMBER")
                 .cast(pl.Float64, strict=False)
                 .cast(pl.Int64)
                 .alias("UPRN")
             )
             .drop_nulls()
-            .drop("BUILDING_REFERENCE_NUMBER")
+            .drop("OSG_REFERENCE_NUMBER")
         )
 
         # Return England, Wales and Scotland EPC data together


### PR DESCRIPTION
---

# Description

Add non-domestic EPC data for Scotland. Updated function `load_set_valid_epc_uprns( )` in `uprns.py` to be able to load the data for Scotland. I've checked the UPRNs that are loaded (the column is called OSG_REFERENCE_NUMBER in the Scotland data). 20 out of 38522 UPRNs were not contained in the OS UPRNs. 

Fixes #314 

# Instructions for Reviewer

In order to test the code in this PR you need to run `uprns.py`

Please pay special attention to ...

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
