### PR TITLE
fix for Glasgow City being called Glasgow in INSPIRE data

### DIFF
--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -188,7 +188,12 @@ if __name__ == "__main__":
     )
 
     # Find closest LA name in the INSPIRE data
-    list_las = outdoor_space.get_inspire_file_match(list_las)
+    list_las = [
+        outdoor_space.get_inspire_file_match(
+            la_name=la, inspire_file_names=inspire_file_names
+        )
+        for la in list_las
+    ]
 
     # Find INSPIRE file path that matches this LA name
     inspire_file_names = inspire_file_names[

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -186,6 +186,11 @@ if __name__ == "__main__":
     inspire_file_names = gpd.read_file(
         config["data"]["processed"]["inspire_file_names"]
     )
+
+    # Find closest LA name in the INSPIRE data
+    list_las = outdoor_space.get_inspire_file_match(list_las)
+
+    # Find INSPIRE file path that matches this LA name
     inspire_file_names = inspire_file_names[
         (inspire_file_names["LAD23NM"].isin(list_las))
         | (inspire_file_names["registration_county"].isin(list_las))

--- a/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
+++ b/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
@@ -6,6 +6,7 @@ import geopandas as gpd
 import logging
 import pandas as pd
 import polars as pl
+import difflib
 from asf_heat_pump_suitability.getters import load_geodata
 from asf_heat_pump_suitability.utils import geo_utils
 
@@ -228,3 +229,40 @@ def sjoin_df_uprn_to_outdoor_space(
             columns=["geometry", "index_right"]
         )
     )
+
+
+def get_inspire_file_match(la_name, inspire_file_names, threshold=0.7):
+    """
+    Finds the closest INSPIRE file for a given LA name, if there is a match above a specified similarity threshold.
+
+    Args:
+        la_name (str): LA name to find an INSPIRE file match for.
+        file_list (gdf): dataframe of INSPIRE file names for England, Wales and Scotland with LAD23NM and registration_county columns.
+        threshold (float): lowest similarity score above which to accept an INSPIRE filename match. Default = 0.7
+
+    Returns:
+        str: name of INSPIRE file that best matches the LA name or None if there was no match above the similarity threshold.
+    """
+    # get list of all possible England, Wales and Scotland LA names in the INSPIRE data
+    combined_list = (
+        pd.concat(
+            [inspire_file_names["LAD23NM"], inspire_file_names["registration_county"]]
+        )
+        .dropna()
+        .tolist()
+    )
+
+    # make INSPIRE file names lower case for better matching, but keep original name to return
+    combined_map = {name.lower(): name for name in combined_list}
+
+    # get closest INSPIRE file match
+    match = difflib.get_close_matches(
+        la_name.lower(), combined_map.keys(), n=1, cutoff=threshold
+    )
+    if not match:
+        print(f"couldn't find an INSPIRE filename for {la_name}")
+    else:
+        match = match[0]
+        print(f"found an INSPIRE file match for {la_name}: {combined_map[match]}")
+
+    return combined_map[match] if match else None

--- a/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
+++ b/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
@@ -264,6 +264,6 @@ def get_inspire_file_match(la_name, inspire_file_names, threshold=0.7):
     else:
         match = matches[0]
         print(f"found an INSPIRE file match for {la_name}: {combined_map[match]}")
-        print(f"other possible matches for {la_name}: {matches[1:]}")
+        print(f"all possible matches for {la_name}: {matches}")
 
     return combined_map[match] if matches else None

--- a/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
+++ b/asf_heat_pump_suitability/pipeline/transform/outdoor_space.py
@@ -237,7 +237,7 @@ def get_inspire_file_match(la_name, inspire_file_names, threshold=0.7):
 
     Args:
         la_name (str): LA name to find an INSPIRE file match for.
-        file_list (gdf): dataframe of INSPIRE file names for England, Wales and Scotland with LAD23NM and registration_county columns.
+        inspire_file_names (gdf): dataframe of INSPIRE file names for England, Wales and Scotland with LAD23NM and registration_county columns.
         threshold (float): lowest similarity score above which to accept an INSPIRE filename match. Default = 0.7
 
     Returns:
@@ -256,13 +256,14 @@ def get_inspire_file_match(la_name, inspire_file_names, threshold=0.7):
     combined_map = {name.lower(): name for name in combined_list}
 
     # get closest INSPIRE file match
-    match = difflib.get_close_matches(
-        la_name.lower(), combined_map.keys(), n=1, cutoff=threshold
+    matches = difflib.get_close_matches(
+        la_name.lower(), combined_map.keys(), n=3, cutoff=threshold
     )
-    if not match:
+    if not matches:
         print(f"couldn't find an INSPIRE filename for {la_name}")
     else:
-        match = match[0]
+        match = matches[0]
         print(f"found an INSPIRE file match for {la_name}: {combined_map[match]}")
+        print(f"other possible matches for {la_name}: {matches[1:]}")
 
-    return combined_map[match] if match else None
+    return combined_map[match] if matches else None


### PR DESCRIPTION
---

# Description

Please include a summary of the changes.

Fixes #335 

Added a function in `outdoor_space.py` that looks for the name in the INSPIRE dataframe that best matches the LA name given. I've tested this in a notebook and works for Glasgow City. Hopefully it doesn't introduce some accidental matches though.  
