### PR TITLE
add south lanarkshire config references

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -132,6 +132,12 @@ constant:
   glasgow:
     la_names: "Glasgow City"
     grid_squares: "NS"
+  south_lanarkshire:
+    la_names: "South Lanarkshire"
+    grid_squares:
+      - "NT"
+      - "NS"
+      - "NX"
   target_crs: 27700 # British National Grid
   tech_types:
     individual: "Individual solution"

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -137,7 +137,6 @@ constant:
     grid_squares:
       - "NT"
       - "NS"
-      - "NX"
   target_crs: 27700 # British National Grid
   tech_types:
     individual: "Individual solution"


### PR DESCRIPTION
---

# Description

I think the grid squares for South Lanarkshire are mainly NT and NS, with a little bit in NX but maybe double check.

Fixes #337 