### PR TITLE
339 bugfix in hn zone col missing

### DIFF
--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -164,10 +164,9 @@ if __name__ == "__main__":
         local_authority=local_authorities
     )
 
-    if len(hn_zones_gdf) > 0:
-        features_df = heat_network_zones.extend_df_heat_network_zone_bool(
-            uprns_df=features_df, uprns_gdf=uprns_gdf, hn_zone_gdf=hn_zones_gdf
-        )
+    features_df = heat_network_zones.extend_df_heat_network_zone_bool(
+        uprns_df=features_df, uprns_gdf=uprns_gdf, hn_zone_gdf=hn_zones_gdf
+    )
 
     # Load spatial signature polygons and label UPRNs in city centres
     spatial_signatures_gdf = load_geodata.load_gdf_spatial_signatures_gb(

--- a/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
+++ b/asf_heat_pump_suitability/pipeline/transform/heat_network_zones.py
@@ -23,6 +23,9 @@ def extend_df_heat_network_zone_bool(
         pl.DataFrame: UPRN dataframe with boolean `in_hn_zone` column.
     """
     if hn_zone_gdf.empty:
+        print(
+            "No heat network zones found. Setting `in_hn_zone` to `False` for all UPRNs..."
+        )
         return uprns_df.with_columns(pl.lit(False).alias("in_hn_zone"))
     else:
         uprns_in_hnz = generate_dict_heat_network_zone_uprns(


### PR DESCRIPTION
Fixes #339 

hn_zone_gdf of len 0 is handled natively in the function to extend the features df with `in_hn_zone` boolean flag. The `if` statement was causing an error downstream because the `in_hn_zone` column was not added but is required in the `decision_tree.py` script.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [ ] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
