### PR TITLE
inspire file name mismatch fix

### DIFF
--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -182,12 +182,10 @@ if __name__ == "__main__":
     # ESTIMATE OUTDOOR SPACE
     # TODO scale beyond Plymouth. This is a temporary fix to working with multiple LAs
     print("Loading land registry data...")
-    inspire_file_names = gpd.read_file(
-        config["data"]["processed"]["inspire_file_names"]
-    )
+    inspire_file_gdf = gpd.read_file(config["data"]["processed"]["inspire_file_names"])
     inspire_file_names = uprns_gdf.sjoin(
-        inspire_file_names, how="inner", predicate="intersects"
-    )
+        inspire_file_gdf, how="inner", predicate="intersects"
+    )["inspire_file_name"].unique()
 
     land_parcels_gdf = pd.concat(
         [

--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -185,10 +185,9 @@ if __name__ == "__main__":
     inspire_file_names = gpd.read_file(
         config["data"]["processed"]["inspire_file_names"]
     )
-    inspire_file_names = inspire_file_names[
-        (inspire_file_names["LAD23NM"].isin(list_las))
-        | (inspire_file_names["registration_county"].isin(list_las))
-    ]["inspire_file_name"].unique()
+    inspire_file_names = uprns_gdf.sjoin(
+        inspire_file_names, how="inner", predicate="intersects"
+    )
 
     land_parcels_gdf = pd.concat(
         [
@@ -197,6 +196,8 @@ if __name__ == "__main__":
         ],
         ignore_index=False,
     )
+    land_parcels_gdf["geometry"] = land_parcels_gdf.normalize()
+    land_parcels_gdf = land_parcels_gdf.drop_duplicates(subset=["geometry"])
 
     buildings_gdf = load_geodata.load_gdf_os_openmap_layer(
         layer="building", grid_squares=grid_squares


### PR DESCRIPTION
---

# Description
Now using sjoin to join UPRNs to inspire file bounds. I am not sure why but using `normalize().drop_duplicates()` wasn't working so I had to split this over two lines and it works that way ?
Fixes #341 
