### PR TITLE
357 fix overlapping polygons

### DIFF
--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -352,14 +352,36 @@ def overlay_gdf_physical_barriers(
     Returns:
         gpd.GeoDataFrame: domestic building cells with overlapping physical barriers removed
     """
-    # Filter to domestic building Voronois only
-    voronoi_gdf = voronoi_gdf.sjoin(
-        tech_gdf[["assigned_tech", "geometry"]], how="inner", predicate="contains"
-    ).drop(columns="index_right")
+    # # Filter to domestic building Voronois only
+    # Add a temporary ID for each Voronoi cell
+    cell_id_col = "_internal_cell_fragment_id"
+
+    voronoi_gdf = voronoi_gdf.assign(**{cell_id_col: np.arange(len(voronoi_gdf))})
+
+    # Get the largest intersecting Voronoi cell for each domestic building.
+    # This method means that buildings with a Voronoi cell that does not completely contain them (e.g. missing a tiny corner)
+    # still retain a Voronoi cell
+    intersection_gdf = sjoin_gdf_max_intersection(
+        container_gdf=voronoi_gdf,
+        within_gdf=tech_gdf,
+        container_id=cell_id_col,
+        within_cols=["ID", "assigned_tech", "geometry"],
+    )
+    # Map each building to its corresponding Voronoi ID
+    cell_to_building_mapping = intersection_gdf.set_index(cell_id_col)["ID"].to_dict()
+
+    # Use the mapping to label the original Voronoi cells with the correct building ID
+    voronoi_gdf["select_id"] = voronoi_gdf[cell_id_col].replace(
+        cell_to_building_mapping
+    )
+    # Filter to the rows where the building ID matches (i.e. only domestic buildings are retained here)
+    domestic_voronoi_gdf = voronoi_gdf[
+        voronoi_gdf["ID"] == voronoi_gdf["select_id"]
+    ].drop(columns="select_id")
 
     # Remove areas covered by polygons and lines
     cells_gdf = (
-        voronoi_gdf.overlay(polygon_overlay_gdf, how="difference")
+        domestic_voronoi_gdf.overlay(polygon_overlay_gdf, how="difference")
         .overlay(line_overlay_gdf, how="difference")
         .explode()
     )

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -471,10 +471,19 @@ def sjoin_gdf_max_intersection(
     building_cols: list[str] = None,
 ) -> gpd.GeoDataFrame:
     """
-    Match polygons from two different geodataframes which have the maximum intersecting overlap area.
+    Match cells to the buildings they have the greatest intersecting area with.
 
     Args:
-        cell_gdf (gpd.GeoDataFrame): polygons
+        cell_gdf (gpd.GeoDataFrame): polygons of cells which contain buildings
+        building_gdf (gpd.GeoDataFrame): polygons of building footprints
+        cell_id (str): name of column containing unique cell ID
+        cell_cols (list[str]): list of columns to retain from `cell_gdf`. Default `None` to retain only columns required for
+        the operation (`cell_id`, `geometry`).
+        building_cols (list[str]): list of columns to retain from `building_gdf`. Default `None` to retain only columns required for
+        the operation (`geometry`).
+
+    Returns:
+        gpd.GeoDataFrame: cells with the building that has the greatest intersecting area with them. One row per unique cell.
     """
     # Ensure required columns are retained
     if cell_cols:
@@ -484,7 +493,7 @@ def sjoin_gdf_max_intersection(
         cell_cols = list(cell_cols)
     else:
         cell_cols = [cell_id, "geometry"]
-    if building_gdf:
+    if building_cols:
         building_cols = set(building_cols)
         building_cols.add("geometry")
         building_cols = list(building_cols)
@@ -500,6 +509,7 @@ def sjoin_gdf_max_intersection(
     intersections_gdf["max_intersection"] = intersections_gdf.groupby(cell_id)[
         "area"
     ].transform("max")
+
     return (
         intersections_gdf[
             intersections_gdf["area"] == intersections_gdf["max_intersection"]

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -337,25 +337,51 @@ def _handle_gdf_fragmented_cells(
     Returns:
         gpd.GeoDataFrame: domestic building cells with overlapping physical barriers removed and cell fragments handled
     """
-    # Add a temporary ID for each building
-    id_col = "_internal_building_id"
-    tech_gdf[id_col] = np.arange(len(tech_gdf))
-    cols = [id_col, "geometry"]
+    # Add a temporary ID for each building and cell fragment
+    building_id_col = "_internal_building_id"
+    cell_id_col = "_internal_cell_fragment_id"
 
-    # Keep only cell fragments that intersect with a building and label with the ID of the building
-    cells_gdf = cells_gdf.sjoin(
-        tech_gdf[cols], how="inner", predicate="intersects"
-    ).drop(columns=["index_right"])
+    tech_gdf = tech_gdf.assign(**{building_id_col: np.arange(len(tech_gdf))})
+    cells_gdf = cells_gdf.assign(**{cell_id_col: np.arange(len(cells_gdf))})
+
+    # Keep only cell fragments that intersect with a building and label with the ID of the building.
+    # We use intersection overlay and get the intersection area between each fragment and building, retaining only the
+    # pairing with the largest intersection per cell fragment. This handles cases where one fragment joins to multiple
+    # buildings to prevent the final set of cells from containing any overlapping geometries.
+    intersections_gdf = gpd.overlay(
+        cells_gdf[[cell_id_col, "geometry"]],
+        tech_gdf[[building_id_col, "geometry"]],
+        how="intersection",
+    )
+    intersections_gdf["area"] = intersections_gdf.geometry.area
+    intersections_gdf["max_intersection"] = intersections_gdf.groupby(cell_id_col)[
+        "area"
+    ].transform("max")
+    intersections_gdf = intersections_gdf[
+        intersections_gdf["area"] == intersections_gdf["max_intersection"]
+    ].copy()
+
+    # Map building IDs to best intersecting cell fragments
+    cells_gdf = cells_gdf.merge(
+        intersections_gdf[[cell_id_col, building_id_col]],
+        on=cell_id_col,
+        how="inner",
+    )
+
+    print(cells_gdf[cell_id_col].duplicated().sum())
+    print(cells_gdf["geometry"].duplicated().sum())
+    print(tech_gdf["geometry"].duplicated().sum())
 
     # Dissolve building footprints and their cell fragments together
+    cols = [building_id_col, "geometry"]
     union_gdf = (
-        pd.concat([cells_gdf[cols], tech_gdf[cols]])
-        .dissolve(by=id_col)
+        pd.concat([cells_gdf[cols], tech_gdf[cols]], ignore_index=True)
+        .dissolve(by=building_id_col)
         .rename(columns={"geometry": "unionised_geometry"})
     )
 
     # Join unionised cells back to original buildings
-    cells_gdf = tech_gdf.merge(union_gdf, how="left", on=id_col)
+    cells_gdf = tech_gdf.merge(union_gdf, how="left", on=building_id_col)
 
     # If building is missing a Voronoi cell (due to overlay operation), then assign it the building footprint geometry
     # This happens in some edge cases
@@ -365,7 +391,7 @@ def _handle_gdf_fragmented_cells(
 
     # Keep the Voronoi cell geometries, filled with building footprints
     return (
-        cells_gdf.drop(columns=["geometry", id_col])
+        cells_gdf.drop(columns=["geometry", building_id_col])
         .rename(columns={"unionised_geometry": "geometry"})
         .set_geometry("geometry", crs=cells_gdf.crs)
     )

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -157,15 +157,47 @@ def generate_gdf_clusters(
         + (clusters_gdf["cluster_id"] + 1).astype(str)
     )
 
+    # TODO move to testing when sample set available
     if round(clusters_gdf["geometry"].area.sum(), 3) > round(
         clusters_gdf["geometry"].union_all().area, 3
     ):
         warnings.warn(
             "Sum of all cluster areas is greater than the area of the cluster union. "
-            "This indicates cluster polygons are overlapping."
+            "This indicates cluster polygons are overlapping.",
+            UserWarning,
+        )
+
+    # TODO move to testing when sample set available
+    joined_gdf = sjoin_gdf_buildings_to_clusters(
+        tech_gdf=tech_gdf, clusters_gdf=clusters_gdf
+    )
+    n_missing = joined_gdf["cluster_id"].isna().sum()
+    if n_missing > 0:
+        warnings.warn(
+            f"There is a problem with the clustering. {n_missing} buildings have not been assigned to a cluster.",
+            UserWarning,
         )
 
     return clusters_gdf
+
+
+def sjoin_gdf_buildings_to_clusters(
+    tech_gdf: gpd.GeoDataFrame, clusters_gdf: gpd.GeoDataFrame
+):
+    """
+    Join buildings to their corresponding cluster.
+
+    Args:
+        tech_gdf (gpd.GeoDataFrame): domestic building footprints with assigned tech types.
+        buildings_gdf (gpd.GeoDataFrame): clusters of building footprints with the same assigned technology, one row per cluster.
+
+    Returns:
+        gpd.GeoDataFrame: building footprints with assigned tech type and cluster ID
+    """
+    buffered_tech_gdf = tech_gdf.copy()
+    # Reduce the size of the building footprints slightly so they can be completely contained within the cluster cells
+    buffered_tech_gdf["geometry"] = buffered_tech_gdf["geometry"].buffer(-0.1)
+    return buffered_tech_gdf.sjoin(clusters_gdf, how="left", predicate="within")
 
 
 def extend_edges_gdf(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -404,18 +404,12 @@ def _handle_gdf_fragmented_cells(
     # We use intersection overlay and get the intersection area between each fragment and building, retaining only the
     # pairing with the largest intersection per cell fragment. This handles cases where one fragment joins to multiple
     # buildings to prevent the final set of cells from containing any overlapping geometries.
-    intersections_gdf = gpd.overlay(
-        cells_gdf[[cell_id_col, "geometry"]],
-        tech_gdf[[building_id_col, "geometry"]],
-        how="intersection",
+    intersections_gdf = sjoin_gdf_max_intersection(
+        container_gdf=cells_gdf,
+        within_gdf=tech_gdf,
+        container_id=cell_id_col,
+        within_id=building_id_col,
     )
-    intersections_gdf["area"] = intersections_gdf.geometry.area
-    intersections_gdf["max_intersection"] = intersections_gdf.groupby(cell_id_col)[
-        "area"
-    ].transform("max")
-    intersections_gdf = intersections_gdf[
-        intersections_gdf["area"] == intersections_gdf["max_intersection"]
-    ].copy()
 
     # Map building IDs to best intersecting cell fragments
     cells_gdf = cells_gdf.merge(
@@ -448,6 +442,25 @@ def _handle_gdf_fragmented_cells(
     )
 
     return cells_gdf[~cells_gdf["geometry"].is_empty]
+
+
+def sjoin_gdf_max_intersection(container_gdf, within_gdf, container_id, within_id):
+    intersections_gdf = gpd.overlay(
+        container_gdf[[container_id, "geometry"]],
+        within_gdf[[within_id, "geometry"]],
+        how="intersection",
+    )
+    intersections_gdf["area"] = intersections_gdf.geometry.area
+    intersections_gdf["max_intersection"] = intersections_gdf.groupby(container_id)[
+        "area"
+    ].transform("max")
+    return (
+        intersections_gdf[
+            intersections_gdf["area"] == intersections_gdf["max_intersection"]
+        ]
+        .copy()
+        .drop(columns=["area", "max_intersection"])
+    )
 
 
 def load_tranform_gdf_linestring_barriers(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -382,15 +382,16 @@ def _handle_gdf_fragmented_cells(
         [pure_fragments_gdf[cols], tech_gdf[cols]], ignore_index=True
     ).dissolve(by=building_id_col)
 
-    # Join unionised cells back to original buildings
+    # Join unionised cells back to original buildings to retain building assets
     cells_gdf = (
+        # Drop building geometries before merging as we already have them included in the dissolve above
         tech_gdf.drop(columns="geometry")
         .merge(union_gdf, how="left", on=building_id_col)
         .set_geometry("geometry", crs=cells_gdf.crs)
+        .drop(columns=[building_id_col])
     )
 
-    # # Keep the Voronoi cell geometries, filled with building footprints
-    return cells_gdf.drop(columns=[building_id_col])
+    return cells_gdf[~cells_gdf["geometry"].is_empty]
 
 
 def load_tranform_gdf_linestring_barriers(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -64,6 +64,7 @@ def generate_gdf_clusters(
     polygon_overlay_gdf: gpd.GeoDataFrame,
     combined_anchor_gdf: gpd.GeoDataFrame,
     radius: float,
+    id_col: str = "ID",
 ) -> gpd.GeoDataFrame:
     """
     Generate clusters of building footprints, where one cluster:
@@ -80,6 +81,7 @@ def generate_gdf_clusters(
         poi_gdf (gpd.GeoDataFrame): anchor properties dataframe taken from POI data, with point geometries
         important_buildings_gdf (gpd.GeoDataFrame): important building footprint polygons
         radius (float): radius in metres around anchor property within which communal solutions should be assigned
+        id_col (str): building ID column. Default "ID".
 
     Returns:
         gpd.GeoDataFrame: clusters of building footprints with the same assigned technology, one row per cluster
@@ -107,6 +109,15 @@ def generate_gdf_clusters(
     else:
         cells_gdf = gdfs[0]
 
+    # TODO move to proper testing when sample test set available
+    if len(cells_gdf) != len(tech_gdf):
+        n_cells = len(cells_gdf)
+        n_buildings = len(tech_gdf)
+        raise UserWarning(
+            f"The number of cells and the number of buildings are different when they should be the same. "
+            f"There is a problem with the clustering. N cells: {n_cells}; N buildings: {n_buildings}"
+        )
+
     # Tech reassignment for cells within a certain distance of anchor properties
     reassigned_gdf = reassign_gdf_near_anchor_properties(
         tech_gdf=tech_gdf,
@@ -115,13 +126,13 @@ def generate_gdf_clusters(
     )
 
     cells_gdf["assigned_tech"] = cells_gdf.ID.map(
-        reassigned_gdf.set_index("ID").to_dict()["assigned_tech"]
+        reassigned_gdf.set_index(id_col).to_dict()["assigned_tech"]
     )
 
     # Add "within_{radius}m_from_anchor_load" as a column to cells_gdf
     cells_gdf = cells_gdf.merge(
-        reassigned_gdf[["ID", f"within_{radius}m_from_anchor_load"]],
-        on="ID",
+        reassigned_gdf[[id_col, f"within_{radius}m_from_anchor_load"]],
+        on=id_col,
         how="left",
     )
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -405,7 +405,7 @@ def _handle_gdf_fragmented_cells(
         container_gdf=cells_gdf,
         within_gdf=tech_gdf,
         container_id=cell_id_col,
-        within_cols={building_id_col, "geometry"},
+        within_cols=[building_id_col, "geometry"],
     )
 
     # Map building IDs to best intersecting cell fragments
@@ -445,16 +445,20 @@ def sjoin_gdf_max_intersection(
     container_gdf,
     within_gdf,
     container_id,
-    container_cols: set[str] = None,
-    within_cols: set[str] = None,
+    container_cols: list[str] = None,
+    within_cols: list[str] = None,
 ):
     if container_cols:
+        container_cols = set(container_cols)
         container_cols.add(container_id)
         container_cols.add("geometry")
+        container_cols = list(container_cols)
     else:
         container_cols = [container_id, "geometry"]
     if within_cols:
+        within_cols = set(within_cols)
         within_cols.add("geometry")
+        container_cols = list(within_cols)
     else:
         within_cols = ["geometry"]
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -272,9 +272,6 @@ def extend_edges_gdf(
     )
     # Join the original building points with IDs to the Voronoi cells and dissolve to get one polygon per internal building ID
     voronoi_gdf = (
-        # TODO because of the 'contains' predicate, we lose a small number of Voronoi cells which are missing a tiny edge.
-        # This is handled later by retaining the building footprint of these buildings instead.
-        # However it could be improved by retaining the max intersection.
         voronoi_gdf.sjoin(points_gdf, how="inner", predicate="contains")
         .dissolve(by=id_col)
         .reset_index()
@@ -408,7 +405,7 @@ def _handle_gdf_fragmented_cells(
         container_gdf=cells_gdf,
         within_gdf=tech_gdf,
         container_id=cell_id_col,
-        within_id=building_id_col,
+        within_cols={building_id_col, "geometry"},
     )
 
     # Map building IDs to best intersecting cell fragments
@@ -444,10 +441,26 @@ def _handle_gdf_fragmented_cells(
     return cells_gdf[~cells_gdf["geometry"].is_empty]
 
 
-def sjoin_gdf_max_intersection(container_gdf, within_gdf, container_id, within_id):
+def sjoin_gdf_max_intersection(
+    container_gdf,
+    within_gdf,
+    container_id,
+    container_cols: set[str] = None,
+    within_cols: set[str] = None,
+):
+    if container_cols:
+        container_cols.add(container_id)
+        container_cols.add("geometry")
+    else:
+        container_cols = [container_id, "geometry"]
+    if within_cols:
+        within_cols.add("geometry")
+    else:
+        within_cols = ["geometry"]
+
     intersections_gdf = gpd.overlay(
-        container_gdf[[container_id, "geometry"]],
-        within_gdf[[within_id, "geometry"]],
+        container_gdf[container_cols],
+        within_gdf[within_cols],
         how="intersection",
     )
     intersections_gdf["area"] = intersections_gdf.geometry.area

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -368,33 +368,29 @@ def _handle_gdf_fragmented_cells(
         how="inner",
     )
 
-    print(cells_gdf[cell_id_col].duplicated().sum())
-    print(cells_gdf["geometry"].duplicated().sum())
-    print(tech_gdf["geometry"].duplicated().sum())
+    # Clean fragments to avoid bleeding geometries creating neighbour 'swallowing' effects during dissolve.
+    # e.g. building A swallows building B's cell due to microscopic overlaps in a cell fragment.
+    pure_fragments_gdf = gpd.overlay(
+        cells_gdf[[building_id_col, "geometry"]],
+        tech_gdf[["geometry"]],
+        how="difference",
+    )
 
     # Dissolve building footprints and their cell fragments together
     cols = [building_id_col, "geometry"]
-    union_gdf = (
-        pd.concat([cells_gdf[cols], tech_gdf[cols]], ignore_index=True)
-        .dissolve(by=building_id_col)
-        .rename(columns={"geometry": "unionised_geometry"})
-    )
+    union_gdf = pd.concat(
+        [pure_fragments_gdf[cols], tech_gdf[cols]], ignore_index=True
+    ).dissolve(by=building_id_col)
 
     # Join unionised cells back to original buildings
-    cells_gdf = tech_gdf.merge(union_gdf, how="left", on=building_id_col)
-
-    # If building is missing a Voronoi cell (due to overlay operation), then assign it the building footprint geometry
-    # This happens in some edge cases
-    cells_gdf["unionised_geometry"] = cells_gdf["unionised_geometry"].fillna(
-        cells_gdf["geometry"]
-    )
-
-    # Keep the Voronoi cell geometries, filled with building footprints
-    return (
-        cells_gdf.drop(columns=["geometry", building_id_col])
-        .rename(columns={"unionised_geometry": "geometry"})
+    cells_gdf = (
+        tech_gdf.drop(columns="geometry")
+        .merge(union_gdf, how="left", on=building_id_col)
         .set_geometry("geometry", crs=cells_gdf.crs)
     )
+
+    # # Keep the Voronoi cell geometries, filled with building footprints
+    return cells_gdf.drop(columns=[building_id_col])
 
 
 def load_tranform_gdf_linestring_barriers(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -19,6 +19,7 @@ import numpy as np
 import shapely
 from shapely.geometry import MultiPoint, Polygon, MultiPolygon
 import libpysal
+import warnings
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.utils import save_utils
 from asf_heat_pump_suitability.getters import load_geodata, load_boundaries
@@ -113,9 +114,10 @@ def generate_gdf_clusters(
     if len(cells_gdf) != len(tech_gdf):
         n_cells = len(cells_gdf)
         n_buildings = len(tech_gdf)
-        raise UserWarning(
+        warnings.warn(
             f"The number of cells and the number of buildings are different when they should be the same. "
-            f"There is a problem with the clustering. N cells: {n_cells}; N buildings: {n_buildings}"
+            f"There is a problem with the clustering. N cells: {n_cells}; N buildings: {n_buildings}",
+            UserWarning,
         )
 
     # Tech reassignment for cells within a certain distance of anchor properties
@@ -154,6 +156,14 @@ def generate_gdf_clusters(
         + "_"
         + (clusters_gdf["cluster_id"] + 1).astype(str)
     )
+
+    if round(clusters_gdf["geometry"].area.sum(), 3) > round(
+        clusters_gdf["geometry"].union_all().area, 3
+    ):
+        warnings.warn(
+            "Sum of all cluster areas is greater than the area of the cluster union. "
+            "This indicates cluster polygons are overlapping."
+        )
 
     return clusters_gdf
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -182,22 +182,22 @@ def generate_gdf_clusters(
 
 
 def sjoin_gdf_buildings_to_clusters(
-    tech_gdf: gpd.GeoDataFrame, clusters_gdf: gpd.GeoDataFrame
-):
+    buildings_gdf: gpd.GeoDataFrame, clusters_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
     """
-    Join buildings to their corresponding cluster.
+    Join buildings to their corresponding cluster. Building footprints are returned with a -10cm buffer.
 
     Args:
-        tech_gdf (gpd.GeoDataFrame): domestic building footprints with assigned tech types.
-        buildings_gdf (gpd.GeoDataFrame): clusters of building footprints with the same assigned technology, one row per cluster.
+        buildings_gdf (gpd.GeoDataFrame): domestic building footprints with assigned tech types.
+        clusters_gdf (gpd.GeoDataFrame): clusters of building footprints with the same assigned technology, one row per cluster.
 
     Returns:
         gpd.GeoDataFrame: building footprints with assigned tech type and cluster ID
     """
-    buffered_tech_gdf = tech_gdf.copy()
+    buffered_buildings_gdf = buildings_gdf.copy()
     # Reduce the size of the building footprints slightly so they can be completely contained within the cluster cells
-    buffered_tech_gdf["geometry"] = buffered_tech_gdf["geometry"].buffer(-0.1)
-    return buffered_tech_gdf.sjoin(clusters_gdf, how="left", predicate="within")
+    buffered_buildings_gdf["geometry"] = buffered_buildings_gdf["geometry"].buffer(-0.1)
+    return buffered_buildings_gdf.sjoin(clusters_gdf, how="left", predicate="within")
 
 
 def extend_edges_gdf(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -362,10 +362,10 @@ def overlay_gdf_physical_barriers(
     # This method means that buildings with a Voronoi cell that does not completely contain them (e.g. missing a tiny corner)
     # still retain a Voronoi cell
     intersection_gdf = sjoin_gdf_max_intersection(
-        container_gdf=voronoi_gdf,
-        within_gdf=tech_gdf,
-        container_id=cell_id_col,
-        within_cols=["ID", "assigned_tech", "geometry"],
+        cell_gdf=voronoi_gdf,
+        building_gdf=tech_gdf,
+        cell_id=cell_id_col,
+        building_cols=["ID", "assigned_tech", "geometry"],
     )
     # Map each building to its corresponding Voronoi ID
     cell_to_building_mapping = intersection_gdf.set_index(cell_id_col)["ID"].to_dict()
@@ -424,10 +424,10 @@ def _handle_gdf_fragmented_cells(
     # pairing with the largest intersection per cell fragment. This handles cases where one fragment joins to multiple
     # buildings to prevent the final set of cells from containing any overlapping geometries.
     intersections_gdf = sjoin_gdf_max_intersection(
-        container_gdf=cells_gdf,
-        within_gdf=tech_gdf,
-        container_id=cell_id_col,
-        within_cols=[building_id_col, "geometry"],
+        cell_gdf=cells_gdf,
+        building_gdf=tech_gdf,
+        cell_id=cell_id_col,
+        building_cols=[building_id_col, "geometry"],
     )
 
     # Map building IDs to best intersecting cell fragments
@@ -464,33 +464,40 @@ def _handle_gdf_fragmented_cells(
 
 
 def sjoin_gdf_max_intersection(
-    container_gdf,
-    within_gdf,
-    container_id,
-    container_cols: list[str] = None,
-    within_cols: list[str] = None,
-):
-    if container_cols:
-        container_cols = set(container_cols)
-        container_cols.add(container_id)
-        container_cols.add("geometry")
-        container_cols = list(container_cols)
+    cell_gdf: gpd.GeoDataFrame,
+    building_gdf: gpd.GeoDataFrame,
+    cell_id: str,
+    cell_cols: list[str] = None,
+    building_cols: list[str] = None,
+) -> gpd.GeoDataFrame:
+    """
+    Match polygons from two different geodataframes which have the maximum intersecting overlap area.
+
+    Args:
+        cell_gdf (gpd.GeoDataFrame): polygons
+    """
+    # Ensure required columns are retained
+    if cell_cols:
+        cell_cols = set(cell_cols)
+        cell_cols.add(cell_id)
+        cell_cols.add("geometry")
+        cell_cols = list(cell_cols)
     else:
-        container_cols = [container_id, "geometry"]
-    if within_cols:
-        within_cols = set(within_cols)
-        within_cols.add("geometry")
-        within_cols = list(within_cols)
+        cell_cols = [cell_id, "geometry"]
+    if building_gdf:
+        building_cols = set(building_cols)
+        building_cols.add("geometry")
+        building_cols = list(building_cols)
     else:
-        within_cols = ["geometry"]
+        building_cols = ["geometry"]
 
     intersections_gdf = gpd.overlay(
-        container_gdf[container_cols],
-        within_gdf[within_cols],
+        cell_gdf[cell_cols],
+        building_gdf[building_cols],
         how="intersection",
     )
     intersections_gdf["area"] = intersections_gdf.geometry.area
-    intersections_gdf["max_intersection"] = intersections_gdf.groupby(container_id)[
+    intersections_gdf["max_intersection"] = intersections_gdf.groupby(cell_id)[
         "area"
     ].transform("max")
     return (

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -458,7 +458,7 @@ def sjoin_gdf_max_intersection(
     if within_cols:
         within_cols = set(within_cols)
         within_cols.add("geometry")
-        container_cols = list(within_cols)
+        within_cols = list(within_cols)
     else:
         within_cols = ["geometry"]
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -169,7 +169,7 @@ def generate_gdf_clusters(
 
     # TODO move to testing when sample set available
     joined_gdf = sjoin_gdf_buildings_to_clusters(
-        tech_gdf=tech_gdf, clusters_gdf=clusters_gdf
+        buildings_gdf=tech_gdf, clusters_gdf=clusters_gdf
     )
     n_missing = joined_gdf["cluster_id"].isna().sum()
     if n_missing > 0:

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -272,6 +272,9 @@ def extend_edges_gdf(
     )
     # Join the original building points with IDs to the Voronoi cells and dissolve to get one polygon per internal building ID
     voronoi_gdf = (
+        # TODO because of the 'contains' predicate, we lose a small number of Voronoi cells which are missing a tiny edge.
+        # This is handled later by retaining the building footprint of these buildings instead.
+        # However it could be improved by retaining the max intersection.
         voronoi_gdf.sjoin(points_gdf, how="inner", predicate="contains")
         .dissolve(by=id_col)
         .reset_index()

--- a/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
+++ b/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
@@ -180,7 +180,8 @@ def identify_df_building_most_suitable_tech(
                 ]
             ]
         )
-        # TODO this will drop valid EPC UPRNs with no building footprint. These need to be mapped to their nearest building footprints.
+        # This will drop valid EPC UPRNs with no building footprint.
+        # These need to be mapped to their nearest building footprints to be included.
         # This is required to prevent the creation of a row with no geometry
     ).drop_nulls(subset=id_col)
 

--- a/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
+++ b/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
@@ -351,13 +351,6 @@ def identify_gdf_tuple_most_suitable_tech_uprn_and_building(
             - GeoDataFrame with UPRN-level most suitable tech and decision tree path.
             - GeoDataFrame with building footprint-level most suitable tech.
     """
-    # Join UPRNs with buildings they intersect with or are up to 3m away.
-    # This allows valid EPC UPRNs which fall just outside building footprints to be matched to a building.
-    uprn_to_building_id = uprns.map_dict_uprns_to_building_id(
-        uprns_gdf=uprns_gdf, buildings_gdf=buildings_gdf, id_col=id_col, max_distance=3
-    )
-    uprns_gdf[id_col] = uprns_gdf["UPRN"].replace(uprn_to_building_id)
-
     # Join corresponding building geometry to each UPRN
     buildings_gdf["building_geometry"] = buildings_gdf["geometry"]
     uprns_gdf = uprns_gdf.merge(

--- a/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
+++ b/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
@@ -64,32 +64,6 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def extend_gdf_building_footprints(
-    gdf: gpd.GeoDataFrame, buildings_gdf: gpd.GeoDataFrame, id_col: str
-) -> gpd.GeoDataFrame:
-    """
-    Extends the GeoDataFrame with the building footprint geometries the UPRNs are located within.
-
-    Args:
-        gdf (gpd.GeoDataFrame): GeoDataFrame with UPRN data.
-        buildings_gdf (gpd.GeoDataFrame): GeoDataFrame with building footprints.
-        id_col (str): The name of the column in `buildings_gdf` that contains the unique identifier for the building footprint (e.g. "ID").
-
-    Returns:
-        gpd.GeoDataFrame: GeoDataFrame with building footprint polygons added.
-    """
-    # Creates a copy of the building geometry column to keep after the spatial join
-    buildings_gdf["building_geometry"] = buildings_gdf["geometry"]
-
-    # Extend the UPRN GeoDataFrame with building footprints geometry using id_col
-    gdf = gdf.merge(
-        buildings_gdf[[id_col, "building_geometry"]],
-        how="left",
-        on=id_col,
-    )
-    return gdf
-
-
 def identify_dict_most_suitable_tech(
     in_block_of_flats: bool, outdoor_space: float, city_centre_or_hnz: bool
 ) -> dict:

--- a/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
+++ b/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
@@ -26,7 +26,7 @@ import geopandas as gpd
 import argparse
 
 # local imports
-from asf_heat_pump_suitability.pipeline.transform.uprns import generate_gdf_uprn_coords
+from asf_heat_pump_suitability.pipeline.transform import uprns
 from asf_heat_pump_suitability.getters.load_geodata import (
     load_gdf_os_openmap_layer,
 )
@@ -206,7 +206,9 @@ def identify_df_building_most_suitable_tech(
                 ]
             ]
         )
-    )
+        # TODO this will drop valid EPC UPRNs with no building footprint. These need to be mapped to their nearest building footprints.
+        # This is required to prevent the creation of a row with no geometry
+    ).drop_nulls(subset=id_col)
 
     # Create df with set of most suitable tech per building footprint
     solutions_per_footprint_df = (
@@ -471,7 +473,7 @@ if __name__ == "__main__":
             local_authority=local_authorities
         )
     )
-    uprns_with_features_gdf = generate_gdf_uprn_coords(df=uprns_with_features_df)
+    uprns_with_features_gdf = uprns.generate_gdf_uprn_coords(df=uprns_with_features_df)
 
     # TODO: move this to add_features.py
     uprns_with_features_gdf["in_city_centre_or_hn_zone"] = (

--- a/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
+++ b/asf_heat_pump_suitability/pipeline/transform/decision_tree.py
@@ -376,8 +376,19 @@ def identify_gdf_tuple_most_suitable_tech_uprn_and_building(
             - GeoDataFrame with UPRN-level most suitable tech and decision tree path.
             - GeoDataFrame with building footprint-level most suitable tech.
     """
-    uprns_gdf = extend_gdf_building_footprints(
-        gdf=uprns_gdf, buildings_gdf=buildings_gdf, id_col=id_col
+    # Join UPRNs with buildings they intersect with or are up to 3m away.
+    # This allows valid EPC UPRNs which fall just outside building footprints to be matched to a building.
+    uprn_to_building_id = uprns.map_dict_uprns_to_building_id(
+        uprns_gdf=uprns_gdf, buildings_gdf=buildings_gdf, id_col=id_col, max_distance=3
+    )
+    uprns_gdf[id_col] = uprns_gdf["UPRN"].replace(uprn_to_building_id)
+
+    # Join corresponding building geometry to each UPRN
+    buildings_gdf["building_geometry"] = buildings_gdf["geometry"]
+    uprns_gdf = uprns_gdf.merge(
+        buildings_gdf[[id_col, "building_geometry"]],
+        how="left",
+        on=id_col,
     )
 
     print("Number of building IDs: ", uprns_gdf[id_col].nunique())

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -270,7 +270,6 @@ def map_dict_uprns_to_building_id(
     uprns_gdf: gpd.GeoDataFrame,
     buildings_gdf: gpd.GeoDataFrame,
     id_col: str,
-    predicate: str = "intersects",
     max_distance: float = 1,
 ) -> dict:
     """
@@ -280,8 +279,6 @@ def map_dict_uprns_to_building_id(
         uprns_gdf (gpd.GeoDataFrame): UPRNs with geospatial point data
         buildings_gdf (gpd.GeoDataFrame): building footprints
         id_col (str): name of building ID column in `buildings_gdf`
-        predicate (str): how to join buildings and UPRNs. Can be one of: `intersects`, which joins UPRNs with building footprints
-        they intersect with, or `within` which joins UPRNs to building footprints they are located within. Default `intersects`.
         max_distance (float): max distance (metres) from which to join UPRNs to a building footprint. Default 1m.
 
     Returns:

--- a/asf_heat_pump_suitability/pipeline/transform/uprns.py
+++ b/asf_heat_pump_suitability/pipeline/transform/uprns.py
@@ -273,7 +273,8 @@ def map_dict_uprns_to_building_id(
     max_distance: float = 1,
 ) -> dict:
     """
-    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within or intersect with, or the nearest building < 1m away if not located within a building.
+    Create a mapping of UPRNs (keys) to the building ID (values) of the building they are located within or intersect
+    with, or the nearest building < 1m away if not located within a building.
 
     Args:
         uprns_gdf (gpd.GeoDataFrame): UPRNs with geospatial point data
@@ -301,7 +302,6 @@ def map_dict_uprns_to_building_id(
     nearest_buildings_uprns = unmatched_uprns.sjoin_nearest(
         buildings_gdf, how="inner", max_distance=max_distance
     )
-
     # combine the two gdfs and turn into a dictionary
     uprns_building_dict = (
         (pd.concat([uprns_inside_buildings, nearest_buildings_uprns]))

--- a/asf_heat_pump_suitability/utils/geo_utils.py
+++ b/asf_heat_pump_suitability/utils/geo_utils.py
@@ -94,11 +94,11 @@ def verify_gdf_crs(
         return gdf
 
 
-def find_overlapping_geometries(
+def find_gdf_overlapping_geometries(
     gdf: gpd.GeoDataFrame, return_geometries: bool = True, id_col=None
 ) -> gpd.GeoDataFrame | set:
     """
-    Find geometries in the same GeoDataFrame which overlap with any other geometry in the same GeoDataFrame.
+    Find overlapping geometries within the same GeoDataFrame.
 
     Args:
         gdf (gpd.GeoDataFrame): containing geometries to check for overlaps

--- a/asf_heat_pump_suitability/utils/geo_utils.py
+++ b/asf_heat_pump_suitability/utils/geo_utils.py
@@ -92,3 +92,39 @@ def verify_gdf_crs(
         return gdf.to_crs(target_crs)
     else:
         return gdf
+
+
+def find_overlapping_geometries(
+    gdf: gpd.GeoDataFrame, return_geometries: bool = True, id_col=None
+) -> gpd.GeoDataFrame | set:
+    """
+    Find geometries in the same GeoDataFrame which overlap with any other geometry in the same GeoDataFrame.
+
+    Args:
+        gdf (gpd.GeoDataFrame): containing geometries to check for overlaps
+        return_geometries (bool): set to `True` to return a `GeoDataFrame` with the overlapping geometries. Set to `False`
+        to return just the IDs of overlapping geometries.
+        id_col (str): name of unique ID for geometries. Required only when `return_geometries` is set to `False`. Default
+        `None` to use index.
+
+    Returns:
+        gpd.GeoDataFrame | set: geometries or IDs of geometries which overlap with any other geometry within the `GeoDataFrame`
+    """
+    buffer = gdf.copy()
+    # Buffer added to prevent touching neighbours being identified as overlapping
+    buffer["geometry"] = buffer["geometry"].buffer(-0.0001)
+    intersecting_gdf = buffer.sjoin(buffer, predicate="intersects")
+    intersecting_gdf = intersecting_gdf.loc[
+        intersecting_gdf.index != intersecting_gdf.index_right
+    ]
+    if return_geometries:
+        return intersecting_gdf
+    else:
+        if id_col:
+            overlapping_ids = set(intersecting_gdf[f"{id_col}_left"])
+        else:
+            overlapping_ids = set(intersecting_gdf.index)
+            id_col = "index"
+
+        print(f"ID used: {id_col}. Overlapping ID count: {len(overlapping_ids)}")
+        return overlapping_ids


### PR DESCRIPTION
Fixes #357 

# Description

The main changes are in the `cluster.py` file. The issue causing overlapping polygons was this:

I have voronoi cells, I overlay the barrier polygons to cut them out of the cells, then dissolve cells back to their corresponding building footprints. The dissolving step was creating the overlapping polygons. This was due to microscopic bleeds of the cell fragments created by possibly rounding errors in the overlay step, causing a building to be dissolved with its own cells AND erroneously a neighbouring cell. E.g. in some cases, building A was dissolved back with cell A AND cell B because of tiny overlaps.

This has now been corrected by specifying that cell fragments are only dissolved back to the building that they have the largest overlap with.

I have checked that this fixes the problem by running `cluster.py` and using the code snippet below to test the before and after of the results.

```
import geopandas as gpd
from asf_heat_pump_suitability.utils import geo_utils
current_gdf = gpd.read_file(f"s3://asf-local-heat-planning-tool/outputs/data/{local_authorities}/{local_authorities}_clustered_tech_polygons_simplified_5m.geojson").to_crs(epsg=27700)
# Currently on dev
geo_utils.find_gdf_overlapping_geometries(current_gdf, return_geometries=False, id_col="cluster_id")
# Currently on 357_fix_overlapping_polygons
geo_utils.find_gdf_overlapping_geometries(clusters_gdf, return_geometries=False, id_col="cluster_id")
```

Additionally, I found some edge cases during debugging caused by a different problem. Some buildings did not receive a Voronoi polygon for clustering, retaining only their building geometry instead. This was due to matching building polygons to their Voronoi cells using the 'contains' predicate. Due to the way we create the Voronoi cells using interpolating points, I believe this sometimes causes small edges of a building to not be fully contained within the cell, thus they are not paired with a cell. 

I fixed that using the same logic as that required for fixing the overlapping clusters problem.

Although the buildings this affected were still included in the map and tool at the end, they were probably not getting effectively clustered, so this should fix that. It will mean that some clusters will be slightly bigger than before as there will now be more connectivity between the edge case buildings and the rest of the map.

Modified files:
- `asf_heat_pump_suitability/pipeline/cluster/cluster.py` - fix fragmented cell handling AGAIN to prevent overlapping polygons. Add warnings to indicate if there are potential issues with the clustering. These warnings will be converted to proper unit tests once the unit testing infrastructure is present.
- `asf_heat_pump_suitability/pipeline/transform/decision_tree.py` - UPRNs with no building footprint were not being handled correctly by this script which resulted in the creation of a row in the final tech type per building footprint geodataframe with no building ID and an empty geometry. This then creates downstream problems in the clustering, giving the illusion that there is an issue with the clustering. I have used the existing mapping function to map UPRNs to either the building footprint they intersect with or the nearest that they are within 3m of. This handles valid EPC UPRNs which fall outside footprints. The remaining unmatched UPRNs are dropped from the analysis. Until a new `dev` run is completed with the changes here merged, this issue will raise the new warnings added in `cluster.py`.
- `asf_heat_pump_suitability/utils/geo_utils.py` - add new function to identify geometries within the same geodataframe which are overlapping.
- `asf_heat_pump_suitability/pipeline/transform/uprns.py` - removed a redundant docstring that I noticed.

# Instructions for Reviewer

In order to test the code in this PR you need to ...
run the `cluster.py` script and then the test snippet above on the results. Run the script using:
`python asf_heat_pump_suitability/pipeline/cluster/cluster.py --local_authorities LOCAL_AUTHORITY`

I ran this on Plymouth and Midlothian already so it would be great if you could test it on a different one, e.g. Vale of Glamorgan.

Please pay special attention to ...
- the new logic to handle cell fragments
- the new logic in `overlay_gdf_physical_barriers` in `cluster.py` intended to retain more Voronoi cells
- the changes to `decision_tree.py`. Are there any potential unintended consequences of these changes that you can see?

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
