### PR TITLE
387 deal with non existing layers for some grid squares

### DIFF
--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -265,7 +265,13 @@ def load_gdf_os_openmap_layer(
 
         for file in files:
             print(f"\nLoading OS OpenMap layer - {layer.title()} file: {file}")
-            gdfs.append(gpd.read_file(file, **kwargs))
+            try:
+                gdfs.append(gpd.read_file(file, **kwargs))
+            except Exception as e:
+                # dealing with non-existing layers (e.g. no bodies of water in the grid square so no surface water area layer)
+                print(
+                    f"Error loading OS OpenMap layer - {layer.title()} file {file}: {e}"
+                )
 
         gdf = pd.concat(gdfs)
         id_col = "ID" if "ID" in gdf.columns else "id"

--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -267,7 +267,7 @@ def load_gdf_os_openmap_layer(
             print(f"\nLoading OS OpenMap layer - {layer.title()} file: {file}")
             try:
                 gdfs.append(gpd.read_file(file, **kwargs))
-            except Exception as e:
+            except FileNotFoundError as e:
                 # dealing with non-existing layers (e.g. no bodies of water in the grid square so no surface water area layer)
                 print(
                     f"Error loading OS OpenMap layer - {layer.title()} file {file}: {e}"


### PR DESCRIPTION

# Description

This PR adds a try/except block to the `load_gdf_os_openmap_layer()` function in `load_geodata.py`. This prevents the script to stop due to missing files/layers for specific grid squares - for example, this was the case for Dudley, where one of the grid squares (grid square `SP`) did not have one of the layers.

Fixes #387 

# Instructions for Reviewer

Can you please check the code runs (without saving) and that this addition does not cause any unexpected behaviour? e.g. existing files not being loaded.

You can check the code using the snippet below:

```
from asf_heat_pump_suitability.getters import load_geodata

grid_square = 'SP' # you can check for 'SO' too for example
for layer in ['building',
        'car_charging_point',
        'electricity_transmission_line',
        'foreshore',
        'functional_site',
        'glasshouse',
        'greenspace_site',
        'important_building',
        'motorway_junction',
        'named_place',
        'railway_station',
        'railway_track',
        'railway_tunnel',
        'road',
        'road_tunnel',
        'roundabout',
        'surface_water_area',
        'surface_water_line',
        'tidal_boundary',
        'tidal_water',
        'woodland']:
    # checking the code runs
    load_geodata.load_gdf_os_openmap_layer(layer = layer, grid_square = grid_square)
```