### PR TITLE
Bugfix 401 aggregate within radius

### DIFF
--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -133,11 +133,10 @@ def generate_gdf_clusters(
     )
 
     # Create cluster geometries
-    cluster_id = "_internal_cluster_id"
     clusters_gdf = (
         cells_gdf.dissolve(by="assigned_tech")
         .explode()
-        .reset_index(names=cluster_id)[["assigned_tech", "geometry"]]
+        .reset_index()[["assigned_tech", "geometry"]]
     )
 
     # Create an ID for each geometry that starts with the tech code and ends with a unique number
@@ -155,9 +154,9 @@ def generate_gdf_clusters(
         reassigned_gdf[[f"within_{radius}m_from_anchor_load", "geometry"]],
         how="left",
         predicate="contains",
-    )
+    ).drop(columns="index_right")
 
-    clusters_gdf = clusters_gdf.dissolve(by="cluster_id", aggfunc="max")
+    clusters_gdf = clusters_gdf.dissolve(by="cluster_id", aggfunc="max").reset_index()
 
     # TODO move to testing when sample set available
     if round(clusters_gdf["geometry"].area.sum(), 3) > round(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -56,7 +56,7 @@ TECH_CODES = {
 NETWORKED = TECH_TYPES["networked"]
 COMMUNAL = TECH_TYPES["communal"]
 
-ANCHOR_REASSINGMENT_MAPPING = {NETWORKED: COMMUNAL}
+ANCHOR_REASSIGNMENT_MAPPING = {NETWORKED: COMMUNAL}
 
 
 def generate_gdf_clusters(
@@ -81,8 +81,7 @@ def generate_gdf_clusters(
         tech_gdf (gpd.GeoDataFrame): domestic building footprints with assigned tech types.
         line_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)LineString geometries to separate clusters by.
         polygon_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)Polygon geometries to separate clusters by.
-        poi_gdf (gpd.GeoDataFrame): anchor properties dataframe taken from POI data, with point geometries
-        important_buildings_gdf (gpd.GeoDataFrame): important building footprint polygons
+        combined_anchor_gdf (gpd.GeoDataFrame): combined anchor property lists from important buildings and POI data, with building footprints
         radius (float): radius in metres around anchor property within which communal solutions should be assigned
         id_col (str): building ID column. Default "ID".
 
@@ -522,7 +521,7 @@ def sjoin_gdf_max_intersection(
     )
 
 
-def load_tranform_gdf_linestring_barriers(
+def load_transform_gdf_linestring_barriers(
     grid_squares: Optional[List[str]],
 ) -> gpd.GeoDataFrame:
     """
@@ -685,7 +684,7 @@ def load_transform_anchor_property_gdfs(
     combined_anchor_gdf = pd.concat(
         [anchors_with_footprint, important_building_gdf], join="inner"
     )
-    combined_anchor_gdf["geometry"] = combined_anchor_gdf.normalize()
+    combined_anchor_gdf["geometry"] = combined_anchor_gdf.geometry.normalize()
     combined_anchor_gdf = combined_anchor_gdf.drop_duplicates(["geometry"])
     return combined_anchor_gdf
 
@@ -718,7 +717,7 @@ def reassign_gdf_near_anchor_properties(
     # if distance column is not NaN (i.e. building is within the radius of an anchor), reassign tech type according to the map
     tech_gdf["assigned_tech"] = np.where(
         tech_gdf["distance_m"].notna(),
-        tech_gdf["assigned_tech"].replace(ANCHOR_REASSINGMENT_MAPPING),
+        tech_gdf["assigned_tech"].replace(ANCHOR_REASSIGNMENT_MAPPING),
         tech_gdf["assigned_tech"],
     )
     # add column with True if near anchor, False if not
@@ -859,7 +858,7 @@ if __name__ == "__main__":
     )
 
     # Load and transform physical barriers for clusters
-    line_overlay_gdf = load_tranform_gdf_linestring_barriers(
+    line_overlay_gdf = load_transform_gdf_linestring_barriers(
         local_authority_dict["grid_squares"]
     )
     polygon_overlay_gdf = load_transform_gdf_polygon_barriers(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -156,6 +156,9 @@ def generate_gdf_clusters(
         predicate="contains",
     ).drop(columns="index_right")
 
+    # At this point we have multiple rows of each cluster geometry with one row for every building within the cluster.
+    # We need to flatten the cluster geometries to one row per cluster, aggregating the within_anchor_radius boolean flag.
+    # Selecting `max` of the boolean will mean any clusters containing one building within the anchor radius will be labelled as within the radius.
     clusters_gdf = clusters_gdf.dissolve(by="cluster_id", aggfunc="max").reset_index()
 
     # TODO move to testing when sample set available

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -158,7 +158,7 @@ def generate_gdf_clusters(
         predicate="contains",
     )
 
-    clusters_gdf = clusters_gdf.groupby("cluster_id").agg(max)
+    clusters_gdf = clusters_gdf.dissolve(by="cluster_id", aggfunc="max")
 
     # TODO move to testing when sample set available
     if round(clusters_gdf["geometry"].area.sum(), 3) > round(

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -56,7 +56,7 @@ TECH_CODES = {
 NETWORKED = TECH_TYPES["networked"]
 COMMUNAL = TECH_TYPES["communal"]
 
-TECH_MAPPING = {NETWORKED: COMMUNAL}
+ANCHOR_REASSINGMENT_MAPPING = {NETWORKED: COMMUNAL}
 
 
 def generate_gdf_clusters(
@@ -133,26 +133,12 @@ def generate_gdf_clusters(
         reassigned_gdf.set_index(id_col).to_dict()["assigned_tech"]
     )
 
-    # Add "within_{radius}m_from_anchor_load" as a column to cells_gdf
-    cells_gdf = cells_gdf.merge(
-        reassigned_gdf[[id_col, f"within_{radius}m_from_anchor_load"]],
-        on=id_col,
-        how="left",
-    )
-
-    # Creating the clusters
+    # Create cluster geometries
+    cluster_id = "_internal_cluster_id"
     clusters_gdf = (
-        cells_gdf.dissolve(
-            by="assigned_tech",
-            aggfunc={
-                # If any building in cluster is within anchor load radius, label cluster as within radius
-                f"within_{radius}m_from_anchor_load": "max",
-            },
-        )
+        cells_gdf.dissolve(by="assigned_tech")
         .explode()
-        .reset_index()[
-            ["assigned_tech", "geometry", f"within_{radius}m_from_anchor_load"]
-        ]
+        .reset_index(names=cluster_id)[["assigned_tech", "geometry"]]
     )
 
     # Create an ID for each geometry that starts with the tech code and ends with a unique number
@@ -164,6 +150,15 @@ def generate_gdf_clusters(
         + "_"
         + (clusters_gdf["cluster_id"] + 1).astype(str)
     )
+
+    # Join boolean flag for each building contained in the cluster back to the cluster to aggregate
+    clusters_gdf = clusters_gdf.sjoin(
+        reassigned_gdf[[f"within_{radius}m_from_anchor_load", "geometry"]],
+        how="left",
+        predicate="contains",
+    )
+
+    clusters_gdf = clusters_gdf.groupby("cluster_id").agg(max)
 
     # TODO move to testing when sample set available
     if round(clusters_gdf["geometry"].area.sum(), 3) > round(
@@ -723,7 +718,7 @@ def reassign_gdf_near_anchor_properties(
     # if distance column is not NaN (i.e. building is within the radius of an anchor), reassign tech type according to the map
     tech_gdf["assigned_tech"] = np.where(
         tech_gdf["distance_m"].notna(),
-        tech_gdf["assigned_tech"].replace(TECH_MAPPING),
+        tech_gdf["assigned_tech"].replace(ANCHOR_REASSINGMENT_MAPPING),
         tech_gdf["assigned_tech"],
     )
     # add column with True if near anchor, False if not


### PR DESCRIPTION
Fixes #401 

# Description

Fix bug causing all values in anchor property flag to show True for all tech types and all clusters except networked heat pump.

Previously, there was a dissolve aggregation step that was dissolving all cells of the same tech type into one multipolygon with the max `within_50m_from_anchor_load` value across the whole tech type. This would be true for all tech types except networked HP which only remains assigned as the tech if the cell is NOT within the anchor load radius. I've fixed this.

Fyi, a small number of clusters will show NAN values at the moment for the boolean flag. This should be fixed by merging the changes in #389 

# Instructions for Reviewer

In order to test the code in this PR you need to ...
run the following line in terminal without saving and check the results of `cluster_gdf`
`python asf_heat_pump_suitability/pipeline/cluster/cluster.py --local_authorities plymouth`

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [ ] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [x] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
