### PR TITLE
406 and 407: fix missing error from except block and enhance cluster id with LA slug

### DIFF
--- a/asf_heat_pump_suitability/getters/load_geodata.py
+++ b/asf_heat_pump_suitability/getters/load_geodata.py
@@ -4,6 +4,7 @@ import os
 import pandas as pd
 from typing import Optional, List
 import boto3
+import pyogrio
 import s3fs
 import shapely
 import logging
@@ -273,7 +274,7 @@ def load_gdf_os_openmap_layer(
             print(f"\nLoading OS OpenMap layer - {layer.title()} file: {file}")
             try:
                 gdfs.append(gpd.read_file(file, **kwargs))
-            except FileNotFoundError as e:
+            except (FileNotFoundError, pyogrio.errors.DataSourceError) as e:
                 # dealing with non-existing layers (e.g. no bodies of water in the grid square so no surface water area layer)
                 print(
                     f"Error loading OS OpenMap layer - {layer.title()} file {file}: {e}"

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -67,6 +67,7 @@ def generate_gdf_clusters(
     polygon_overlay_gdf: gpd.GeoDataFrame,
     combined_anchor_gdf: gpd.GeoDataFrame,
     radius: float,
+    local_authorities_slug: str,
     id_col: str = "ID",
 ) -> gpd.GeoDataFrame:
     """
@@ -83,6 +84,7 @@ def generate_gdf_clusters(
         polygon_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)Polygon geometries to separate clusters by.
         combined_anchor_gdf (gpd.GeoDataFrame): combined anchor property lists from important buildings and POI data, with building footprints
         radius (float): radius in metres around anchor property within which communal solutions should be assigned
+        local_authorities_slug (str): slug of local authority to generate clusters for. Used to create unique cluster IDs.
         id_col (str): building ID column. Default "ID".
 
     Returns:
@@ -147,6 +149,7 @@ def generate_gdf_clusters(
         clusters_gdf["assigned_tech"].map(TECH_CODES)
         + "_"
         + (clusters_gdf["cluster_id"] + 1).astype(str)
+        + local_authorities_slug
     )
 
     # Join boolean flag for each building contained in the cluster back to the cluster to aggregate
@@ -880,6 +883,7 @@ if __name__ == "__main__":
         polygon_overlay_gdf=polygon_overlay_gdf,
         combined_anchor_gdf=combined_anchor_gdf,
         radius=ANCHOR_RADIUS,
+        local_authorities_slug=local_authority_dict["url_slug"],
     )
 
     # Add heat network zones to clusters_gdf, if they exist


### PR DESCRIPTION
---

# Description

This PR:
- adds a prefix with LA slug to cluster ID. This is required by the front end, to avoid confusion between clusters across LAs (that previously had the same ID e.g. IND_101 in LA1 and LA2 should now be, respectively, IND_102_la1_slug and IND_102_la2_slug)
- Fixes a bug when loading OS open map data layers

Fixes #406 #407

# Instructions for Reviewer

You can check the code using the snippet below:

```
from asf_heat_pump_suitability.getters import load_geodata

grid_square = 'SP' # you can check for 'SO' too for example
for layer in ['building',
        'car_charging_point',
        'electricity_transmission_line',
        'foreshore',
        'functional_site',
        'glasshouse',
        'greenspace_site',
        'important_building',
        'motorway_junction',
        'named_place',
        'railway_station',
        'railway_track',
        'railway_tunnel',
        'road',
        'road_tunnel',
        'roundabout',
        'surface_water_area',
        'surface_water_line',
        'tidal_boundary',
        'tidal_water',
        'woodland']:
    # checking the code runs
    load_geodata.load_gdf_os_openmap_layer(layer = layer, grid_square = grid_square)
```

No need to run anything to test the cluster_id, as I've run the pipeline and checked it's generating the correct output.