### PR TITLE
415 postcode analysis for individual solutions

### DIFF
--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -41,7 +41,6 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
-# Lowercase keys to avoid case-sensitivity bugs with multi-word inputs
 la_code_mapping = {
     "babergh": "E07000200",
     "wiltshire": "E06000054",
@@ -76,11 +75,14 @@ if __name__ == "__main__":
         )
     )
 
+    # Load buildings geodataframe for the local authority
+    print(f"Loading {local_authority} buildings geodataframe...")
     buildings_gdf = load_geodata.load_gdf_os_openmap_layer(
         layer="building", grid_squares=local_authority_dict["grid_squares"]
     )
 
-    print("Loading clusters...")
+    # Load clusters geodataframe for the local authority
+    print(f"Loading {local_authority} clusters ...")
     clusters_gdf = gpd.read_parquet(
         config["output"]["dataset"]["tech_clusters"].format(
             local_authorities=local_authority_dict["url_slug"],
@@ -88,17 +90,16 @@ if __name__ == "__main__":
         ),
     ).to_crs(epsg=27700)
 
+    # Map UPRNs to clusters
+    print(f"Mapping {local_authority} UPRNs to clusters...")
     uprns_df = cluster.map_df_uprns_to_clusters(
         uprns_df=uprns_df, buildings_gdf=buildings_gdf, clusters_gdf=clusters_gdf
     )
 
-    print(len(uprns_df))
-    # Drop cluster_ids starting with DESNZ_HNZ
+    # Dropping UPRNs in HN zone
     uprns_df = uprns_df.filter(~pl.col("cluster_id").str.starts_with("DESNZ_HNZ"))
-    print(len(uprns_df))
 
-    # Map each UPRN to its postcode
-    print("Mapping UPRNs to postcodes...")
+    print("Loading UPRN to postcode mapping from S3...")
     s3_client = boto3.client("s3")
 
     path = config["data"]["geodata"]["gb_uprn_country_mapping"]
@@ -121,7 +122,7 @@ if __name__ == "__main__":
         pl.col("lad25cd") == la_code_mapping[local_authority]
     )
 
-    # Merge the UPRN to country mapping with the UPRNs DataFrame
+    # Extend uprns_df with postcode information
     uprns_df = uprns_df.join(
         uprn_to_postcode_df.select(["UPRN", "postcode"]),
         on="UPRN",
@@ -133,12 +134,12 @@ if __name__ == "__main__":
         pl.col("UPRN").count().over("postcode").alias("n_domestic_uprns_in_postcode")
     )
 
-    # Number of UPRNs per postcode overall
+    # Aggregate UPRN counts per postcode
     uprns_per_postcode_df = uprn_to_postcode_df.group_by("postcode").agg(
         pl.col("UPRN").count().alias("n_uprns_in_postcode")
     )
 
-    # Merge overall UPRN counts
+    # Extend uprns_df with overall UPRN counts per postcode
     uprns_df = uprns_df.join(
         uprns_per_postcode_df.select(["postcode", "n_uprns_in_postcode"]),
         on="postcode",
@@ -146,12 +147,14 @@ if __name__ == "__main__":
     )
 
     # Identify suitability flags
+    # Suitable for individual solutions if cluster_id starts with "IND"
     uprns_df = uprns_df.with_columns(
         pl.col("cluster_id")
         .str.starts_with("IND")
         .alias("suitable_for_individual_solutions")
     )
 
+    # Less suitable for individual solutions if cluster_id starts with "NHP", "COM", or "DESNZ"
     uprns_df = uprns_df.with_columns(
         (
             pl.col("cluster_id").str.starts_with("NHP")

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
         )
     )
 
-    # Group and generate summary DataFrame
+    # Group and generate summary df
     summary_per_postcode_df = (
         uprns_df.group_by("postcode")
         .agg(
@@ -211,7 +211,7 @@ if __name__ == "__main__":
         )
         .with_columns(
             [
-                # Percent UPRNs in owner-occupied tenure (with safety for division-by-zero)
+                # Percent UPRNs in owner-occupied tenure
                 (
                     pl.col("n_owner-occupied")
                     / pl.col("n_domestic_uprns_in_postcode")
@@ -223,7 +223,7 @@ if __name__ == "__main__":
                     / pl.col("n_domestic_uprns_in_postcode")
                     * 100
                 ).alias("percent_unknown_tenure"),
-                # Properly aliased boolean suitability column
+                # Postcode suitability for individual solutions: True if at least one UPRN is suitable for individual solutions, False otherwise
                 (
                     pl.col("one_uprn_or_more_suitable_for_individual_solutions")
                     & ~pl.col("one_uprn_or_more_less_suitable_for_individual_solutions")
@@ -238,7 +238,7 @@ if __name__ == "__main__":
         )
     )
 
-    # Save summary per postcode DF locally as a CSV file
+    # Save summary per postcode df locally as a CSV file
     summary_per_postcode_df.write_csv(
         os.path.join(
             PROJECT_DIR,

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -1,0 +1,174 @@
+"""
+Analysis of postcodes most suitable for individual solutions.
+
+Run with: python asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py --local_authorities LOCAL_AUTHORITY
+
+where LOCAL_AUTHORITY is the name of the local authority to run the analysis for, e.g. "plymouth" or "glasgow city".
+"""
+
+import argparse
+import polars as pl
+import geopandas as gpd
+import pandas as pd
+
+from asf_heat_pump_suitability import config
+from asf_heat_pump_suitability.pipeline.cluster import cluster
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Create ArgumentParser and parse.
+
+    Returns:
+        argparse.Namespace: populated `Namespace`
+    """
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--local_authorities",
+        help="Local authority or authorities (case insensitive) e.g. -- 'plymouth' to run for Plymouth or --'glasgow city' 'south lanarkshire' to run for both Glasgow City and South Lanarkshire.",
+        type=str,
+        nargs="+",
+        required=True,
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    from asf_heat_pump_suitability.getters import load_geodata
+    from asf_heat_pump_suitability.pipeline.transform import local_authority
+    from asf_heat_pump_suitability import config
+
+    args = parse_arguments()
+    local_authorities = args.local_authorities
+    tolerance_m = config["constant"]["clustering"]["tolerance_m"]
+
+    local_authority_dict = local_authority.get_dict_la_data(local_authorities)
+
+    print(f"Loading {local_authorities} domestic UPRNs...")
+    uprns_df = pl.read_parquet(
+        config["output"]["dataset"]["domestic_uprns_with_features"].format(
+            local_authority=local_authority_dict["url_slug"]
+        )
+    )
+
+    buildings_gdf = load_geodata.load_gdf_os_openmap_layer(
+        layer="building", grid_squares=local_authority_dict["grid_squares"]
+    )
+
+    print("Loading clusters...")
+    clusters_gdf = gpd.read_parquet(
+        config["output"]["dataset"]["tech_clusters"].format(
+            local_authorities=local_authority_dict["url_slug"],
+            tolerance_m=tolerance_m,
+        ),
+    ).to_crs(epsg=27700)
+
+    uprns_df = cluster.map_df_uprns_to_clusters(
+        uprns_df=uprns_df, buildings_gdf=buildings_gdf, clusters_gdf=clusters_gdf
+    )
+
+    # Drop cluster_ids starting with DESNZ_HNZ
+    uprns_df = uprns_df.filter(~uprns_df["cluster_id"].str.startswith("DESNZ_HNZ"))
+
+    # Map each UPRN to its postcode
+    print("Mapping UPRNs to postcodes...")
+    import boto3
+
+    s3_client = boto3.client("s3")
+
+    path = config["data"]["geodata"]["gb_uprn_country_mapping"]
+    bucket_name = path.split("s3://")[1].split("/")[0]
+    prefix = path.split(f"s3://{bucket_name}/")[1]
+
+    response = s3_client.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
+    files = [
+        f"s3://{bucket_name}/{obj['Key']}"
+        for obj in response.get("Contents", [])
+        if obj["Key"].endswith(".csv")
+    ]
+
+    uprn_to_country_df = pd.concat(
+        [pd.read_csv(file, usecols=["UPRN", "PCDS"]) for file in files],
+        ignore_index=True,
+    )
+
+    # Number of UPRNs per postcode
+    uprn_to_country_df = (
+        uprn_to_country_df.groupby("PCDS").agg({"UPRN": "count"}).reset_index()
+    )
+    uprn_to_country_df.rename(
+        columns={"UPRN": "n_uprns", "PCDS": "postcode"}, inplace=True
+    )
+
+    # Merge the UPRN to country mapping with the UPRNs DataFrame
+    uprns_df = uprns_df.join(
+        pl.DataFrame(uprn_to_country_df),
+        on="postcode",
+        how="left",
+    )
+
+    # Identify postcodes most suitable for individual solutions, those with cluster_id starting with "IND"
+    uprns_df = uprns_df.with_columns(
+        pl.when(uprns_df["cluster_id"].str.startswith("IND"))
+        .then(pl.lit(True))
+        .otherwise(pl.lit(False))
+        .alias("suitable_for_individual_solutions")
+    )
+
+    # Identify postcodes less suitable for individual solutions, those with cluster_id starting with "NHP", "COM" or "DESNZ"
+    uprns_df = uprns_df.with_columns(
+        pl.when(
+            uprns_df["cluster_id"].str.startswith("NHP")
+            | uprns_df["cluster_id"].str.startswith("COM")
+            | uprns_df["cluster_id"].str.startswith("DESNZ")
+        )
+        .then(pl.lit(True))
+        .otherwise(pl.lit(False))
+        .alias("less_suitable_for_individual_solutions")
+    )
+
+    # Get df of postcodes where less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False
+    postcodes_df = uprns_df.filter(
+        (uprns_df["less_suitable_for_individual_solutions"])
+        & ~(uprns_df["suitable_for_individual_solutions"])
+    ).select(["postcode"])
+
+    # TODO: use all postcodes in the local authority, not just those with UPRNs
+
+    # for each postcode, get the number of UPRNs and the number of UPRNs
+    uprns_df.select(
+        [
+            "postcode",
+            "n_uprns",
+            "suitable_for_individual_solutions",
+            "TNURE",
+            "max_contiguous_outdoor_space_area_m2",
+        ]
+    ).groupby("postcode").agg(
+        [
+            pl.first("n_uprns").alias("total_uprns"),
+            pl.any("suitable_for_individual_solutions").alias(
+                "is_suitable_for_individual_solutions"
+            ),
+            pl.sum(
+                pl.when(uprns_df["TNURE"] == "owner-occupied").then(1).otherwise(0)
+            ).alias("n_owner-occupied"),
+            pl.sum(pl.when(uprns_df["TNURE"].is_null()).then(1).otherwise(0)).alias(
+                "n_unknown_tenure"
+            ),
+            pl.mean("max_contiguous_outdoor_space_area_m2").alias(
+                "mean_max_contiguous_outdoor_space_area_m2"
+            ),
+        ]
+    ).with_columns(
+        # percent uprns in owner-occupied tenure
+        (pl.col("n_owner-occupied") / pl.col("total_uprns") * 100).alias(
+            "percent_owner_occupied"
+        ),
+        # percent uprns with unknown tenure
+        (pl.col("n_unknown_tenure") / pl.col("total_uprns") * 100).alias(
+            "percent_unknown_tenure"
+        ),
+    )

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -86,7 +86,6 @@ if __name__ == "__main__":
     clusters_gdf = gpd.read_parquet(
         config["output"]["dataset"]["tech_clusters"].format(
             local_authorities=local_authority_dict["url_slug"],
-            tolerance_m=tolerance_m,
         ),
     ).to_crs(epsg=27700)
 
@@ -192,17 +191,31 @@ if __name__ == "__main__":
         uprns_df.group_by("postcode")
         .agg(
             [
-                pl.col("n_domestic_uprns_in_postcode")
-                .first()
-                .alias("n_domestic_uprns_in_postcode"),
-                pl.col("n_uprns_in_postcode").first().alias("n_uprns_in_postcode"),
+                pl.col("n_domestic_uprns_in_postcode").first(),
+                pl.col("n_uprns_in_postcode").first(),
                 pl.col("suitable_for_individual_solutions")
                 .any()
                 .alias("one_uprn_or_more_suitable_for_individual_solutions"),
                 pl.col("less_suitable_for_individual_solutions")
                 .any()
                 .alias("one_uprn_or_more_less_suitable_for_individual_solutions"),
-                pl.col("TENURE").eq("owner-occupied").sum().alias("n_owner-occupied"),
+                pl.col("suitable_for_individual_solutions")
+                .count()
+                .alias("n_suitable_for_individual_solutions"),
+                pl.col("less_suitable_for_individual_solutions")
+                .count()
+                .alias("n_less_suitable_for_individual_solutions"),
+                (
+                    pl.col("n_suitable_for_individual_solutions")
+                    / pl.col("n_domestic_uprns_in_postcode")
+                    * 100
+                ).alias("percent_suitable_for_individual_solutions"),
+                (
+                    pl.col("n_less_suitable_for_individual_solutions")
+                    / pl.col("n_domestic_uprns_in_postcode")
+                    * 100
+                ).alias("percent_less_suitable_for_individual_solutions"),
+                pl.col("TENURE").eq("owner-occupied").sum().alias("n_owner_occupied"),
                 pl.col("TENURE").is_null().sum().alias("n_unknown_tenure"),
                 pl.col("max_contiguous_outdoor_space_area_m2")
                 .mean()
@@ -213,7 +226,7 @@ if __name__ == "__main__":
             [
                 # Percent UPRNs in owner-occupied tenure
                 (
-                    pl.col("n_owner-occupied")
+                    pl.col("n_owner_occupied")
                     / pl.col("n_domestic_uprns_in_postcode")
                     * 100
                 ).alias("percent_domestic_owner_occupied"),
@@ -223,10 +236,14 @@ if __name__ == "__main__":
                     / pl.col("n_domestic_uprns_in_postcode")
                     * 100
                 ).alias("percent_unknown_tenure"),
-                # Postcode suitability for individual solutions: True if at least one UPRN is suitable for individual solutions, False otherwise
+                # Postcode suitable for individual solutions: True if at least one UPRN is suitable for individual solutions, False otherwise
+                pl.col("one_uprn_or_more_suitable_for_individual_solutions").alias(
+                    "postcode_suitable_for_individual_solutions"
+                ),
+                # Postcode less suitable for individual solutions: True if at least one UPRN is less suitable for individual solutions and no UPRNs are suitable for individual solutions, False otherwise
                 (
-                    pl.col("one_uprn_or_more_suitable_for_individual_solutions")
-                    & ~pl.col("one_uprn_or_more_less_suitable_for_individual_solutions")
+                    ~pl.col("one_uprn_or_more_suitable_for_individual_solutions")
+                    & pl.col("one_uprn_or_more_less_suitable_for_individual_solutions")
                 ).alias("postcode_less_suitable_for_individual_solutions"),
             ]
         )
@@ -246,3 +263,12 @@ if __name__ == "__main__":
             f"summary_{local_authority}_postcode_suitability_individual_solutions_{datetime.today().strftime('%Y%m%d')}.csv",
         )
     )
+
+    # Check that postcodes in postcodes_less_suitable_individual_df are the postcodes in summary_per_postcode_df where postcode_less_suitable_for_individual_solutions is True
+    postcodes_less_suitable_individual_df_check = summary_per_postcode_df.filter(
+        pl.col("postcode_less_suitable_for_individual_solutions")
+    ).select("postcode")
+
+    assert postcodes_less_suitable_individual_df.frame_equal(
+        postcodes_less_suitable_individual_df_check
+    ), "Postcodes in postcodes_less_suitable_individual_df do not match postcodes in summary_per_postcode_df where postcode_less_suitable_for_individual_solutions is True"

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -1,18 +1,25 @@
 """
 Analysis of postcodes most suitable for individual solutions.
 
-Run with: python asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py --local_authorities LOCAL_AUTHORITY
+Run with: python asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py --local_authority LOCAL_AUTHORITY
 
-where LOCAL_AUTHORITY is the name of the local authority to run the analysis for, e.g. "plymouth" or "glasgow city".
+where LOCAL_AUTHORITY is the name of the local authority to run the analysis for, e.g. "plymouth" or "east suffolk".
 """
 
+# package imports
 import argparse
 import polars as pl
 import geopandas as gpd
-import pandas as pd
+import os
+import boto3
+from datetime import datetime
 
+# local imports
+from asf_heat_pump_suitability import PROJECT_DIR
 from asf_heat_pump_suitability import config
 from asf_heat_pump_suitability.pipeline.cluster import cluster
+from asf_heat_pump_suitability.getters import load_geodata
+from asf_heat_pump_suitability.pipeline.transform import local_authority as tla
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -25,28 +32,44 @@ def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--local_authorities",
-        help="Local authority or authorities (case insensitive) e.g. -- 'plymouth' to run for Plymouth or --'glasgow city' 'south lanarkshire' to run for both Glasgow City and South Lanarkshire.",
+        "--local_authority",
+        help="Local authority to run the analysis for, e.g. 'plymouth' or 'glasgow city'.",
         type=str,
-        nargs="+",
         required=True,
     )
 
     return parser.parse_args()
 
 
+# Lowercase keys to avoid case-sensitivity bugs with multi-word inputs
+la_code_mapping = {
+    "babergh": "E07000200",
+    "wiltshire": "E06000054",
+    "east suffolk": "E07000244",
+    "ipswich": "E07000202",
+    "mid suffolk": "E07000203",
+    "west suffolk": "E07000245",
+    "breckland": "E07000143",
+    "west berkshire": "E06000037",
+    "somerset": "E06000066",
+    "dorset": "E06000059",
+    "plymouth": "E06000026",
+}
+
 if __name__ == "__main__":
-    from asf_heat_pump_suitability.getters import load_geodata
-    from asf_heat_pump_suitability.pipeline.transform import local_authority
-    from asf_heat_pump_suitability import config
-
     args = parse_arguments()
-    local_authorities = args.local_authorities
+    local_authority = args.local_authority.strip().lower()
+
+    if local_authority not in la_code_mapping:
+        raise ValueError(
+            f"Local authority '{local_authority}' is not present in la_code_mapping. "
+            f"Available options: {list(la_code_mapping.keys())}"
+        )
+
     tolerance_m = config["constant"]["clustering"]["tolerance_m"]
+    local_authority_dict = tla.get_dict_la_data(local_authority)
 
-    local_authority_dict = local_authority.get_dict_la_data(local_authorities)
-
-    print(f"Loading {local_authorities} domestic UPRNs...")
+    print(f"Loading {local_authority} domestic UPRNs...")
     uprns_df = pl.read_parquet(
         config["output"]["dataset"]["domestic_uprns_with_features"].format(
             local_authority=local_authority_dict["url_slug"]
@@ -69,13 +92,13 @@ if __name__ == "__main__":
         uprns_df=uprns_df, buildings_gdf=buildings_gdf, clusters_gdf=clusters_gdf
     )
 
+    print(len(uprns_df))
     # Drop cluster_ids starting with DESNZ_HNZ
-    uprns_df = uprns_df.filter(~uprns_df["cluster_id"].str.startswith("DESNZ_HNZ"))
+    uprns_df = uprns_df.filter(~pl.col("cluster_id").str.starts_with("DESNZ_HNZ"))
+    print(len(uprns_df))
 
     # Map each UPRN to its postcode
     print("Mapping UPRNs to postcodes...")
-    import boto3
-
     s3_client = boto3.client("s3")
 
     path = config["data"]["geodata"]["gb_uprn_country_mapping"]
@@ -89,86 +112,123 @@ if __name__ == "__main__":
         if obj["Key"].endswith(".csv")
     ]
 
-    uprn_to_country_df = pd.concat(
-        [pd.read_csv(file, usecols=["UPRN", "PCDS"]) for file in files],
-        ignore_index=True,
-    )
+    uprn_to_postcode_df = pl.concat(
+        [pl.read_csv(file, columns=["UPRN", "PCDS", "lad25cd"]) for file in files]
+    ).rename({"PCDS": "postcode"})
 
-    # Number of UPRNs per postcode
-    uprn_to_country_df = (
-        uprn_to_country_df.groupby("PCDS").agg({"UPRN": "count"}).reset_index()
-    )
-    uprn_to_country_df.rename(
-        columns={"UPRN": "n_uprns", "PCDS": "postcode"}, inplace=True
+    # Filter the UPRN to country mapping to only include UPRNs in the local authority
+    uprn_to_postcode_df = uprn_to_postcode_df.filter(
+        pl.col("lad25cd") == la_code_mapping[local_authority]
     )
 
     # Merge the UPRN to country mapping with the UPRNs DataFrame
     uprns_df = uprns_df.join(
-        pl.DataFrame(uprn_to_country_df),
+        uprn_to_postcode_df.select(["UPRN", "postcode"]),
+        on="UPRN",
+        how="left",
+    )
+
+    # Add n_domestic_uprns_in_postcode as a column in uprns_df
+    uprns_df = uprns_df.with_columns(
+        pl.col("UPRN").count().over("postcode").alias("n_domestic_uprns_in_postcode")
+    )
+
+    # Number of UPRNs per postcode overall
+    uprns_per_postcode_df = uprn_to_postcode_df.group_by("postcode").agg(
+        pl.col("UPRN").count().alias("n_uprns_in_postcode")
+    )
+
+    # Merge overall UPRN counts
+    uprns_df = uprns_df.join(
+        uprns_per_postcode_df.select(["postcode", "n_uprns_in_postcode"]),
         on="postcode",
         how="left",
     )
 
-    # Identify postcodes most suitable for individual solutions, those with cluster_id starting with "IND"
+    # Identify suitability flags
     uprns_df = uprns_df.with_columns(
-        pl.when(uprns_df["cluster_id"].str.startswith("IND"))
-        .then(pl.lit(True))
-        .otherwise(pl.lit(False))
+        pl.col("cluster_id")
+        .str.starts_with("IND")
         .alias("suitable_for_individual_solutions")
     )
 
-    # Identify postcodes less suitable for individual solutions, those with cluster_id starting with "NHP", "COM" or "DESNZ"
     uprns_df = uprns_df.with_columns(
-        pl.when(
-            uprns_df["cluster_id"].str.startswith("NHP")
-            | uprns_df["cluster_id"].str.startswith("COM")
-            | uprns_df["cluster_id"].str.startswith("DESNZ")
-        )
-        .then(pl.lit(True))
-        .otherwise(pl.lit(False))
-        .alias("less_suitable_for_individual_solutions")
+        (
+            pl.col("cluster_id").str.starts_with("NHP")
+            | pl.col("cluster_id").str.starts_with("COM")
+            | pl.col("cluster_id").str.starts_with("DESNZ")
+        ).alias("less_suitable_for_individual_solutions")
     )
 
     # Get df of postcodes where less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False
-    postcodes_df = uprns_df.filter(
-        (uprns_df["less_suitable_for_individual_solutions"])
-        & ~(uprns_df["suitable_for_individual_solutions"])
-    ).select(["postcode"])
+    postcodes_df = (
+        uprns_df.filter(
+            pl.col("less_suitable_for_individual_solutions")
+            & ~pl.col("suitable_for_individual_solutions")
+        )
+        .select(["postcode"])
+        .unique()
+    )
 
-    # TODO: use all postcodes in the local authority, not just those with UPRNs
+    # Save postcodes_df locally as a CSV file
+    postcodes_df.write_csv(
+        os.path.join(
+            PROJECT_DIR,
+            "outputs",
+            f"postcodes_{local_authority}_less_suitable_for_individual_solutions_{datetime.today().strftime('%Y%m%d')}.csv",
+        )
+    )
 
-    # for each postcode, get the number of UPRNs and the number of UPRNs
-    uprns_df.select(
-        [
-            "postcode",
-            "n_uprns",
-            "suitable_for_individual_solutions",
-            "TNURE",
-            "max_contiguous_outdoor_space_area_m2",
-        ]
-    ).groupby("postcode").agg(
-        [
-            pl.first("n_uprns").alias("total_uprns"),
-            pl.any("suitable_for_individual_solutions").alias(
-                "is_suitable_for_individual_solutions"
-            ),
-            pl.sum(
-                pl.when(uprns_df["TNURE"] == "owner-occupied").then(1).otherwise(0)
-            ).alias("n_owner-occupied"),
-            pl.sum(pl.when(uprns_df["TNURE"].is_null()).then(1).otherwise(0)).alias(
-                "n_unknown_tenure"
-            ),
-            pl.mean("max_contiguous_outdoor_space_area_m2").alias(
-                "mean_max_contiguous_outdoor_space_area_m2"
-            ),
-        ]
-    ).with_columns(
-        # percent uprns in owner-occupied tenure
-        (pl.col("n_owner-occupied") / pl.col("total_uprns") * 100).alias(
-            "percent_owner_occupied"
-        ),
-        # percent uprns with unknown tenure
-        (pl.col("n_unknown_tenure") / pl.col("total_uprns") * 100).alias(
-            "percent_unknown_tenure"
-        ),
+    # Group and generate summary DataFrame
+    summary_per_postcode_df = (
+        uprns_df.select(
+            [
+                "postcode",
+                "n_domestic_uprns_in_postcode",
+                "n_uprns_in_postcode",
+                "suitable_for_individual_solutions",
+                "TENURE",
+                "max_contiguous_outdoor_space_area_m2",
+            ]
+        )
+        .group_by("postcode")
+        .agg(
+            [
+                pl.col("n_domestic_uprns_in_postcode")
+                .first()
+                .alias("n_domestic_uprns_in_postcode"),
+                pl.col("n_uprns_in_postcode").first().alias("n_uprns_in_postcode"),
+                pl.col("suitable_for_individual_solutions")
+                .any()
+                .alias("is_suitable_for_individual_solutions"),
+                pl.col("TENURE").eq("owner-occupied").sum().alias("n_owner-occupied"),
+                pl.col("TENURE").is_null().sum().alias("n_unknown_tenure"),
+                pl.col("max_contiguous_outdoor_space_area_m2")
+                .mean()
+                .alias("mean_max_contiguous_outdoor_space_area_m2"),
+            ]
+        )
+        .with_columns(
+            # Percent UPRNs in owner-occupied tenure
+            (
+                pl.col("n_owner-occupied")
+                / pl.col("n_domestic_uprns_in_postcode")
+                * 100
+            ).alias("percent_owner_occupied"),
+            # Percent UPRNs with unknown tenure
+            (
+                pl.col("n_unknown_tenure")
+                / pl.col("n_domestic_uprns_in_postcode")
+                * 100
+            ).alias("percent_unknown_tenure"),
+        )
+    )
+
+    # Save summary per postcode DF locally as a CSV file
+    summary_per_postcode_df.write_csv(
+        os.path.join(
+            PROJECT_DIR,
+            "outputs",
+            f"summary_{local_authority}_less_suitable_for_individual_solutions_{datetime.today().strftime('%Y%m%d')}.csv",
+        )
     )

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -146,15 +146,15 @@ if __name__ == "__main__":
         how="left",
     )
 
-    # Identify suitability flags
-    # Suitable for individual solutions if cluster_id starts with "IND"
+    # Identify suitability flags at UPRN level based on cluster_id prefixes
+    # 1) Suitable for individual solutions if cluster_id starts with "IND"
     uprns_df = uprns_df.with_columns(
         pl.col("cluster_id")
         .str.starts_with("IND")
         .alias("suitable_for_individual_solutions")
     )
 
-    # Less suitable for individual solutions if cluster_id starts with "NHP", "COM", or "DESNZ"
+    # 2) Less suitable for individual solutions if cluster_id starts with "NHP", "COM", or "DESNZ"
     uprns_df = uprns_df.with_columns(
         (
             pl.col("cluster_id").str.starts_with("NHP")
@@ -163,18 +163,33 @@ if __name__ == "__main__":
         ).alias("less_suitable_for_individual_solutions")
     )
 
-    # Get df of postcodes where less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False
-    postcodes_df = (
-        uprns_df.filter(
-            pl.col("less_suitable_for_individual_solutions")
-            & ~pl.col("suitable_for_individual_solutions")
+    # Suitability at postcode level
+    # Less suitable for Individual solutions at postcode level: if less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False
+    # Essentially, if there is at least one UPRN suitable for individual solutions in the postcode, then the postcode is considered suitable for individual solutions.
+    postcodes_less_suitabe_individual_df = (
+        uprns_df.group_by("postcode")
+        # aggregate so that less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False, then the postcode is considered less suitable for individual solutions
+        .agg(
+            [
+                pl.col("less_suitable_for_individual_solutions")
+                .any()
+                .alias("less_suitable_for_individual_solutions"),
+                pl.col("suitable_for_individual_solutions")
+                .any()
+                .alias("suitable_for_individual_solutions"),
+            ]
         )
-        .select(["postcode"])
-        .unique()
-    )
+        .with_columns(
+            (
+                pl.col("less_suitable_for_individual_solutions")
+                & ~pl.col("suitable_for_individual_solutions")
+            ).alias("postcode_less_suitable_for_individual_solutions")
+        )
+        .filter(pl.col("postcode_less_suitable_for_individual_solutions"))
+    ).select(["postcode"])
 
     # Save postcodes_df locally as a CSV file
-    postcodes_df.write_csv(
+    postcodes_less_suitabe_individual_df.write_csv(
         os.path.join(
             PROJECT_DIR,
             "outputs",
@@ -203,7 +218,10 @@ if __name__ == "__main__":
                 pl.col("n_uprns_in_postcode").first().alias("n_uprns_in_postcode"),
                 pl.col("suitable_for_individual_solutions")
                 .any()
-                .alias("is_suitable_for_individual_solutions"),
+                .alias("one_uprn_or_more_suitable_for_individual_solutions"),
+                pl.col("less_suitable_for_individual_solutions")
+                .any()
+                .alias("one_uprn_or_more_less_suitable_for_individual_solutions"),
                 pl.col("TENURE").eq("owner-occupied").sum().alias("n_owner-occupied"),
                 pl.col("TENURE").is_null().sum().alias("n_unknown_tenure"),
                 pl.col("max_contiguous_outdoor_space_area_m2")
@@ -224,7 +242,16 @@ if __name__ == "__main__":
                 / pl.col("n_domestic_uprns_in_postcode")
                 * 100
             ).alias("percent_unknown_tenure"),
+            # postcode suitability for individual solutions if at least one UPRN in the postcode is suitable for individual solutions and none are less suitable for individual solutions.
+            pl.col("one_uprn_or_more_suitable_for_individual_solutions")
+            & ~pl.col("one_uprn_or_more_less_suitable_for_individual_solutions"),
         )
+        .alias("postcode_less_suitable_for_individual_solutions")
+    ).drop(
+        [
+            "n_owner-occupied",
+            "n_unknown_tenure",
+        ]
     )
 
     # Save summary per postcode DF locally as a CSV file

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -216,7 +216,7 @@ if __name__ == "__main__":
                     pl.col("n_owner-occupied")
                     / pl.col("n_domestic_uprns_in_postcode")
                     * 100
-                ).alias("percent_owner_occupied"),
+                ).alias("percent_domestic_owner_occupied"),
                 # Percent UPRNs with unknown tenure
                 (
                     pl.col("n_unknown_tenure")

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -153,12 +153,12 @@ if __name__ == "__main__":
         .alias("suitable_for_individual_solutions")
     )
 
-    # 2) Less suitable for individual solutions if cluster_id starts with "NHP", "COM", or "DESNZ"
+    # 2) Less suitable for individual solutions if cluster_id starts with "NHP", "COM", or "DHNZ"
     uprns_df = uprns_df.with_columns(
         (
             pl.col("cluster_id").str.starts_with("NHP")
             | pl.col("cluster_id").str.starts_with("COM")
-            | pl.col("cluster_id").str.starts_with("DESNZ")
+            | pl.col("cluster_id").str.starts_with("DHNZ")
         ).alias("less_suitable_for_individual_solutions")
     )
 
@@ -205,16 +205,6 @@ if __name__ == "__main__":
                 pl.col("less_suitable_for_individual_solutions")
                 .count()
                 .alias("n_less_suitable_for_individual_solutions"),
-                (
-                    pl.col("n_suitable_for_individual_solutions")
-                    / pl.col("n_domestic_uprns_in_postcode")
-                    * 100
-                ).alias("percent_suitable_for_individual_solutions"),
-                (
-                    pl.col("n_less_suitable_for_individual_solutions")
-                    / pl.col("n_domestic_uprns_in_postcode")
-                    * 100
-                ).alias("percent_less_suitable_for_individual_solutions"),
                 pl.col("TENURE").eq("owner-occupied").sum().alias("n_owner_occupied"),
                 pl.col("TENURE").is_null().sum().alias("n_unknown_tenure"),
                 pl.col("max_contiguous_outdoor_space_area_m2")
@@ -224,6 +214,18 @@ if __name__ == "__main__":
         )
         .with_columns(
             [
+                # Percent UPRNs suitable for individual solutions
+                (
+                    pl.col("n_suitable_for_individual_solutions")
+                    / pl.col("n_domestic_uprns_in_postcode")
+                    * 100
+                ).alias("percent_suitable_for_individual_solutions"),
+                # Percent UPRNs less suitable for individual solutions
+                (
+                    pl.col("n_less_suitable_for_individual_solutions")
+                    / pl.col("n_domestic_uprns_in_postcode")
+                    * 100
+                ).alias("percent_less_suitable_for_individual_solutions"),
                 # Percent UPRNs in owner-occupied tenure
                 (
                     pl.col("n_owner_occupied")
@@ -265,10 +267,34 @@ if __name__ == "__main__":
     )
 
     # Check that postcodes in postcodes_less_suitable_individual_df are the postcodes in summary_per_postcode_df where postcode_less_suitable_for_individual_solutions is True
-    postcodes_less_suitable_individual_df_check = summary_per_postcode_df.filter(
-        pl.col("postcode_less_suitable_for_individual_solutions")
-    ).select("postcode")
+    postcodes_less_suitable_individual_set_check = set(
+        summary_per_postcode_df.filter(
+            pl.col("postcode_less_suitable_for_individual_solutions")
+        )
+        .select("postcode")
+        .to_series()
+    )
+    postcodes_less_suitable_individual_set = set(
+        postcodes_less_suitable_individual_df.select("postcode").to_series()
+    )
+    assert (
+        postcodes_less_suitable_individual_set
+        == postcodes_less_suitable_individual_set_check
+    ), "Postcodes in postcodes_less_suitable_individual_df do not match postcodes in summary_per_postcode_df where postcode_less_suitable_for_individual_solutions is True."
 
-    assert postcodes_less_suitable_individual_df.frame_equal(
-        postcodes_less_suitable_individual_df_check
-    ), "Postcodes in postcodes_less_suitable_individual_df do not match postcodes in summary_per_postcode_df where postcode_less_suitable_for_individual_solutions is True"
+    # check that no postcode have both postcode_suitable_for_individual_solutions and postcode_less_suitable_for_individual_solutions as True or as False
+    assert (
+        summary_per_postcode_df.filter(
+            pl.col("postcode_suitable_for_individual_solutions")
+            & pl.col("postcode_less_suitable_for_individual_solutions")
+        ).height
+        == 0
+    ), "Some postcodes have both postcode_suitable_for_individual_solutions and postcode_less_suitable_for_individual_solutions as True."
+
+    assert (
+        summary_per_postcode_df.filter(
+            ~pl.col("postcode_suitable_for_individual_solutions")
+            & ~pl.col("postcode_less_suitable_for_individual_solutions")
+        ).height
+        == 0
+    ), "Some postcodes have both postcode_suitable_for_individual_solutions and postcode_less_suitable_for_individual_solutions as False."

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -166,30 +166,20 @@ if __name__ == "__main__":
     # Suitability at postcode level
     # Less suitable for Individual solutions at postcode level: if less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False
     # Essentially, if there is at least one UPRN suitable for individual solutions in the postcode, then the postcode is considered suitable for individual solutions.
-    postcodes_less_suitabe_individual_df = (
+    postcodes_less_suitable_individual_df = (
         uprns_df.group_by("postcode")
-        # aggregate so that less_suitable_for_individual_solutions is True and suitable_for_individual_solutions is False, then the postcode is considered less suitable for individual solutions
         .agg(
-            [
-                pl.col("less_suitable_for_individual_solutions")
-                .any()
-                .alias("less_suitable_for_individual_solutions"),
-                pl.col("suitable_for_individual_solutions")
-                .any()
-                .alias("suitable_for_individual_solutions"),
-            ]
-        )
-        .with_columns(
             (
-                pl.col("less_suitable_for_individual_solutions")
-                & ~pl.col("suitable_for_individual_solutions")
+                pl.col("less_suitable_for_individual_solutions").any()
+                & ~pl.col("suitable_for_individual_solutions").any()
             ).alias("postcode_less_suitable_for_individual_solutions")
         )
         .filter(pl.col("postcode_less_suitable_for_individual_solutions"))
-    ).select(["postcode"])
+        .select("postcode")
+    )
 
     # Save postcodes_df locally as a CSV file
-    postcodes_less_suitabe_individual_df.write_csv(
+    postcodes_less_suitable_individual_df.write_csv(
         os.path.join(
             PROJECT_DIR,
             "outputs",
@@ -199,17 +189,7 @@ if __name__ == "__main__":
 
     # Group and generate summary DataFrame
     summary_per_postcode_df = (
-        uprns_df.select(
-            [
-                "postcode",
-                "n_domestic_uprns_in_postcode",
-                "n_uprns_in_postcode",
-                "suitable_for_individual_solutions",
-                "TENURE",
-                "max_contiguous_outdoor_space_area_m2",
-            ]
-        )
-        .group_by("postcode")
+        uprns_df.group_by("postcode")
         .agg(
             [
                 pl.col("n_domestic_uprns_in_postcode")
@@ -230,28 +210,32 @@ if __name__ == "__main__":
             ]
         )
         .with_columns(
-            # Percent UPRNs in owner-occupied tenure
-            (
-                pl.col("n_owner-occupied")
-                / pl.col("n_domestic_uprns_in_postcode")
-                * 100
-            ).alias("percent_owner_occupied"),
-            # Percent UPRNs with unknown tenure
-            (
-                pl.col("n_unknown_tenure")
-                / pl.col("n_domestic_uprns_in_postcode")
-                * 100
-            ).alias("percent_unknown_tenure"),
-            # postcode suitability for individual solutions if at least one UPRN in the postcode is suitable for individual solutions and none are less suitable for individual solutions.
-            pl.col("one_uprn_or_more_suitable_for_individual_solutions")
-            & ~pl.col("one_uprn_or_more_less_suitable_for_individual_solutions"),
+            [
+                # Percent UPRNs in owner-occupied tenure (with safety for division-by-zero)
+                (
+                    pl.col("n_owner-occupied")
+                    / pl.col("n_domestic_uprns_in_postcode")
+                    * 100
+                ).alias("percent_owner_occupied"),
+                # Percent UPRNs with unknown tenure
+                (
+                    pl.col("n_unknown_tenure")
+                    / pl.col("n_domestic_uprns_in_postcode")
+                    * 100
+                ).alias("percent_unknown_tenure"),
+                # Properly aliased boolean suitability column
+                (
+                    pl.col("one_uprn_or_more_suitable_for_individual_solutions")
+                    & ~pl.col("one_uprn_or_more_less_suitable_for_individual_solutions")
+                ).alias("postcode_less_suitable_for_individual_solutions"),
+            ]
         )
-        .alias("postcode_less_suitable_for_individual_solutions")
-    ).drop(
-        [
-            "n_owner-occupied",
-            "n_unknown_tenure",
-        ]
+        .drop(
+            [
+                "one_uprn_or_more_suitable_for_individual_solutions",
+                "one_uprn_or_more_less_suitable_for_individual_solutions",
+            ]
+        )
     )
 
     # Save summary per postcode DF locally as a CSV file
@@ -259,6 +243,6 @@ if __name__ == "__main__":
         os.path.join(
             PROJECT_DIR,
             "outputs",
-            f"summary_{local_authority}_less_suitable_for_individual_solutions_{datetime.today().strftime('%Y%m%d')}.csv",
+            f"summary_{local_authority}_postcode_suitability_individual_solutions_{datetime.today().strftime('%Y%m%d')}.csv",
         )
     )

--- a/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
+++ b/asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py
@@ -270,9 +270,7 @@ if __name__ == "__main__":
     postcodes_less_suitable_individual_set_check = set(
         summary_per_postcode_df.filter(
             pl.col("postcode_less_suitable_for_individual_solutions")
-        )
-        .select("postcode")
-        .to_series()
+        ).get_column("postcode")
     )
     postcodes_less_suitable_individual_set = set(
         postcodes_less_suitable_individual_df.select("postcode").to_series()


### PR DESCRIPTION
---

# Description

This PR adds an analysis script to:
- **create a list of postcodes "less suitable" for individual solutions for specific LAs**: the assumption being that any clusters identified as networked HP, communal or DHN are less suitable for individual solutions.
- **identify all postcodes in each area including a summary of information for each**:
   - number of addresses in the postcode (both domestic and overall)
   - the average outdoor space on each address
   - distribution of tenure (we're showing owner occupiers and unknown info)
   - a tag of whether the postcode overall is most suitable/less suitable for individual solutions (if at least one property within a postcode is suitable for individual then the postcode is overall suitable of individual - we'd rather have false positives, than false negatives)

Fixes #415 

# Instructions for Reviewer

hey @crispy-wonton ,

You can check if the code runs for you with 
```
python -i asf_heat_pump_suitability/research/analysis/postcodes_individual_solutions/postcodes_individual_solutions.py --local_authority plymouth
```

Can you please check the logic holds and that I made no mistake coding it?

