### PR TITLE
433 Repair invalid geometries in cluster.py

### DIFF
--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -279,11 +279,9 @@ def extend_edges_gdf(
         "Joining Voronois to original building footprints and dissolving per footprint..."
     )
     # Join the original building points with IDs to the Voronoi cells and dissolve to get one polygon per internal building ID
-    voronoi_gdf = (
-        voronoi_gdf.sjoin(points_gdf, how="inner", predicate="contains")
-        .dissolve(by=id_col)
-        .reset_index()
-    ).clip(boundary)
+    voronoi_gdf = voronoi_gdf.sjoin(points_gdf, how="inner", predicate="contains")
+    voronoi_gdf.geometry = voronoi_gdf.geometry.make_valid()
+    voronoi_gdf = (voronoi_gdf.dissolve(by=id_col).reset_index()).clip(boundary)
 
     # Clip Voronoi cells to a max buffer
     print("Clip Voronoi cells to maximum buffer...")


### PR DESCRIPTION
---

# Description

I was getting shapely.errors.GEOSException: TopologyException: unable to assign free hole to a shell at .... in generate_gdf_clusters() due to invalid geometries in one of the LAs.

I've tested this fix in 11 different LAs and it worked smoothly.


Fixes #433

# Instructions for Reviewer

Please review this quick fix PR. 

You can check the code works by doing 

```
python asf_heat_pump_suitability/pipeline/cluster/cluster.py --local_authorities plymouth
```

Please do not use `save`.