### PR TITLE
436 Fix bug due to different representations of null values in `compute_contextual_features.py`

### DIFF
--- a/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
@@ -88,7 +88,7 @@ def extend_df_contextual_features(
     for col in dummy_cols:
         uprns_df = uprns_df.with_columns(
             pl.col(col)
-            .cast(pl.Utf8)  # ensure it's a string column
+            .cast(pl.String)  # ensure it's a string column
             .str.to_lowercase()  # null and NULL will be converted to "null" string, so we can group them under "unknown"
             .str.strip_chars()
             # Group all nulls under "unknown"

--- a/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
@@ -90,7 +90,7 @@ def extend_df_contextual_features(
             pl.col(col)
             .cast(pl.String)  # ensure it's a string column
             .str.to_lowercase()  # null and NULL will be converted to "null" string, so we can group them under "unknown"
-            .str.strip_chars()
+            .str.strip_chars()  # strip leading and trailing white space
             # Group all nulls under "unknown"
             .map_elements(
                 lambda val: "unknown" if val in (None, "null", "") else val,

--- a/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
@@ -85,18 +85,22 @@ def extend_df_contextual_features(
     """
 
     dummy_cols = ["ATTACHMENT", "TENURE", "CURRENT_ENERGY_RATING"]
-    for col in dummy_cols:
-        uprns_df = uprns_df.with_columns(
-            pl.col(col)
-            .cast(pl.String)  # ensure it's a string column
-            .str.to_lowercase()  # null and NULL will be converted to "null" string, so we can group them under "unknown"
-            .str.strip_chars()  # strip leading and trailing white space
-            # Group all nulls under "unknown"
-            .map_elements(
-                lambda val: "unknown" if val in (None, "null", "") else val,
-                return_dtype=pl.Utf8,
-            )
-        )
+
+    unknowns_mapping = {
+        "": "unknown",
+        "null": "unknown",
+    }
+
+    uprns_df = uprns_df.with_columns(
+        pl.col(col)
+        .cast(pl.String)
+        .str.to_lowercase()
+        .str.strip_chars()
+        .replace(unknowns_mapping)
+        .fill_null("unknown")
+        for col in dummy_cols
+    )
+
     # Get value counts per feature
     dummy_contextual_feat_df = (
         uprns_df.select(dummy_cols + ["cluster_id"])

--- a/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py
@@ -85,6 +85,18 @@ def extend_df_contextual_features(
     """
 
     dummy_cols = ["ATTACHMENT", "TENURE", "CURRENT_ENERGY_RATING"]
+    for col in dummy_cols:
+        uprns_df = uprns_df.with_columns(
+            pl.col(col)
+            .cast(pl.Utf8)  # ensure it's a string column
+            .str.to_lowercase()  # null and NULL will be converted to "null" string, so we can group them under "unknown"
+            .str.strip_chars()
+            # Group all nulls under "unknown"
+            .map_elements(
+                lambda val: "unknown" if val in (None, "null", "") else val,
+                return_dtype=pl.Utf8,
+            )
+        )
     # Get value counts per feature
     dummy_contextual_feat_df = (
         uprns_df.select(dummy_cols + ["cluster_id"])
@@ -97,7 +109,7 @@ def extend_df_contextual_features(
     dummy_cols_to_keep = [
         col
         for col in dummy_contextual_feat_df.columns
-        if any(col.startswith(prefix) for prefix in dummy_cols)
+        if any(col.lower().startswith(prefix.lower()) for prefix in dummy_cols)
     ]
     dummy_contextual_feat_df = dummy_contextual_feat_df.select(
         ["cluster_id"] + dummy_cols_to_keep


### PR DESCRIPTION
---

# Description

I was getting

```
polars.exceptions.DuplicateError: unable to hstack, column with name "CURRENT_ENERGY_RATING_null" already exists 
```

because of different representations of null values in EPC data for one of the LAs.


Fixes #436 

# Instructions for Reviewer

Please review the quick fix and run the pipeline in test mode with

```
python asf_heat_pump_suitability/pipeline/run/compute_contextual_features.py --local_authorities plymouth
```