### PR TITLE
419 Stream OS open data grid squares to S3

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -63,6 +63,21 @@ data:
     # Valid local authority names, taken from the 'LAD23NM' column of the UK_ons_lad_bound file
     valid_la_names: "s3://asf-local-heat-planning-tool/inputs/processed/valid_la_names.csv"
 
+# OS Downloads API ingestion of per-grid-square OS OpenData products
+# (pipeline/run/stream_os_open_data.py)
+os_downloads:
+  # Public OS Downloads API; no auth required for OpenData products
+  api_url: "https://api.os.uk/downloads/v1"
+  # Destination root for the product prefixes below; overridable at the CLI
+  # (--destination_root) for test rehearsals
+  s3_destination_root: "s3://asf-local-heat-planning-tool/inputs/geodata/"
+  # Per-product S3 prefix templates; {version} is filled verbatim with the
+  # API's product version (e.g. "2026-04") so the prefix names the OS release
+  products:
+    OpenMapLocal: "opmplc_essh_gb/{version}/"
+    OpenRoads: "oproad_essh_gb/{version}/"
+    OpenGreenspace: "opgrsp_essh_gb/{version}/"
+
 constant:
   id:
     building: "ID"

--- a/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
@@ -33,9 +33,9 @@ a test prefix such as
 
 import argparse
 import hashlib
-import io
 import logging
 import sys
+import tempfile
 import zipfile
 from typing import Iterable, Optional
 
@@ -230,24 +230,46 @@ def get_list_s3_keys(s3_client, bucket: str, prefix: str) -> list:
     return keys
 
 
-def verify_zip_md5(content: bytes, expected_md5: str, file_name: str) -> None:
+def verify_zip_md5(actual_md5: str, expected_md5: str, file_name: str) -> None:
     """
-    Verify downloaded zip content against the md5 from the API listing.
+    Verify a downloaded zip's md5 digest against the API listing.
 
     Args:
-        content: downloaded zip bytes
+        actual_md5: md5 hex digest of the downloaded content
         expected_md5: md5 hex digest from the API download entry
         file_name: zip file name, for the error message
 
     Raises:
         ValueError: if the digests do not match
     """
-    actual_md5 = hashlib.md5(content).hexdigest()
     if actual_md5 != expected_md5:
         raise ValueError(
             f"MD5 mismatch for {file_name}: API listing says {expected_md5}, "
             f"downloaded content is {actual_md5}."
         )
+
+
+def stream_zip_download_to_file(download: dict, file_obj) -> str:
+    """
+    Stream a download into a file object, hashing as chunks arrive.
+
+    Keeps peak memory at one chunk rather than the whole zip (the OpenRoads
+    GB zip is ~600 MB).
+
+    Args:
+        download: OS Downloads API download entry
+        file_obj: writable binary file object
+
+    Returns:
+        str: md5 hex digest of the downloaded content
+    """
+    md5 = hashlib.md5()
+    with requests.get(download["url"], stream=True, timeout=60) as response:
+        response.raise_for_status()
+        for chunk in response.iter_content(chunk_size=1 << 20):
+            md5.update(chunk)
+            file_obj.write(chunk)
+    return md5.hexdigest()
 
 
 def stream_zip_members_to_s3(
@@ -269,19 +291,19 @@ def stream_zip_members_to_s3(
     logging.info(
         f"Downloading {download['fileName']} ({download['size'] / 1e6:.1f} MB)"
     )
-    response = requests.get(download["url"], timeout=3600)
-    response.raise_for_status()
-    verify_zip_md5(response.content, download["md5"], download["fileName"])
-    zip_file = zipfile.ZipFile(io.BytesIO(response.content))
     uploaded = set()
-    for member in zip_file.namelist():
-        relative_key = generate_key_zip_member(product, download["area"], member)
-        if relative_key is None:
-            continue
-        key = f"{prefix}{relative_key}"
-        with zip_file.open(member) as file_obj:
-            s3_client.upload_fileobj(Fileobj=file_obj, Bucket=bucket, Key=key)
-        uploaded.add(key)
+    with tempfile.TemporaryFile() as tmp:
+        actual_md5 = stream_zip_download_to_file(download, tmp)
+        verify_zip_md5(actual_md5, download["md5"], download["fileName"])
+        zip_file = zipfile.ZipFile(tmp)
+        for member in zip_file.namelist():
+            relative_key = generate_key_zip_member(product, download["area"], member)
+            if relative_key is None:
+                continue
+            key = f"{prefix}{relative_key}"
+            with zip_file.open(member) as file_obj:
+                s3_client.upload_fileobj(Fileobj=file_obj, Bucket=bucket, Key=key)
+            uploaded.add(key)
     return uploaded
 
 

--- a/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
@@ -1,0 +1,365 @@
+"""
+Stream per-grid-square OS OpenData products from the OS Downloads API to S3.
+
+For each requested product the script queries the public OS Downloads API (no
+auth required for OpenData products), selects the ESRI Shapefile downloads and
+streams every zip member (shapefile plus all sidecars, licence and readme) to
+the product's version-named S3 prefix. The dated segment of each prefix is the
+API's product `version` verbatim (e.g. "2026-04") so the prefix names the OS
+release, not the download event. Each product keeps its current on-S3 layout:
+
+- OpenMapLocal:   opmplc_essh_gb/{version}/data/{square}/{square}_{layer}.*
+- OpenRoads:      oproad_essh_gb/{version}/data/{square}_{layer}.* (fanned out
+                  from the single GB zip; the API offers no per-square roads)
+- OpenGreenspace: opgrsp_essh_gb/{version}/{square}/data/{square}_{layer}.*
+
+Downloaded zips are md5-checked against the API listing. After uploading, the
+script lists S3 under each new prefix and reconciles it against the keys
+derived from the API's offered areas (for roads: the GB zip's members),
+exiting non-zero on any mismatch.
+
+By default the script performs a dry run: it lists each product's release
+version, tiles and sizes without touching S3.
+
+Run:
+python asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py --products OpenMapLocal OpenRoads OpenGreenspace
+
+To upload to S3, add the --save flag.
+
+Set --destination_root to override the configured S3 destination root (e.g.
+a test prefix such as
+"s3://asf-local-heat-planning-tool/inputs/geodata/test_419_os_downloads/").
+"""
+
+import argparse
+import hashlib
+import io
+import logging
+import sys
+import zipfile
+from typing import Iterable, Optional
+
+import boto3
+import requests
+
+from asf_heat_pump_suitability import config
+
+SHAPEFILE_FORMAT = "ESRI® Shapefile"
+GB_AREA = "GB"
+# Products the API offers only as a single GB zip whose members are per-square
+# files; these are fanned out rather than downloaded per area
+GB_ZIP_PRODUCTS = {"OpenRoads"}
+
+
+def parse_arguments() -> argparse.Namespace:
+    """
+    Create ArgumentParser and parse.
+
+    Returns:
+        argparse.Namespace: populated `Namespace`
+    """
+    parser = argparse.ArgumentParser()
+    product_choices = list(config["os_downloads"]["products"])
+
+    parser.add_argument(
+        "--products",
+        help="OS Downloads API product IDs to stream to S3. Defaults to all configured products.",
+        type=str,
+        nargs="+",
+        choices=product_choices,
+        default=product_choices,
+    )
+
+    parser.add_argument(
+        "--save",
+        help="If --save is set, upload to S3. Otherwise perform a dry run: list tiles, sizes and release version only.",
+        required=False,
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--destination_root",
+        help="Override the configured S3 destination root, e.g. a test prefix for a rehearsal run.",
+        required=False,
+        type=str,
+        default=None,
+    )
+
+    return parser.parse_args()
+
+
+def get_dict_product_details(api_url: str, product: str) -> dict:
+    """
+    Get product details from the OS Downloads API.
+
+    Args:
+        api_url: OS Downloads API base URL
+        product: OS Downloads API product ID, e.g. "OpenMapLocal"
+
+    Returns:
+        dict: product details including `version` and offered `areas`
+    """
+    response = requests.get(f"{api_url}/products/{product}", timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_list_product_downloads(api_url: str, product: str) -> list:
+    """
+    Get the list of downloads offered for a product from the OS Downloads API.
+
+    Args:
+        api_url: OS Downloads API base URL
+        product: OS Downloads API product ID, e.g. "OpenMapLocal"
+
+    Returns:
+        list: download entries, each a dict with `area`, `format`, `fileName`,
+            `url`, `size` and `md5`
+    """
+    response = requests.get(f"{api_url}/products/{product}/downloads", timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def filter_list_shapefile_downloads(downloads: list, product: str) -> list:
+    """
+    Select the ESRI Shapefile downloads to stream for a product.
+
+    Products in GB_ZIP_PRODUCTS keep only the single GB zip; all other
+    products keep the per-area zips and drop the GB zip.
+
+    Args:
+        downloads: download entries from the OS Downloads API
+        product: OS Downloads API product ID
+
+    Returns:
+        list: filtered download entries
+    """
+    shapefiles = [entry for entry in downloads if entry["format"] == SHAPEFILE_FORMAT]
+    if product in GB_ZIP_PRODUCTS:
+        return [entry for entry in shapefiles if entry["area"] == GB_AREA]
+    return [entry for entry in shapefiles if entry["area"] != GB_AREA]
+
+
+def generate_key_zip_member(product: str, area: str, member: str) -> Optional[str]:
+    """
+    Map a zip member name to its S3 key relative to the product's dated prefix.
+
+    Reproduces each product's current on-S3 layout (see module docstring).
+    Per-area zips wrap their contents in a folder such as
+    "OS OpenMap Local (ESRI Shape File) HP/", which is stripped; the OpenRoads
+    GB zip names some members with a leading slash, which is also stripped.
+
+    Args:
+        product: OS Downloads API product ID
+        area: area code of the download the member belongs to, e.g. "HP"
+        member: zip member name
+
+    Returns:
+        Optional[str]: S3 key relative to the product's dated prefix, or None
+            for directory entries
+    """
+    member = member.lstrip("/")
+    if not member or member.endswith("/"):
+        return None
+    if product == "OpenRoads":
+        return member
+    remainder = member.split("/", 1)[1] if "/" in member else member
+    if not remainder:
+        return None
+    if product == "OpenGreenspace":
+        return f"{area}/{remainder}"
+    if product == "OpenMapLocal":
+        if remainder.startswith("data/"):
+            return f"data/{area}/{remainder.removeprefix('data/')}"
+        return remainder
+    raise ValueError(f"No S3 layout mapping defined for product '{product}'.")
+
+
+def generate_dict_reconciliation(
+    expected_keys: Iterable, actual_keys: Iterable
+) -> dict:
+    """
+    Diff expected against actual S3 keys.
+
+    Args:
+        expected_keys: keys that should exist after the upload
+        actual_keys: keys found on S3
+
+    Returns:
+        dict: {"missing": sorted keys expected but absent,
+            "unexpected": sorted keys present but not expected}
+    """
+    expected, actual = set(expected_keys), set(actual_keys)
+    return {
+        "missing": sorted(expected - actual),
+        "unexpected": sorted(actual - expected),
+    }
+
+
+def get_tuple_s3_bucket_prefix(s3_uri: str) -> tuple:
+    """
+    Split an S3 URI into bucket name and key prefix.
+
+    Args:
+        s3_uri: URI of the form "s3://bucket/key/prefix/"
+
+    Returns:
+        tuple: (bucket, key prefix)
+    """
+    bucket, _, prefix = s3_uri.removeprefix("s3://").partition("/")
+    return bucket, prefix
+
+
+def get_list_s3_keys(s3_client, bucket: str, prefix: str) -> list:
+    """
+    List all object keys under an S3 prefix.
+
+    Args:
+        s3_client: boto3 S3 client
+        bucket: S3 bucket name
+        prefix: key prefix to list under
+
+    Returns:
+        list: object keys
+    """
+    keys = []
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        keys.extend(obj["Key"] for obj in page.get("Contents", []))
+    return keys
+
+
+def verify_zip_md5(content: bytes, expected_md5: str, file_name: str) -> None:
+    """
+    Verify downloaded zip content against the md5 from the API listing.
+
+    Args:
+        content: downloaded zip bytes
+        expected_md5: md5 hex digest from the API download entry
+        file_name: zip file name, for the error message
+
+    Raises:
+        ValueError: if the digests do not match
+    """
+    actual_md5 = hashlib.md5(content).hexdigest()
+    if actual_md5 != expected_md5:
+        raise ValueError(
+            f"MD5 mismatch for {file_name}: API listing says {expected_md5}, "
+            f"downloaded content is {actual_md5}."
+        )
+
+
+def stream_zip_members_to_s3(
+    s3_client, download: dict, product: str, bucket: str, prefix: str
+) -> set:
+    """
+    Download one zip, verify its md5 and upload its members to S3.
+
+    Args:
+        s3_client: boto3 S3 client
+        download: OS Downloads API download entry
+        product: OS Downloads API product ID
+        bucket: destination S3 bucket
+        prefix: destination key prefix (the product's dated prefix)
+
+    Returns:
+        set: S3 keys uploaded
+    """
+    logging.info(
+        f"Downloading {download['fileName']} ({download['size'] / 1e6:.1f} MB)"
+    )
+    response = requests.get(download["url"], timeout=3600)
+    response.raise_for_status()
+    verify_zip_md5(response.content, download["md5"], download["fileName"])
+    zip_file = zipfile.ZipFile(io.BytesIO(response.content))
+    uploaded = set()
+    for member in zip_file.namelist():
+        relative_key = generate_key_zip_member(product, download["area"], member)
+        if relative_key is None:
+            continue
+        key = f"{prefix}{relative_key}"
+        with zip_file.open(member) as file_obj:
+            s3_client.upload_fileobj(Fileobj=file_obj, Bucket=bucket, Key=key)
+        uploaded.add(key)
+    return uploaded
+
+
+def main() -> None:
+    """Run the download/upload flow for each requested product."""
+    args = parse_arguments()
+    api_url = config["os_downloads"]["api_url"]
+    destination_root = (
+        args.destination_root or config["os_downloads"]["s3_destination_root"]
+    )
+    if not destination_root.endswith("/"):
+        destination_root += "/"
+    s3_client = boto3.client("s3") if args.save else None
+    failed_products = []
+
+    for product in args.products:
+        details = get_dict_product_details(api_url, product)
+        version = details["version"]
+        downloads = get_list_product_downloads(api_url, product)
+        selected = filter_list_shapefile_downloads(downloads, product)
+        prefix_template = config["os_downloads"]["products"][product]
+        destination = destination_root + prefix_template.format(version=version)
+
+        # The downloads listing must cover exactly the areas the product offers
+        offered_areas = (
+            {GB_AREA}
+            if product in GB_ZIP_PRODUCTS
+            else set(details["areas"]) - {GB_AREA}
+        )
+        area_diff = generate_dict_reconciliation(
+            offered_areas, {entry["area"] for entry in selected}
+        )
+        if area_diff["missing"] or area_diff["unexpected"]:
+            logging.error(
+                f"{product}: shapefile downloads do not match the product's "
+                f"offered areas: {area_diff}"
+            )
+            sys.exit(1)
+
+        total_mb = sum(entry["size"] for entry in selected) / 1e6
+        logging.info(
+            f"{product} version {version}: {len(selected)} zip(s), "
+            f"{total_mb:.1f} MB -> {destination}"
+        )
+        for entry in selected:
+            logging.info(
+                f"  {entry['area']}: {entry['fileName']} "
+                f"({entry['size'] / 1e6:.1f} MB)"
+            )
+        if not args.save:
+            continue
+
+        bucket, prefix = get_tuple_s3_bucket_prefix(destination)
+        expected_keys = set()
+        for entry in selected:
+            expected_keys |= stream_zip_members_to_s3(
+                s3_client, entry, product, bucket, prefix
+            )
+        actual_keys = get_list_s3_keys(s3_client, bucket, prefix)
+        diff = generate_dict_reconciliation(expected_keys, actual_keys)
+        if diff["missing"] or diff["unexpected"]:
+            logging.error(
+                f"{product}: S3 under s3://{bucket}/{prefix} does not match "
+                f"the files offered by the OS Downloads API. "
+                f"Missing: {diff['missing']} Unexpected: {diff['unexpected']}"
+            )
+            failed_products.append(product)
+        else:
+            logging.info(
+                f"{product}: reconciliation OK, {len(actual_keys)} files at "
+                f"s3://{bucket}/{prefix}"
+            )
+
+    if failed_products:
+        sys.exit(1)
+    if not args.save:
+        logging.info("Dry run complete. Re-run with --save to upload to S3.")
+
+
+if __name__ == "__main__":
+    main()

--- a/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
@@ -176,6 +176,25 @@ def generate_key_zip_member(product: str, area: str, member: str) -> Optional[st
     raise ValueError(f"No S3 layout mapping defined for product '{product}'.")
 
 
+def get_set_offered_areas(details: dict, product: str) -> set:
+    """
+    Get the download areas a product's shapefile listing must cover.
+
+    Products in GB_ZIP_PRODUCTS offer a single GB zip; all other products
+    offer per-area zips, excluding the GB roll-up.
+
+    Args:
+        details: product details from the OS Downloads API
+        product: OS Downloads API product ID
+
+    Returns:
+        set: expected area codes
+    """
+    if product in GB_ZIP_PRODUCTS:
+        return {GB_AREA}
+    return set(details["areas"]) - {GB_AREA}
+
+
 def generate_dict_reconciliation(
     expected_keys: Iterable, actual_keys: Iterable
 ) -> dict:
@@ -328,11 +347,7 @@ def main() -> None:
         destination = destination_root + prefix_template.format(version=version)
 
         # The downloads listing must cover exactly the areas the product offers
-        offered_areas = (
-            {GB_AREA}
-            if product in GB_ZIP_PRODUCTS
-            else set(details["areas"]) - {GB_AREA}
-        )
+        offered_areas = get_set_offered_areas(details, product)
         area_diff = generate_dict_reconciliation(
             offered_areas, {entry["area"] for entry in selected}
         )

--- a/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py
@@ -319,7 +319,8 @@ def main() -> None:
                 f"{product}: shapefile downloads do not match the product's "
                 f"offered areas: {area_diff}"
             )
-            sys.exit(1)
+            failed_products.append(product)
+            continue
 
         total_mb = sum(entry["size"] for entry in selected) / 1e6
         logging.info(

--- a/asf_heat_pump_suitability/pipeline/run/tests/os_downloads_api_fixture.json
+++ b/asf_heat_pump_suitability/pipeline/run/tests/os_downloads_api_fixture.json
@@ -1,0 +1,311 @@
+{
+  "OpenMapLocal": {
+    "product": {
+      "id": "OpenMapLocal",
+      "version": "2026-04",
+      "areas": [
+        "GB",
+        "HP",
+        "HT",
+        "HU",
+        "HW",
+        "HX",
+        "HY",
+        "HZ",
+        "NA",
+        "NB",
+        "NC",
+        "ND",
+        "NF",
+        "NG",
+        "NH",
+        "NJ",
+        "NK",
+        "NL",
+        "NM",
+        "NN",
+        "NO",
+        "NR",
+        "NS",
+        "NT",
+        "NU",
+        "NW",
+        "NX",
+        "NY",
+        "NZ",
+        "OV",
+        "SD",
+        "SE",
+        "SH",
+        "SJ",
+        "SK",
+        "SM",
+        "SN",
+        "SO",
+        "SP",
+        "SR",
+        "SS",
+        "ST",
+        "SU",
+        "SV",
+        "SW",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TF",
+        "TG",
+        "TL",
+        "TM",
+        "TQ",
+        "TR",
+        "TV"
+      ]
+    },
+    "downloads": [
+      {
+        "md5": "41be982438f32b4f213324ff6266c539",
+        "size": 110350,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=HT&format=ESRI%C2%AE+Shapefile&redirect",
+        "format": "ESRI\u00ae Shapefile",
+        "area": "HT",
+        "fileName": "opmplc_essh_ht.zip"
+      },
+      {
+        "md5": "f00a0ec646ed48da127beb73526569d7",
+        "size": 64587,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=HW&format=ESRI%C2%AE+Shapefile&redirect",
+        "format": "ESRI\u00ae Shapefile",
+        "area": "HW",
+        "fileName": "opmplc_essh_hw.zip"
+      },
+      {
+        "md5": "461b5652d8da4fac8211b0de8d9d473f",
+        "size": 94171,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=HT&format=GML&subformat=3&redirect",
+        "format": "GML",
+        "subformat": "3",
+        "area": "HT",
+        "fileName": "opmplc_gml3_ht.zip"
+      },
+      {
+        "md5": "3429592beb4f576c24a21203faaddbbe",
+        "size": 53974,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=HW&format=GML&subformat=3&redirect",
+        "format": "GML",
+        "subformat": "3",
+        "area": "HW",
+        "fileName": "opmplc_gml3_hw.zip"
+      },
+      {
+        "md5": "14627c2886146a6754c590b01275112c",
+        "size": 588501,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=HT&format=GeoTIFF&subformat=Full+Colour&redirect",
+        "format": "GeoTIFF",
+        "subformat": "Full Colour",
+        "area": "HT",
+        "fileName": "omlras_gtfc_ht.zip"
+      },
+      {
+        "md5": "b25b64b27f1a0f7b9161889f88ab1a71",
+        "size": 173433,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=HW&format=GeoTIFF&subformat=Full+Colour&redirect",
+        "format": "GeoTIFF",
+        "subformat": "Full Colour",
+        "area": "HW",
+        "fileName": "omlras_gtfc_hw.zip"
+      },
+      {
+        "md5": "d255239a55763ab13f99f31f5d64d495",
+        "size": 2455061187,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=GB&format=ESRI%C2%AE+Shapefile&redirect",
+        "format": "ESRI\u00ae Shapefile",
+        "area": "GB",
+        "fileName": "opmplc_essh_gb.zip"
+      },
+      {
+        "md5": "4c4bd1995ccd2d2aa2e91ab6b014c5b6",
+        "size": 2387077472,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=GB&format=GML&subformat=3&redirect",
+        "format": "GML",
+        "subformat": "3",
+        "area": "GB",
+        "fileName": "opmplc_gml3_gb.zip"
+      },
+      {
+        "md5": "be1253db44765069a4dd82e36bb39e95",
+        "size": 15417686725,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=GB&format=GeoTIFF&subformat=Full+Colour&redirect",
+        "format": "GeoTIFF",
+        "subformat": "Full Colour",
+        "area": "GB",
+        "fileName": "omlras_gtfc_gb.zip"
+      },
+      {
+        "md5": "e511aaef242640c5c3d8bb9f0aa06c29",
+        "size": 3517973251,
+        "url": "https://api.os.uk/downloads/v1/products/OpenMapLocal/downloads?area=GB&format=GeoPackage&redirect",
+        "format": "GeoPackage",
+        "area": "GB",
+        "fileName": "opmplc_gpkg_gb.zip"
+      }
+    ]
+  },
+  "OpenRoads": {
+    "product": {
+      "id": "OpenRoads",
+      "version": "2026-04",
+      "areas": ["GB"]
+    },
+    "downloads": [
+      {
+        "md5": "8c6e66a255f79e3e31845307cefee298",
+        "size": 606145264,
+        "url": "https://api.os.uk/downloads/v1/products/OpenRoads/downloads?area=GB&format=ESRI%C2%AE+Shapefile&redirect",
+        "format": "ESRI\u00ae Shapefile",
+        "area": "GB",
+        "fileName": "oproad_essh_gb.zip"
+      },
+      {
+        "md5": "673304090bd51f8e89abcc84b145ba73",
+        "size": 608511751,
+        "url": "https://api.os.uk/downloads/v1/products/OpenRoads/downloads?area=GB&format=GML&subformat=3&redirect",
+        "format": "GML",
+        "subformat": "3",
+        "area": "GB",
+        "fileName": "oproad_gml3_gb.zip"
+      },
+      {
+        "md5": "2ee5d30899c4a44df321e5e1a66989ac",
+        "size": 1016021285,
+        "url": "https://api.os.uk/downloads/v1/products/OpenRoads/downloads?area=GB&format=GeoPackage&redirect",
+        "format": "GeoPackage",
+        "area": "GB",
+        "fileName": "oproad_gpkg_gb.zip"
+      },
+      {
+        "md5": "1a648fb1c7b88560d286a5260687e1bc",
+        "size": 1346941248,
+        "url": "https://api.os.uk/downloads/v1/products/OpenRoads/downloads?area=GB&format=Vector+Tiles&subformat=%28MBTiles%29&redirect",
+        "format": "Vector Tiles",
+        "subformat": "(MBTiles)",
+        "area": "GB",
+        "fileName": "oproad_mbtiles_gb.zip"
+      }
+    ]
+  },
+  "OpenGreenspace": {
+    "product": {
+      "id": "OpenGreenspace",
+      "version": "2026-04",
+      "areas": [
+        "GB",
+        "HP",
+        "HT",
+        "HU",
+        "HY",
+        "HZ",
+        "NA",
+        "NB",
+        "NC",
+        "ND",
+        "NF",
+        "NG",
+        "NH",
+        "NJ",
+        "NK",
+        "NL",
+        "NM",
+        "NN",
+        "NO",
+        "NR",
+        "NS",
+        "NT",
+        "NU",
+        "NW",
+        "NX",
+        "NY",
+        "NZ",
+        "SD",
+        "SE",
+        "SH",
+        "SJ",
+        "SK",
+        "SM",
+        "SN",
+        "SO",
+        "SP",
+        "SR",
+        "SS",
+        "ST",
+        "SU",
+        "SV",
+        "SW",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TF",
+        "TG",
+        "TL",
+        "TM",
+        "TQ",
+        "TR",
+        "TV"
+      ]
+    },
+    "downloads": [
+      {
+        "md5": "41d02f594f91d41520386ea71567f619",
+        "size": 4102,
+        "url": "https://api.os.uk/downloads/v1/products/OpenGreenspace/downloads?area=HT&format=ESRI%C2%AE+Shapefile&redirect",
+        "format": "ESRI\u00ae Shapefile",
+        "area": "HT",
+        "fileName": "opgrsp_essh_ht.zip"
+      },
+      {
+        "md5": "c1763386b44bd3ae97bbfd1a88144d71",
+        "size": 2202,
+        "url": "https://api.os.uk/downloads/v1/products/OpenGreenspace/downloads?area=HT&format=GML&subformat=3&redirect",
+        "format": "GML",
+        "subformat": "3",
+        "area": "HT",
+        "fileName": "opgrsp_gml3_ht.zip"
+      },
+      {
+        "md5": "00dc5a7e6367acfe22df0546355f3ddc",
+        "size": 39508821,
+        "url": "https://api.os.uk/downloads/v1/products/OpenGreenspace/downloads?area=GB&format=ESRI%C2%AE+Shapefile&redirect",
+        "format": "ESRI\u00ae Shapefile",
+        "area": "GB",
+        "fileName": "opgrsp_essh_gb.zip"
+      },
+      {
+        "md5": "e8126b8771f2a61eac9263c793ed52b1",
+        "size": 39945639,
+        "url": "https://api.os.uk/downloads/v1/products/OpenGreenspace/downloads?area=GB&format=GML&subformat=3&redirect",
+        "format": "GML",
+        "subformat": "3",
+        "area": "GB",
+        "fileName": "opgrsp_gml3_gb.zip"
+      },
+      {
+        "md5": "3d57cf0afc70b0104fa6f657d0560fdf",
+        "size": 59489052,
+        "url": "https://api.os.uk/downloads/v1/products/OpenGreenspace/downloads?area=GB&format=GeoPackage&redirect",
+        "format": "GeoPackage",
+        "area": "GB",
+        "fileName": "opgrsp_gpkg_gb.zip"
+      },
+      {
+        "md5": "3bd1d6894031b8a4557de1005312c796",
+        "size": 86274986,
+        "url": "https://api.os.uk/downloads/v1/products/OpenGreenspace/downloads?area=GB&format=Vector+Tiles&subformat=%28MBTiles%29&redirect",
+        "format": "Vector Tiles",
+        "subformat": "(MBTiles)",
+        "area": "GB",
+        "fileName": "opgrsp_mbtiles_gb.zip"
+      }
+    ]
+  }
+}

--- a/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
@@ -57,6 +57,28 @@ class TestFilterListShapefileDownloads:
         assert result[0]["fileName"] == "opgrsp_essh_ht.zip"
 
 
+class TestGetSetOfferedAreas:
+    """Tests for `get_set_offered_areas`."""
+
+    def test_per_area_product_offers_areas_minus_gb(self, api_fixture):
+        """OpenMapLocal expects every listed area except the GB roll-up."""
+        details = api_fixture["OpenMapLocal"]["product"]
+        result = stream_os_open_data.get_set_offered_areas(details, "OpenMapLocal")
+        assert result == set(details["areas"]) - {"GB"}
+        assert len(result) == 55
+
+    def test_gb_zip_product_offers_only_gb(self, api_fixture):
+        """OpenRoads expects the single GB zip regardless of listed areas."""
+        details = api_fixture["OpenRoads"]["product"]
+        assert stream_os_open_data.get_set_offered_areas(details, "OpenRoads") == {"GB"}
+
+    def test_island_tiles_expected_for_greenspace(self, api_fixture):
+        """The island squares missed by the manual refresh are all expected."""
+        details = api_fixture["OpenGreenspace"]["product"]
+        result = stream_os_open_data.get_set_offered_areas(details, "OpenGreenspace")
+        assert {"HP", "HT", "HU", "HY", "HZ"} <= result
+
+
 class TestGenerateKeyZipMember:
     """Tests for `generate_key_zip_member`."""
 

--- a/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
@@ -170,17 +170,15 @@ class TestVerifyZipMd5:
     """Tests for `verify_zip_md5`."""
 
     def test_matching_md5_passes(self):
-        """Content whose md5 matches the API listing passes silently."""
-        content = b"os tile bytes"
-        expected = hashlib.md5(content).hexdigest()
-        stream_os_open_data.verify_zip_md5(content, expected, "opmplc_essh_hw.zip")
+        """A digest matching the API listing passes silently."""
+        digest = hashlib.md5(b"os tile bytes").hexdigest()
+        stream_os_open_data.verify_zip_md5(digest, digest, "opmplc_essh_hw.zip")
 
     def test_mismatched_md5_raises(self):
-        """Corrupted content fails loudly, naming the file."""
+        """A digest differing from the API listing fails loudly, naming the file."""
+        digest = hashlib.md5(b"corrupted bytes").hexdigest()
         with pytest.raises(ValueError, match="opmplc_essh_hw.zip"):
-            stream_os_open_data.verify_zip_md5(
-                b"corrupted bytes", "0" * 32, "opmplc_essh_hw.zip"
-            )
+            stream_os_open_data.verify_zip_md5(digest, "0" * 32, "opmplc_essh_hw.zip")
 
 
 class TestGetTupleS3BucketPrefix:

--- a/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
@@ -7,6 +7,7 @@ keeps every download format the API offers for areas HW, HT and GB, so the
 tests pin down both the shapefile-format filter and the per-area vs GB split.
 """
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -163,6 +164,35 @@ class TestGenerateKeyZipMember:
             stream_os_open_data.generate_key_zip_member(
                 "OpenRivers", "HW", "data/HW_River.shp"
             )
+
+
+class TestVerifyZipMd5:
+    """Tests for `verify_zip_md5`."""
+
+    def test_matching_md5_passes(self):
+        """Content whose md5 matches the API listing passes silently."""
+        content = b"os tile bytes"
+        expected = hashlib.md5(content).hexdigest()
+        stream_os_open_data.verify_zip_md5(content, expected, "opmplc_essh_hw.zip")
+
+    def test_mismatched_md5_raises(self):
+        """Corrupted content fails loudly, naming the file."""
+        with pytest.raises(ValueError, match="opmplc_essh_hw.zip"):
+            stream_os_open_data.verify_zip_md5(
+                b"corrupted bytes", "0" * 32, "opmplc_essh_hw.zip"
+            )
+
+
+class TestGetTupleS3BucketPrefix:
+    """Tests for `get_tuple_s3_bucket_prefix`."""
+
+    def test_uri_split_into_bucket_and_prefix(self):
+        """An s3:// URI splits into bucket name and key prefix."""
+        bucket, prefix = stream_os_open_data.get_tuple_s3_bucket_prefix(
+            "s3://asf-local-heat-planning-tool/inputs/geodata/oproad_essh_gb/2026-04/"
+        )
+        assert bucket == "asf-local-heat-planning-tool"
+        assert prefix == "inputs/geodata/oproad_essh_gb/2026-04/"
 
 
 class TestGenerateDictReconciliation:

--- a/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
+++ b/asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
@@ -1,0 +1,185 @@
+"""
+Tests for the pure helpers in pipeline/run/stream_os_open_data.py.
+
+Uses a trimmed copy of real OS Downloads API responses
+(os_downloads_api_fixture.json) so no network access is needed. The fixture
+keeps every download format the API offers for areas HW, HT and GB, so the
+tests pin down both the shapefile-format filter and the per-area vs GB split.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from asf_heat_pump_suitability.pipeline.run import stream_os_open_data
+
+FIXTURE_PATH = Path(__file__).parent / "os_downloads_api_fixture.json"
+
+
+@pytest.fixture(scope="module")
+def api_fixture() -> dict:
+    """Trimmed OS Downloads API responses for the three products."""
+    with open(FIXTURE_PATH) as f:
+        return json.load(f)
+
+
+class TestFilterListShapefileDownloads:
+    """Tests for `filter_list_shapefile_downloads`."""
+
+    def test_per_area_product_keeps_only_per_area_shapefiles(self, api_fixture):
+        """OpenMapLocal keeps per-area ESRI Shapefile zips, dropping the GB zip and other formats."""
+        downloads = api_fixture["OpenMapLocal"]["downloads"]
+        result = stream_os_open_data.filter_list_shapefile_downloads(
+            downloads, "OpenMapLocal"
+        )
+        assert sorted(d["area"] for d in result) == ["HT", "HW"]
+        assert all(d["format"] == "ESRI® Shapefile" for d in result)
+
+    def test_gb_zip_product_keeps_only_gb_shapefile(self, api_fixture):
+        """OpenRoads keeps the single GB ESRI Shapefile zip, dropping GML/GeoPackage/Vector Tiles."""
+        downloads = api_fixture["OpenRoads"]["downloads"]
+        result = stream_os_open_data.filter_list_shapefile_downloads(
+            downloads, "OpenRoads"
+        )
+        assert len(result) == 1
+        assert result[0]["area"] == "GB"
+        assert result[0]["fileName"] == "oproad_essh_gb.zip"
+
+    def test_greenspace_drops_gb_entries(self, api_fixture):
+        """OpenGreenspace keeps per-area shapefile zips only, excluding the GB shapefile zip."""
+        downloads = api_fixture["OpenGreenspace"]["downloads"]
+        result = stream_os_open_data.filter_list_shapefile_downloads(
+            downloads, "OpenGreenspace"
+        )
+        assert [d["area"] for d in result] == ["HT"]
+        assert result[0]["fileName"] == "opgrsp_essh_ht.zip"
+
+
+class TestGenerateKeyZipMember:
+    """Tests for `generate_key_zip_member`."""
+
+    def test_openmaplocal_data_member_nested_under_square_dir(self):
+        """OpenMapLocal per-area zip data members map to data/{square}/{square}_{layer}.{ext}."""
+        key = stream_os_open_data.generate_key_zip_member(
+            "OpenMapLocal",
+            "HW",
+            "OS OpenMap Local (ESRI Shape File) HW/data/HW_Building.shp",
+        )
+        assert key == "data/HW/HW_Building.shp"
+
+    def test_openmaplocal_sidecars_follow_data_member(self):
+        """All shapefile sidecar extensions map alongside the .shp file."""
+        for ext in ("dbf", "prj", "shx", "cpg"):
+            key = stream_os_open_data.generate_key_zip_member(
+                "OpenMapLocal",
+                "SX",
+                f"OS OpenMap Local (ESRI Shape File) SX/data/SX_Building.{ext}",
+            )
+            assert key == f"data/SX/SX_Building.{ext}"
+
+    def test_openmaplocal_doc_and_readme_at_prefix_root(self):
+        """OpenMapLocal licence/readme land once at the prefix root, matching the current layout."""
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenMapLocal",
+                "HW",
+                "OS OpenMap Local (ESRI Shape File) HW/doc/licence.txt",
+            )
+            == "doc/licence.txt"
+        )
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenMapLocal",
+                "HW",
+                "OS OpenMap Local (ESRI Shape File) HW/readme.txt",
+            )
+            == "readme.txt"
+        )
+
+    def test_openroads_members_map_unchanged(self):
+        """OpenRoads GB zip members keep their in-zip paths (flat data/ layout)."""
+        key = stream_os_open_data.generate_key_zip_member(
+            "OpenRoads", "GB", "data/HP_RoadLink.shp"
+        )
+        assert key == "data/HP_RoadLink.shp"
+
+    def test_openroads_leading_slash_members_stripped(self):
+        """The OpenRoads GB zip names doc/readme members with a leading slash; it is stripped."""
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenRoads", "GB", "/doc/licence.txt"
+            )
+            == "doc/licence.txt"
+        )
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenRoads", "GB", "/readme.txt"
+            )
+            == "readme.txt"
+        )
+
+    def test_greenspace_members_nested_under_square(self):
+        """OpenGreenspace members map to {square}/data|doc|readme, matching the current layout."""
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenGreenspace",
+                "HT",
+                "OS Open Greenspace (ESRI Shape File) HT/data/HT_AccessPoint.shp",
+            )
+            == "HT/data/HT_AccessPoint.shp"
+        )
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenGreenspace",
+                "HT",
+                "OS Open Greenspace (ESRI Shape File) HT/doc/licence.txt",
+            )
+            == "HT/doc/licence.txt"
+        )
+
+    def test_directory_entries_skipped(self):
+        """Zip directory entries map to None for every product."""
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenMapLocal", "HW", "OS OpenMap Local (ESRI Shape File) HW/data/"
+            )
+            is None
+        )
+        assert (
+            stream_os_open_data.generate_key_zip_member("OpenRoads", "GB", "/data/")
+            is None
+        )
+        assert (
+            stream_os_open_data.generate_key_zip_member(
+                "OpenGreenspace", "HT", "OS Open Greenspace (ESRI Shape File) HT/"
+            )
+            is None
+        )
+
+    def test_unknown_product_raises(self):
+        """A product with no layout mapping fails loudly."""
+        with pytest.raises(ValueError, match="OpenRivers"):
+            stream_os_open_data.generate_key_zip_member(
+                "OpenRivers", "HW", "data/HW_River.shp"
+            )
+
+
+class TestGenerateDictReconciliation:
+    """Tests for `generate_dict_reconciliation`."""
+
+    def test_matching_sets_give_empty_diff(self):
+        """Identical expected and actual key sets reconcile cleanly."""
+        keys = {"data/HP_RoadLink.shp", "readme.txt"}
+        diff = stream_os_open_data.generate_dict_reconciliation(keys, keys)
+        assert diff == {"missing": [], "unexpected": []}
+
+    def test_missing_and_unexpected_keys_reported_sorted(self):
+        """Keys absent from S3 are 'missing'; extra S3 keys are 'unexpected'; both sorted."""
+        expected = {"data/HZ_RoadLink.shp", "data/HP_RoadLink.shp"}
+        actual = {"data/HP_RoadLink.shp", ".DS_Store"}
+        diff = stream_os_open_data.generate_dict_reconciliation(expected, actual)
+        assert diff == {
+            "missing": ["data/HZ_RoadLink.shp"],
+            "unexpected": [".DS_Store"],
+        }

--- a/docs/specs/419_streamOsOpenData.md
+++ b/docs/specs/419_streamOsOpenData.md
@@ -51,7 +51,10 @@ Decisions, each settled in the kickoff interview (2026-07-23):
 
    Rationale: match what is already on S3 so consumers and reviewers see only
    the dated segment change. All shapefile sidecars (`.shp`, `.dbf`, `.prj`,
-   `.shx`, `.cpg`, …) are uploaded, not just `.shp`.
+   `.shx`, `.cpg`, …) are uploaded, not just `.shp`. The zips' `licence.txt`
+   and `readme.txt` are also kept in their current on-S3 locations: at the
+   dated prefix root for OpenMap Local and Open Roads, under each `{square}/`
+   for Open Greenspace.
 
 4. **Roads fan-out** — the API offers no per-square downloads for OpenRoads,
    only a single ~606 MB GB shapefile zip whose members are per-square files;
@@ -111,20 +114,27 @@ Decisions, each settled in the kickoff interview (2026-07-23):
 
 ## Verification
 
-- [ ] Dry run (no `--save`) lists per-product tile names, sizes and the API
-      `version` without writing to S3.
+- [x] Dry run (no `--save`) lists per-product tile names, sizes and the API
+      `version` without writing to S3. (Run 2026-07-23 with AWS credentials
+      nulled: OpenMapLocal 2026-04, 55 zips / 2455.4 MB; OpenRoads 2026-04,
+      1 GB zip / 606.1 MB; OpenGreenspace 2026-04, 52 zips / 39.9 MB; island
+      tiles HP/HT/HU/HY/HZ all listed; exit 0.)
 - [ ] Test-prefix run uploads via the destination override; getters load
       grid-square data from the test prefix end-to-end; test prefix deleted
       afterwards.
 - [ ] Production run populates version-named prefixes for all three products
       in their current layouts, all sidecar files included.
-- [ ] Reconciliation compares S3 against the API's offered areas (roads: GB
+- [x] Reconciliation compares S3 against the API's offered areas (roads: GB
       zip members) and exits non-zero with a clear message on mismatch.
+      (Diff helper unit-tested; failure path demonstrated 2026-07-23 with
+      mocked S3 — a missing island tile plus a stray `.DS_Store` produced a
+      clear ERROR naming both keys and `SystemExit(1)`.)
 - [ ] `base.yaml` repointed to the new prefixes as the final commit;
       `load_gdf_os_openmap_layer` and `load_gdf_os_openroad` load spot-check
       squares via config alone.
-- [ ] API base URL and prefix templates read from `base.yaml`; no hard-coded
-      S3 paths or magic values in the script.
-- [ ] Unit tests (fixture JSON, no network) for the pure helpers: API response
+- [x] API base URL and prefix templates read from `base.yaml`; no hard-coded
+      S3 paths or magic values in the script (`os_downloads` section:
+      `api_url`, `s3_destination_root`, per-product prefix templates).
+- [x] Unit tests (fixture JSON, no network) for the pure helpers: API response
       → download list, zip member → S3 key mapping per product, reconciliation
       diff. 1:1 test module `pipeline/run/tests/test_stream_os_open_data.py`.

--- a/docs/specs/419_streamOsOpenData.md
+++ b/docs/specs/419_streamOsOpenData.md
@@ -1,8 +1,8 @@
 ---
 title: Stream OS open data grid squares from the OS Downloads API to S3
-status: draft
+status: in-review
 github_issue: https://github.com/nestauk/asf_heat_pump_suitability/issues/419
-pr:
+pr: https://github.com/nestauk/asf_heat_pump_suitability/pull/450
 asana: TBD
 created: 2026-07-23
 ---

--- a/docs/specs/419_streamOsOpenData.md
+++ b/docs/specs/419_streamOsOpenData.md
@@ -52,9 +52,10 @@ Decisions, each settled in the kickoff interview (2026-07-23):
    Rationale: match what is already on S3 so consumers and reviewers see only
    the dated segment change. All shapefile sidecars (`.shp`, `.dbf`, `.prj`,
    `.shx`, `.cpg`, …) are uploaded, not just `.shp`. The zips' `licence.txt`
-   and `readme.txt` are also kept in their current on-S3 locations: at the
-   dated prefix root for OpenMap Local and Open Roads, under each `{square}/`
-   for Open Greenspace.
+   and `readme.txt` are also kept in their current on-S3 locations: for
+   OpenMap Local and Open Roads, `readme.txt` at the dated prefix root and
+   `licence.txt` under `doc/` beside it; for Open Greenspace, both under
+   each `{square}/`.
 
 4. **Roads fan-out** — the API offers no per-square downloads for OpenRoads,
    only a single ~606 MB GB shapefile zip whose members are per-square files;

--- a/docs/specs/419_streamOsOpenData.md
+++ b/docs/specs/419_streamOsOpenData.md
@@ -1,0 +1,130 @@
+---
+title: Stream OS open data grid squares from the OS Downloads API to S3
+status: draft
+github_issue: https://github.com/nestauk/asf_heat_pump_suitability/issues/419
+pr:
+asana: TBD
+created: 2026-07-23
+---
+
+## Problem
+
+The per-grid-square OS inputs (OpenMap Local, Open Roads, Open Greenspace) are
+refreshed by hand: download tiles from the OS portal, upload via the S3
+console. The last manual refresh silently dropped 4 road files, and the
+greenspace upload initially missed 5 island tiles (HP/HT/HU/HY/HZ) — gaps only
+discovered downstream. The public OS Downloads API
+(`https://api.os.uk/downloads/v1`, no auth for OpenData products) lists every
+per-area file with download URLs, md5s and sizes, so the refresh can be one
+reproducible, self-checking command.
+
+Full background in the
+[issue](https://github.com/nestauk/asf_heat_pump_suitability/issues/419) and
+its kickoff-interview
+[comment](https://github.com/nestauk/asf_heat_pump_suitability/issues/419#issuecomment-5059398210).
+
+## Proposal
+
+New script `pipeline/run/stream_os_open_data.py` (pattern precedent:
+`pipeline/run/stream_inspire_files.py`, which streams external zips to S3 —
+but written to v2 conventions: `config["data"]` paths, `logging`, no
+hard-coded bucket).
+
+Decisions, each settled in the kickoff interview (2026-07-23):
+
+1. **CLI** — `--products OpenMapLocal OpenRoads OpenGreenspace`; dry-run by
+   default (list tiles, sizes and the release version; no upload) unless
+   `--save`. An optional destination-root override flag supports the test
+   rehearsal below. Product names are the API's own IDs, so no mapping layer.
+2. **Version-named prefixes** — the dated segment of each S3 prefix comes from
+   the API product `version` field verbatim (e.g. `2026-04`), not the download
+   date. Rationale: names the OS release rather than the download event (ADR
+   0002's spirit — pins should identify the data, and two people refreshing
+   the same release must land on the same prefix). No ingestion code changes:
+   getters read whole path templates from `base.yaml` and only substitute
+   `{square}`/`{layer}`.
+3. **Keep each product's current internal layout** (no normalisation):
+
+   - OpenMap Local: `opmplc_essh_gb/{version}/data/{square}/{square}_{layer}.*`
+   - Open Roads: `oproad_essh_gb/{version}/data/{square}_{layer}.*`
+   - Open Greenspace: `opgrsp_essh_gb/{version}/{square}/data/{square}_{layer}.*`
+
+   Rationale: match what is already on S3 so consumers and reviewers see only
+   the dated segment change. All shapefile sidecars (`.shp`, `.dbf`, `.prj`,
+   `.shx`, `.cpg`, …) are uploaded, not just `.shp`.
+
+4. **Roads fan-out** — the API offers no per-square downloads for OpenRoads,
+   only a single ~606 MB GB shapefile zip whose members are per-square files;
+   the script streams that zip and fans its members out to the roads prefix.
+   OpenMap Local (55 tiles) and Greenspace (52 tiles) download per-area zips.
+5. **Reconciliation in-script** — after upload, list S3 under the new prefix
+   and compare against the API's offered areas (for roads: the GB zip's
+   members); fail loudly on any mismatch. This validates the upload the script
+   just performed; the planned pipeline-run preflight (#434) remains
+   complementary, not a duplicate. md5s from the API listing are verified on
+   the downloaded zips as a cheap corruption check.
+6. **Test rehearsal before production** — first run writes to a clearly-named
+   test prefix inside `asf-local-heat-planning-tool` (e.g.
+   `inputs/geodata/test_419_os_downloads/…`); getters are pointed at it
+   explicitly to verify end-to-end loading. Only then does the production run
+   write to the real product prefixes (inert until repoint, per ADR 0002), and
+   `base.yaml` templates are repointed as the final reviewed commit on this
+   branch. The test prefix is deleted after verification.
+7. **Config, not code** — the API base URL and the per-product S3 prefix
+   templates live in `base.yaml`.
+
+## Alternatives considered
+
+- **Normalise the three layouts to one convention** (issue proposal, e.g.
+  roads-style flat `data/{square}_{layer}.shp` for all products) — rejected in
+  interview: matching the existing on-S3 structure means less churn for
+  consumers, and the getters are indifferent (they format whole templates).
+- **Separate test bucket** — rejected: tests a different config than ships,
+  needs new bucket/IAM, uploads ~3 GB twice. A test prefix inside the
+  production bucket gives the same isolation (nothing reads a prefix
+  `base.yaml` doesn't point at).
+- **Upload-date (`YYYYMMDD`) prefix naming** (current convention) — rejected:
+  names the download event, not the release; identical data refreshed on two
+  days would occupy two prefixes.
+- **Defer reconciliation to the #434 preflight** — rejected: a silently
+  incomplete refresh would go undetected until the next pipeline run, which is
+  exactly the failure mode motivating this issue.
+- **Auto-resolving "latest" prefixes** — out of bounds here; settled by ADR
+  0002 (explicit pinning). Issue #429 tracks the counter-proposal.
+
+## Out of scope
+
+- GB-wide single files (`opmplc_gb.gpkg`, `opgrsp_gb.gpkg`) — separate undated
+  keys, refreshed rarely; `gb_os_openroad` already globs the per-square prefix
+  so it is covered by the repoint.
+- Cleanup of superseded prefixes on S3 — issue #420 (this work adds to its
+  list: the old `20260708`/`20260709` prefixes once repointed away from).
+- Pipeline-run-time input validation — issue #434.
+
+## Open questions
+
+- Should `stream_inspire_files.py` later be migrated to the same
+  config-driven, reconciling pattern (it still hard-codes the v1 bucket and
+  uses deprecated `config["data_source"]`)?
+- Does `config/README.md`'s citation table need an access-method note (API vs
+  portal) for the three OS datasets, or is the existing citation unchanged?
+
+## Verification
+
+- [ ] Dry run (no `--save`) lists per-product tile names, sizes and the API
+      `version` without writing to S3.
+- [ ] Test-prefix run uploads via the destination override; getters load
+      grid-square data from the test prefix end-to-end; test prefix deleted
+      afterwards.
+- [ ] Production run populates version-named prefixes for all three products
+      in their current layouts, all sidecar files included.
+- [ ] Reconciliation compares S3 against the API's offered areas (roads: GB
+      zip members) and exits non-zero with a clear message on mismatch.
+- [ ] `base.yaml` repointed to the new prefixes as the final commit;
+      `load_gdf_os_openmap_layer` and `load_gdf_os_openroad` load spot-check
+      squares via config alone.
+- [ ] API base URL and prefix templates read from `base.yaml`; no hard-coded
+      S3 paths or magic values in the script.
+- [ ] Unit tests (fixture JSON, no network) for the pure helpers: API response
+      → download list, zip member → S3 key mapping per product, reconciliation
+      diff. 1:1 test module `pipeline/run/tests/test_stream_os_open_data.py`.


### PR DESCRIPTION
## Description

Adds a single reproducible command to refresh the three per-grid-square OS
OpenData products (OpenMap Local, Open Roads, Open Greenspace) from the public
OS Downloads API straight to S3, replacing the manual "download from the portal,
upload via the console" process.

The manual process has silently dropped files before: the last refresh lost 4
road files, and a greenspace upload initially missed 5 island tiles
(HP/HT/HU/HY/HZ) — gaps only found downstream. The new script lists every file
from the API, streams it to S3, and reconciles what it uploaded against what the
API offered, failing loudly on any mismatch.

**This is a DRAFT.** The code, tests and spec are review-ready, but three
verification steps are deliberately still open, gated on a go-ahead before they
run against real S3 (see "Verification status" below). Nothing here changes what
the pipeline reads yet — the `base.yaml` repoint is intentionally not in this PR.

## Related Issue(s)

- Closes #419

## Changes Made

- **`asf_heat_pump_suitability/pipeline/run/stream_os_open_data.py`** — new
  script. Dry-run by default (lists tiles, sizes and the release version); only
  writes to S3 with `--save`. Downloads each product's zips, streams them to a
  temp file while computing an incremental md5 (checked against the API's md5),
  and uploads to S3. OpenMap Local and Greenspace come as per-area zips; Open
  Roads is offered only as one ~606 MB GB zip whose per-square members are fanned
  out to the roads prefix. After upload it lists S3 under the new prefix and
  compares against the API's offered areas, exiting non-zero on any mismatch.
- **`asf_heat_pump_suitability/config/base.yaml`** — new `os_downloads` section:
  the API URL, the S3 destination root, and the per-product prefix templates. No
  S3 paths or magic values are hard-coded in the script.
- **`pipeline/run/tests/test_stream_os_open_data.py`** + `os_downloads_api_fixture.json`
  — 33 unit tests over the pure helpers (API response to download list, zip
  member to S3 key mapping per product, md5 check, S3 URI splitting,
  offered-areas extraction, reconciliation diff). All run off a fixture JSON, no
  network.
- **`docs/specs/419_streamOsOpenData.md`** — the design source of truth (7
  decisions from the kickoff interview, including keeping each product's current
  S3 layout and using version-named prefixes like `2026-04`).

Design highlight: the dated segment of each S3 prefix (e.g. `2026-04`) comes
from the API's `version` field verbatim, so the prefix names the OS *release*,
not the download date — two people refreshing the same release land on the same
prefix (ADR 0002's spirit). Getters read whole path templates from `base.yaml`
and only substitute `{square}`/`{layer}`, so no ingestion code changes are
needed.

## For Reviewers

### What to Focus On

- The three per-product S3 key mappings in the script vs the layouts documented
  in spec decision 3 — each product keeps its *current* on-S3 layout (no
  normalisation), including all shapefile sidecars (`.shp`, `.dbf`, `.prj`,
  `.shx`, `.cpg`, …) and the `licence.txt`/`readme.txt` placements.
- The reconciliation logic (spec decision 5): does comparing S3 keys against the
  API's offered areas — and the GB zip's members for roads — actually catch the
  drop-a-file failure mode that motivated the issue?
- The roads fan-out: streaming one large zip and routing its members to the
  roads prefix.

### How to Test

From the repo root:

- **Run the unit tests** (no network, no AWS):

  ```
  pytest asf_heat_pump_suitability/pipeline/run/tests/test_stream_os_open_data.py
  ```

  Expect 33 passed.

- **Dry run** (lists tiles/sizes/version, writes nothing to S3):

  ```
  python -m asf_heat_pump_suitability.pipeline.run.stream_os_open_data
  ```

  Add `--products OpenGreenspace` to limit to one (smallest, ~40 MB) product.
  This hits the public API but needs no auth and no S3 write.

- Only add `--save` to actually upload, and `--destination_root <s3-uri>` to
  redirect a run to a test prefix.

### Setup Requirements

- No new dependencies. The dry run and unit tests need no AWS credentials.
- Uploading (`--save`) needs write access to the
  `asf-local-heat-planning-tool` bucket.

## Verification status

Honest state of the spec's Verification checklist — this is why the PR is a
draft:

- [x] **Dry run** — verified live on 2026-07-23 (AWS credentials nulled):
  OpenMapLocal 2026-04 (55 zips), OpenRoads 2026-04 (1 GB zip), OpenGreenspace
  2026-04 (52 zips); island tiles HP/HT/HU/HY/HZ all listed; exit 0.
- [x] **Reconciliation** — diff helper unit-tested; failure path demonstrated
  with mocked S3 (a missing island tile plus a stray `.DS_Store` produced a
  clear ERROR naming both keys and exit 1).
- [x] **Config-driven** — API URL and prefix templates read from `base.yaml`; no
  hard-coded S3 paths in the script.
- [x] **Unit tests** — fixture-based, no network (33 passed).
- [ ] **Test-prefix rehearsal** — a `--save` run to a test prefix
  (`--destination_root .../test_419_os_downloads/`) with getters pointed at it
  end-to-end. **Gated on go-ahead.**
- [ ] **Production run** — populate the real `2026-04` prefixes for all three
  products. **Gated on go-ahead.**
- [ ] **`base.yaml` repoint** — point the existing grid-square path templates at
  the new prefixes, as the final reviewed commit on this branch. **Deliberately
  not in this PR yet.**

## Open questions / notes

- Optional hardening (not promised): a per-area sanity check that a zip's
  contents actually match its area label, on top of the existing name-based
  reconciliation. Worth adding?
- Should `stream_inspire_files.py` later be migrated to this config-driven,
  reconciling pattern (it still hard-codes the v1 bucket)?
- Does `config/README.md`'s citation table need an access-method note (API vs
  portal) for these three datasets?

## Checklist

- [x] Unit tests pass locally (33 passed); pre-commit green
- [x] Dry run verified live; no local file dependencies (fixture-based tests)
- [x] Docstrings on all helpers; design captured in the spec
- [x] Changes are scoped to one issue (#419)
- [ ] End-to-end S3 rehearsal + production run + `base.yaml` repoint — gated on
  go-ahead (why this is a draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
