### PR TITLE
468 optimise cluster

### DIFF
--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -98,12 +98,13 @@ def generate_gdf_clusters(
 
     # Create Voronoi polygons and overlay physical barriers for all local authority boundaries
     for boundary in boundary_gdf["geometry"].unique():
+        bounded_tech_gdf = tech_gdf[tech_gdf.within(boundary)]
         voronoi_gdf = extend_edges_gdf(gdf=buildings_gdf, boundary=boundary)
 
         # One cell per building
         cells_gdf = overlay_gdf_physical_barriers(
             voronoi_gdf=voronoi_gdf,
-            tech_gdf=tech_gdf,
+            tech_gdf=bounded_tech_gdf,
             line_overlay_gdf=line_overlay_gdf,
             polygon_overlay_gdf=polygon_overlay_gdf,
             id_col=id_col,
@@ -325,6 +326,8 @@ def extend_edges_gdf(
     arr = voronoi_gdf.sort_values(building_id_col)
     unique_ids, first_idx = np.unique(arr[building_id_col].values, return_index=True)
     # Split the Voronoi geometries into groups. One group == one building ID
+    # first_idx[1:] skips the first element which is always 0. This is because np.split splits the array at the locations of
+    # each index. If we included index 0, it would create an empty group at the start.
     geom_groups = np.split(arr.geometry.values, first_idx[1:])
     voronoi_gdf = gpd.GeoDataFrame(
         {building_id_col: unique_ids},

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -168,7 +168,19 @@ def generate_gdf_clusters(
     # At this point we have multiple rows of each cluster geometry with one row for every building within the cluster.
     # We need to flatten the cluster geometries to one row per cluster, aggregating the within_anchor_radius boolean flag.
     # Selecting `max` of the boolean will mean any clusters containing one building within the anchor radius will be labelled as within the radius.
-    clusters_gdf = clusters_gdf.dissolve(by="cluster_id", aggfunc="max").reset_index()
+    # clusters_gdf = clusters_gdf.dissolve(by="cluster_id", aggfunc="max").reset_index()
+    clusters_gdf = (
+        clusters_gdf.groupby(by="cluster_id")
+        .agg(
+            {
+                "geometry": "first",
+                "assigned_tech": "first",
+                f"within_{radius}m_from_anchor_load": "max",
+            }
+        )
+        .reset_index()
+        .set_geometry(column="geometry", crs=clusters_gdf.crs)
+    )
 
     # TODO move to testing when sample set available
     if round(clusters_gdf["geometry"].area.sum(), 3) > round(
@@ -285,11 +297,12 @@ def extend_edges_gdf(
     print(
         "Joining Voronois to original building footprints and dissolving per footprint..."
     )
+
     # Join the original building points with IDs to the Voronoi cells and dissolve to get one polygon per internal building ID
     # Intersects (rather than contains) allows for small floating point errors without dropping Voronois
     voronoi_gdf = voronoi_gdf.sjoin(points_gdf, how="inner", predicate="intersects")
     voronoi_gdf.geometry = voronoi_gdf.geometry.make_valid()
-    voronoi_gdf = (voronoi_gdf.dissolve(by=id_col).reset_index()).clip(boundary)
+    voronoi_gdf = voronoi_gdf.clip(boundary).dissolve(by=id_col).reset_index()
 
     # Clip Voronoi cells to a max buffer
     print("Clip Voronoi cells to maximum buffer...")

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -250,17 +250,18 @@ def extend_edges_gdf(
     gdf = gdf[gdf.within(boundary)]
 
     # Add an internal unique ID to each building
-    id_col = "_internal_building_id"
-    gdf[id_col] = np.arange(len(gdf))
+    building_id_col = "_internal_building_id"
+    gdf[building_id_col] = np.arange(len(gdf))
 
     all_points = []
-    all_ids = []
+    all_building_ids = []
 
     print("Densifying building polygon edges...")
     # Densify polygon edges with additional points to prepare for Voronoi diagram
     for _, row in gdf.iterrows():
         geom = row.geometry
-        id = row[id_col]
+        # Assign building ID
+        building_id = row[building_id_col]
         # Deal with any multipolygon buildings
         polys = geom.geoms if isinstance(geom, MultiPolygon) else [geom]
 
@@ -278,43 +279,51 @@ def extend_edges_gdf(
             # Add corner vertices of building into list, dropping the last one which is a duplicate of the starting point
             pts.extend(Point(coord) for coord in exterior.coords[:-1])
             all_points.extend(pts)
-            all_ids.extend([id] * len(pts))
+            all_building_ids.extend([building_id] * len(pts))
 
     print(f"Generated {len(all_points)} points.")
     # Create a gdf of all densified points, where one row is one point
-    points_gdf = gpd.GeoDataFrame({id_col: all_ids}, geometry=all_points, crs=gdf.crs)
+    point_ids = np.arange(
+        len(all_points)
+    )  # Set unique ID for each point for later joins
+    points_gdf = gpd.GeoDataFrame(
+        {"point_id": point_ids, building_id_col: all_building_ids},
+        geometry=all_points,
+        crs=gdf.crs,
+    )
 
-    # Convert to a Multipoint collection for Voronoi.
-    # Pass raw coordinate array rather than a list of Point objects to avoid Python object overhead.
+    # Convert to a Multipoint collection for Voronoi
     coords = MultiPoint(shapely.get_coordinates(points_gdf.geometry.values))
 
     print("Computing Voronoi diagram...")
-    # Compute Voronoi polygons up to specified boundary, create one Voronoi cell per point
-    voronoi_collection = shapely.voronoi_polygons(coords, extend_to=boundary)
+    # Compute Voronoi polygons up to specified boundary, create one Voronoi cell per point and retain the original order of points
+    voronoi_collection = shapely.voronoi_polygons(
+        coords, extend_to=boundary, ordered=True
+    )
 
-    # Convert to a geodataframe using a numpy array rather than a Python list to avoid copying all geometries.
+    # Convert to a geodataframe
     voronoi_gdf = gpd.GeoDataFrame(
-        geometry=np.array(voronoi_collection.geoms), crs=gdf.crs
+        {
+            "voronoi_id": point_ids,
+            building_id_col: all_building_ids,
+            "geometry": np.array(voronoi_collection.geoms),
+        },
+        crs=gdf.crs,
     )
 
     print(
         "Joining Voronois to original building footprints and dissolving per footprint..."
     )
 
-    # Join the original building points with IDs to the Voronoi cells and union per building ID.
-    # Intersects (rather than contains) allows for small floating point errors without dropping Voronois.
-    # Deduplicate on the Voronoi cell index: intersects can match a cell to neighbouring seed points
-    # that land on its boundary, producing duplicate rows in the same building's group.
-    # union_all via sorted numpy groups is faster than dissolve (no pandas groupby overhead) and
-    # tolerates the microscopic floating-point overlaps that coverage_union_all would reject.
-    voronoi_gdf = voronoi_gdf.sjoin(points_gdf, how="inner", predicate="intersects")
-    voronoi_gdf = voronoi_gdf[~voronoi_gdf.index.duplicated(keep="first")]
     voronoi_gdf.geometry = voronoi_gdf.geometry.make_valid()
-    arr = voronoi_gdf.sort_values(id_col)
-    unique_ids, first_idx = np.unique(arr[id_col].values, return_index=True)
+    # Sort building IDs and then get the first index of each unique building ID
+    arr = voronoi_gdf.sort_values(building_id_col)
+    unique_ids, first_idx = np.unique(arr[building_id_col].values, return_index=True)
+    # Split the Voronoi geometries into groups. One group == one building ID
     geom_groups = np.split(arr.geometry.values, first_idx[1:])
     voronoi_gdf = gpd.GeoDataFrame(
-        {id_col: unique_ids},
+        {building_id_col: unique_ids},
+        # For each group of Voronoi polygons, union them into one polygon representing a Voronoi for the whole building
         geometry=[shapely.union_all(g) for g in geom_groups],
         crs=voronoi_gdf.crs,
     ).clip(boundary)
@@ -322,14 +331,14 @@ def extend_edges_gdf(
     # Clip Voronoi cells to a max buffer
     print("Clip Voronoi cells to maximum buffer...")
     clipped_voronoi_gdf = _clip_gdf_voronoi_cells_polygon_buffer(
-        polygon_gdf=gdf, voronoi_gdf=voronoi_gdf, buffer=buffer, id_col=id_col
+        polygon_gdf=gdf, voronoi_gdf=voronoi_gdf, buffer=buffer, id_col=building_id_col
     )
 
     # Return Voronoi cell geometries per building with original building ID
     return gpd.GeoDataFrame(
         gdf.drop(columns=["geometry"])
-        .merge(clipped_voronoi_gdf, how="inner", on=id_col)
-        .drop(columns=[id_col]),
+        .merge(clipped_voronoi_gdf, how="inner", on=building_id_col)
+        .drop(columns=[building_id_col]),
         geometry="geometry",
         crs=gdf.crs,
     )

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -179,7 +179,7 @@ def generate_gdf_clusters(
             }
         )
         .reset_index()
-        .set_geometry(column="geometry", crs=clusters_gdf.crs)
+        .set_geometry(col="geometry", crs=clusters_gdf.crs)
     )
 
     # TODO move to testing when sample set available
@@ -302,7 +302,7 @@ def extend_edges_gdf(
     # Intersects (rather than contains) allows for small floating point errors without dropping Voronois
     voronoi_gdf = voronoi_gdf.sjoin(points_gdf, how="inner", predicate="intersects")
     voronoi_gdf.geometry = voronoi_gdf.geometry.make_valid()
-    voronoi_gdf = voronoi_gdf.clip(boundary).dissolve(by=id_col).reset_index()
+    voronoi_gdf = (voronoi_gdf.dissolve(by=id_col).reset_index()).clip(boundary)
 
     # Clip Voronoi cells to a max buffer
     print("Clip Voronoi cells to maximum buffer...")
@@ -400,9 +400,7 @@ def overlay_gdf_physical_barriers(
     cell_to_building_mapping = intersection_gdf.set_index(cell_id_col)[id_col].to_dict()
 
     # Use the mapping to label the original Voronoi cells with the correct building ID
-    voronoi_gdf["select_id"] = voronoi_gdf[cell_id_col].replace(
-        cell_to_building_mapping
-    )
+    voronoi_gdf["select_id"] = voronoi_gdf[cell_id_col].map(cell_to_building_mapping)
     # Filter to the rows where the building ID matches (i.e. only domestic buildings are retained here)
     domestic_voronoi_gdf = voronoi_gdf[
         voronoi_gdf[id_col] == voronoi_gdf["select_id"]

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -284,25 +284,40 @@ def extend_edges_gdf(
     # Create a gdf of all densified points, where one row is one point
     points_gdf = gpd.GeoDataFrame({id_col: all_ids}, geometry=all_points, crs=gdf.crs)
 
-    # Convert to a Multipoint collection for Voronoi
-    coords = MultiPoint(points_gdf.geometry.tolist())
+    # Convert to a Multipoint collection for Voronoi.
+    # Pass raw coordinate array rather than a list of Point objects to avoid Python object overhead.
+    coords = MultiPoint(shapely.get_coordinates(points_gdf.geometry.values))
 
     print("Computing Voronoi diagram...")
     # Compute Voronoi polygons up to specified boundary, create one Voronoi cell per point
     voronoi_collection = shapely.voronoi_polygons(coords, extend_to=boundary)
 
-    # Convert to a geodataframe
-    voronoi_gdf = gpd.GeoDataFrame(geometry=list(voronoi_collection.geoms), crs=gdf.crs)
+    # Convert to a geodataframe using a numpy array rather than a Python list to avoid copying all geometries.
+    voronoi_gdf = gpd.GeoDataFrame(
+        geometry=np.array(voronoi_collection.geoms), crs=gdf.crs
+    )
 
     print(
         "Joining Voronois to original building footprints and dissolving per footprint..."
     )
 
-    # Join the original building points with IDs to the Voronoi cells and dissolve to get one polygon per internal building ID
-    # Intersects (rather than contains) allows for small floating point errors without dropping Voronois
+    # Join the original building points with IDs to the Voronoi cells and union per building ID.
+    # Intersects (rather than contains) allows for small floating point errors without dropping Voronois.
+    # Deduplicate on the Voronoi cell index: intersects can match a cell to neighbouring seed points
+    # that land on its boundary, producing duplicate rows in the same building's group.
+    # union_all via sorted numpy groups is faster than dissolve (no pandas groupby overhead) and
+    # tolerates the microscopic floating-point overlaps that coverage_union_all would reject.
     voronoi_gdf = voronoi_gdf.sjoin(points_gdf, how="inner", predicate="intersects")
+    voronoi_gdf = voronoi_gdf[~voronoi_gdf.index.duplicated(keep="first")]
     voronoi_gdf.geometry = voronoi_gdf.geometry.make_valid()
-    voronoi_gdf = (voronoi_gdf.dissolve(by=id_col).reset_index()).clip(boundary)
+    arr = voronoi_gdf.sort_values(id_col)
+    unique_ids, first_idx = np.unique(arr[id_col].values, return_index=True)
+    geom_groups = np.split(arr.geometry.values, first_idx[1:])
+    voronoi_gdf = gpd.GeoDataFrame(
+        {id_col: unique_ids},
+        geometry=[shapely.union_all(g) for g in geom_groups],
+        crs=voronoi_gdf.crs,
+    ).clip(boundary)
 
     # Clip Voronoi cells to a max buffer
     print("Clip Voronoi cells to maximum buffer...")
@@ -314,7 +329,7 @@ def extend_edges_gdf(
     return gpd.GeoDataFrame(
         gdf.drop(columns=["geometry"])
         .merge(clipped_voronoi_gdf, how="inner", on=id_col)
-        .drop(columns=["index_right", id_col]),
+        .drop(columns=[id_col]),
         geometry="geometry",
         crs=gdf.crs,
     )
@@ -348,13 +363,16 @@ def _clip_gdf_voronoi_cells_polygon_buffer(
         # Simplify with a tolerance of 1mm to remove vertices which are extremely close together
     ).simplify(0.001)
 
-    # Clip Voronoi cells to the defined buffer area if they are larger than it by calculating intersections
-    clipped_gdf = voronoi_gdf.overlay(buffered_gdf, how="intersection")
-    # Filter clipped cells (intersections) to ensure each polygon's Voronoi cell is clipped only by its own buffer
-    return (
-        clipped_gdf[clipped_gdf[f"{id_col}_1"] == clipped_gdf[f"{id_col}_2"]]
-        .drop(columns=[f"{id_col}_2"])
-        .rename(columns={f"{id_col}_1": id_col})
+    # Clip each Voronoi cell to its own building's buffer using a 1:1 merge and vectorised intersection.
+    # This avoids the full cross-join overhead of overlay by only computing the intersection for matching pairs.
+    clipped_gdf = voronoi_gdf.merge(
+        buffered_gdf.rename(columns={"geometry": "buffer_geom"}), on=id_col
+    )
+    clipped_gdf["geometry"] = clipped_gdf["geometry"].intersection(
+        clipped_gdf["buffer_geom"]
+    )
+    return clipped_gdf.set_geometry(col="geometry", crs=voronoi_gdf.crs).drop(
+        columns="buffer_geom"
     )
 
 

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -584,10 +584,9 @@ def load_transform_gdf_polygon_barriers(
     - Tidal boundaries
     - Woodland
 
-    Additionally, load physical barriers with (Multi)LineString geometries - major roads and railways - for the
-    specified grid squares. A buffer is added around each geometry to cover the width of the road / railway.
-
-    # TODO add road types to docstring
+    Additionally, load physical barriers with (Multi)LineString geometries - railways, and roads of the following types:
+    "A Road", "B Road", "Motorway", "Minor Road"- for the specified grid squares. A buffer is added around each
+    geometry to cover the width of the road / railway.
 
     Args:
         grid_squares (Optional[List[str]]): names of grid squares in OS mapping for regions of Great Britain to be loaded.

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -282,18 +282,24 @@ def extend_edges_gdf(
             all_building_ids.extend([building_id] * len(pts))
 
     print(f"Generated {len(all_points)} points.")
-    # Create a gdf of all densified points, where one row is one point
-    point_ids = np.arange(
-        len(all_points)
-    )  # Set unique ID for each point for later joins
-    points_gdf = gpd.GeoDataFrame(
-        {"point_id": point_ids, building_id_col: all_building_ids},
-        geometry=all_points,
-        crs=gdf.crs,
-    )
+    # Extract a flat (N, 2) float64 array of all point coordinates
+    coords_arr = shapely.get_coordinates(np.array(all_points))
+
+    # ordered=True requires every input coordinate to be unique — GEOS raises GEOSException otherwise.
+    # Buildings can (rarely) share corner coordinates (e.g. shared walls), so duplicates can exist.
+    # To combat this we jitter duplicates by a 0.1mm x-offset so both buildings keep their seed points.
+
+    # Returns the index of the first occurrence of each unique coordinate pair
+    _, first_occ = np.unique(coords_arr, axis=0, return_index=True)
+    # Mark every position that is NOT a first occurrence as a duplicate
+    is_dup = np.ones(len(coords_arr), dtype=bool)
+    is_dup[first_occ] = False
+    # Offset each duplicate's x coordinate by a unique multiple of 0.1mm - this should not affect the overall shape of buildings significantly.
+    # (progressive multiples ensure jittered points don't collide with each other)
+    coords_arr[is_dup, 0] += np.arange(1, is_dup.sum() + 1) * 1e-4
 
     # Convert to a Multipoint collection for Voronoi
-    coords = MultiPoint(shapely.get_coordinates(points_gdf.geometry.values))
+    coords = MultiPoint(coords_arr)
 
     print("Computing Voronoi diagram...")
     # Compute Voronoi polygons up to specified boundary, create one Voronoi cell per point and retain the original order of points
@@ -301,10 +307,9 @@ def extend_edges_gdf(
         coords, extend_to=boundary, ordered=True
     )
 
-    # Convert to a geodataframe
+    # Convert to a geodataframe — with ordered=True the nth cell maps directly to the nth input point
     voronoi_gdf = gpd.GeoDataFrame(
         {
-            "voronoi_id": point_ids,
             building_id_col: all_building_ids,
             "geometry": np.array(voronoi_collection.geoms),
         },

--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -67,7 +67,6 @@ def generate_gdf_clusters(
     buildings_gdf: gpd.GeoDataFrame,
     boundary_gdf: gpd.GeoDataFrame,
     tech_gdf: gpd.GeoDataFrame,
-    line_overlay_gdf: gpd.GeoDataFrame,
     polygon_overlay_gdf: gpd.GeoDataFrame,
     combined_anchor_gdf: gpd.GeoDataFrame,
     radius: float,
@@ -84,7 +83,6 @@ def generate_gdf_clusters(
         buildings_gdf (gpd.GeoDataFrame): all building footprint polygons for area of interest, including domestic and non-domestic.
         boundary_gdf (gpd.GeoDataFrame): boundaries of Local Authorities to generate clusters for.
         tech_gdf (gpd.GeoDataFrame): domestic building footprints with assigned tech types.
-        line_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)LineString geometries to separate clusters by.
         polygon_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)Polygon geometries to separate clusters by.
         combined_anchor_gdf (gpd.GeoDataFrame): combined anchor property lists from important buildings and POI data, with building footprints
         radius (float): radius in metres around anchor property within which communal solutions should be assigned
@@ -105,7 +103,6 @@ def generate_gdf_clusters(
         cells_gdf = overlay_gdf_physical_barriers(
             voronoi_gdf=voronoi_gdf,
             tech_gdf=bounded_tech_gdf,
-            line_overlay_gdf=line_overlay_gdf,
             polygon_overlay_gdf=polygon_overlay_gdf,
             id_col=id_col,
         )
@@ -396,7 +393,6 @@ def _clip_gdf_voronoi_cells_polygon_buffer(
 def overlay_gdf_physical_barriers(
     voronoi_gdf: gpd.GeoDataFrame,
     tech_gdf: gpd.GeoDataFrame,
-    line_overlay_gdf: gpd.GeoDataFrame,
     polygon_overlay_gdf: gpd.GeoDataFrame,
     id_col: str,
 ) -> gpd.GeoDataFrame:
@@ -409,7 +405,6 @@ def overlay_gdf_physical_barriers(
     Args:
         voronoi_gdf (gpd.GeoDataFrame): Voronoi polygons around building footprints
         tech_gdf (gpd.GeoDataFrame): domestic building footprints with assigned tech types
-        line_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)LineString geometries
         polygon_overlay_gdf (gpd.GeoDataFrame): physical barriers with (Multi)Polygon geometries.
         id_col (str): building ID column.
 
@@ -442,11 +437,9 @@ def overlay_gdf_physical_barriers(
     ].drop(columns="select_id")
 
     # Remove areas covered by polygons and lines
-    cells_gdf = (
-        domestic_voronoi_gdf.overlay(polygon_overlay_gdf, how="difference")
-        .overlay(line_overlay_gdf, how="difference")
-        .explode()
-    )
+    cells_gdf = domestic_voronoi_gdf.overlay(
+        polygon_overlay_gdf, how="difference"
+    ).explode()
 
     # Deal with buildings that have multiple cell fragments
     # This happens in edge cases where a barrier bisects a Voronoi polygon
@@ -581,43 +574,6 @@ def sjoin_gdf_max_intersection(
     )
 
 
-def load_transform_gdf_linestring_barriers(
-    grid_squares: Optional[List[str]],
-) -> gpd.GeoDataFrame:
-    """
-    Load physical barriers with (Multi)LineString geometries - major roads and railways - for the specified grid squares. A
-    buffer is added around each geometry to cover the width of the road / railway.
-
-    # TODO add road types to docstring
-
-    Args:
-        grid_squares (Optional[List[str]]): names of grid squares in OS mapping for regions of Great Britain to be loaded.
-        Find grid square information at: https://www.ordnancesurvey.co.uk/documents/resources/guide-to-nationalgrid.pdf
-
-    Returns:
-        gpd.GeoDataFrame: physical barriers with (Multi)LineString geometries
-    """
-    # Linestrings
-    roads_gdf = load_geodata.load_gdf_os_openroad(grid_squares=grid_squares)
-
-    railways_gdf = load_geodata.load_gdf_os_openmap_layer(
-        layer="railway_track", grid_squares=grid_squares
-    )
-
-    barrier_road_types = ["A Road", "B Road", "Motorway", "Minor Road"]
-
-    barrier_roads_gdf = roads_gdf[roads_gdf["function"].isin(barrier_road_types)]
-
-    line_overlays = [barrier_roads_gdf, railways_gdf]
-    line_overlay_gdf = pd.concat([gdf[["geometry"]] for gdf in line_overlays])
-
-    # TODO make more specific for different road types
-    # Add buffer assumed to be width of road / railway (3.5m total - 1.75m either side)
-    line_overlay_gdf["geometry"] = line_overlay_gdf.geometry.buffer(1.75)
-
-    return line_overlay_gdf
-
-
 def load_transform_gdf_polygon_barriers(
     grid_squares: Optional[List[str]],
 ) -> gpd.GeoDataFrame:
@@ -627,6 +583,11 @@ def load_transform_gdf_polygon_barriers(
     - Water bodies
     - Tidal boundaries
     - Woodland
+
+    Additionally, load physical barriers with (Multi)LineString geometries - major roads and railways - for the
+    specified grid squares. A buffer is added around each geometry to cover the width of the road / railway.
+
+    # TODO add road types to docstring
 
     Args:
         grid_squares (Optional[List[str]]): names of grid squares in OS mapping for regions of Great Britain to be loaded.
@@ -652,9 +613,31 @@ def load_transform_gdf_polygon_barriers(
         layer="tidal_water", grid_squares=grid_squares
     )
 
-    polygon_overlays = [forest_gdf, greenspace_gdf, tidal_water_gdf, surface_water_gdf]
+    # Linestrings
+    roads_gdf = load_geodata.load_gdf_os_openroad(grid_squares=grid_squares)
+    barrier_road_types = ["A Road", "B Road", "Motorway", "Minor Road"]
+    barrier_roads_gdf = roads_gdf[roads_gdf["function"].isin(barrier_road_types)]
 
-    return pd.concat([gdf[["geometry"]] for gdf in polygon_overlays])
+    railways_gdf = load_geodata.load_gdf_os_openmap_layer(
+        layer="railway_track", grid_squares=grid_squares
+    )
+
+    line_overlays = [barrier_roads_gdf, railways_gdf]
+    line_overlay_gdf = pd.concat([gdf[["geometry"]] for gdf in line_overlays])
+
+    # TODO make more specific for different road types
+    # Add buffer assumed to be width of road / railway (3.5m total - 1.75m either side)
+    line_overlay_gdf["geometry"] = line_overlay_gdf.geometry.buffer(1.75)
+
+    overlays = [
+        forest_gdf,
+        greenspace_gdf,
+        tidal_water_gdf,
+        surface_water_gdf,
+        line_overlay_gdf,
+    ]
+
+    return pd.concat([gdf[["geometry"]] for gdf in overlays])
 
 
 def reassign_gdf_communal_networked(
@@ -928,9 +911,6 @@ if __name__ == "__main__":
     )
 
     # Load and transform physical barriers for clusters
-    line_overlay_gdf = load_transform_gdf_linestring_barriers(
-        local_authority_dict["grid_squares"]
-    )
     polygon_overlay_gdf = load_transform_gdf_polygon_barriers(
         local_authority_dict["grid_squares"]
     )
@@ -944,7 +924,6 @@ if __name__ == "__main__":
         buildings_gdf=buildings_gdf,
         boundary_gdf=boundary_gdf,
         tech_gdf=tech_gdf,
-        line_overlay_gdf=line_overlay_gdf,
         polygon_overlay_gdf=polygon_overlay_gdf,
         combined_anchor_gdf=combined_anchor_gdf,
         radius=ANCHOR_RADIUS,

--- a/asf_heat_pump_suitability/pipeline/cluster/tests/test_cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/tests/test_cluster.py
@@ -284,7 +284,6 @@ class TestGenerateGdfClusters:
             buildings_gdf=gdf_mixed_buildings,
             boundary_gdf=gdf_enclosing_boundary,
             tech_gdf=tech_gdf,
-            line_overlay_gdf=empty_gdf,
             polygon_overlay_gdf=empty_gdf,
             combined_anchor_gdf=empty_gdf,
             radius=50,
@@ -325,7 +324,6 @@ class TestGenerateGdfClusters:
             buildings_gdf=gdf_mixed_buildings,
             boundary_gdf=gdf_enclosing_boundary,
             tech_gdf=domestic_tech_gdf,
-            line_overlay_gdf=empty_gdf,
             polygon_overlay_gdf=empty_gdf,
             combined_anchor_gdf=empty_gdf,
             radius=50,
@@ -372,7 +370,6 @@ class TestGenerateGdfClusters:
             buildings_gdf=gdf_mixed_buildings,
             boundary_gdf=gdf_enclosing_boundary,
             tech_gdf=tech_gdf,
-            line_overlay_gdf=empty_gdf,
             polygon_overlay_gdf=empty_gdf,
             combined_anchor_gdf=empty_gdf,
             radius=50,
@@ -397,7 +394,6 @@ class TestGenerateGdfClusters:
             buildings_gdf=gdf_mixed_buildings,
             boundary_gdf=gdf_enclosing_boundary,
             tech_gdf=tech_gdf,
-            line_overlay_gdf=empty_gdf,
             polygon_overlay_gdf=empty_gdf,
             combined_anchor_gdf=empty_gdf,
             radius=50,
@@ -621,15 +617,18 @@ class TestOverlayGdfPhysicalBarriers:
         return gpd.read_parquet(fpath).set_crs(epsg=27700)
 
     @pytest.fixture(scope="class")
-    def gdf_line_overlay_mixed_buildings(self):
+    def gdf_polygon_overlay_mixed_buildings(self):
         """
-        Create a geodataframe of line polygons (linestrings converted to polygons) that meet the following criteria:
+        Create a geodataframe of polygons (incl. linestrings converted to polygons) that meet the following criteria:
         1. One road separates the corner of a building off from the rest of the footprint.
         2. One road bisects a building.
         3. The other roads go around and between buildings to separate clusters.
-        The buildings affected are separate from those affected by the overlay polygons.
+        4. Overlaps with the corner of a building.
+        5. Completely overlaps a building.
+        6. Bisects a building.
+        Different buildings are affected by the different polygons.
         """
-        line_dict = {
+        polygon_dict = {
             "geometry": [
                 Polygon(
                     [
@@ -675,23 +674,6 @@ class TestOverlayGdfPhysicalBarriers:
                         (400025.89, 400012.87),
                     ]
                 ),
-            ]
-        }
-
-        # Dissolve overlapping polygons and explode back to one line per polygon
-        return gpd.GeoDataFrame(line_dict, crs="EPSG:27700").dissolve().explode()
-
-    @pytest.fixture(scope="class")
-    def gdf_polygon_overlay_mixed_buildings(self):
-        """
-        Create a geodataframe of overlay polygons that meet the following criteria:
-        1. Overlaps with the corner of a building.
-        2. Completely overlaps a building.
-        3. Bisects a building.
-        The buildings affected are separate from those affected by the line polygons.
-        """
-        polygon_dict = {
-            "geometry": [
                 Polygon(
                     [
                         (400015.8, 400046.4),
@@ -766,7 +748,6 @@ class TestOverlayGdfPhysicalBarriers:
         self,
         gdf_mixed_buildings_voronoi,
         tech_gdf,
-        gdf_line_overlay_mixed_buildings,
         gdf_polygon_overlay_mixed_buildings,
     ):
         """Test Voronoi cells entirely contain buildings after overlaying barriers. This tests the function can handle
@@ -777,7 +758,6 @@ class TestOverlayGdfPhysicalBarriers:
         cells_gdf = overlay_gdf_physical_barriers(
             voronoi_gdf=gdf_mixed_buildings_voronoi,
             tech_gdf=domestic_tech_gdf,
-            line_overlay_gdf=gdf_line_overlay_mixed_buildings,
             polygon_overlay_gdf=gdf_polygon_overlay_mixed_buildings,
             id_col="building_id",
         )


### PR DESCRIPTION
Fixes #468 

# Description

First pass optimisation of `cluster.py` script for speed and memory gains. Cut from 10m4s to 5m2s.

Modified files:
- `asf_heat_pump_suitability/pipeline/cluster/cluster.py` - conduct some vectorisation of geospatial manipulations rather than using heavy processes like `dissolve`

# Instructions for Reviewer

In order to test the code in this PR you need to ...
I have tested the code and it works. You can run the following code from terminal to test it:
```uv run python -i asf_heat_pump_suitability/pipeline/cluster/cluster.py --local_authorities plymouth --release_date 20260812```

This will run the code on this branch using the output from the upstream scripts run on `dev`.

I have compared the outputs to the outputs of the `cluster.py` script run on `dev` using the same upstream inputs. I have found some differences which I have outlined in the sprint 6 slide deck. I believe the diffs are negligible. Let me know if there's further comparisons you think I should do :)

Please pay special attention to...
The new logic applied in the clustering to ensure we are achieving the same end goal as before.

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
