### PR TITLE
472 Filter geometry checks to the clusters layer (3/3)

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -405,6 +405,10 @@ compare_versions:
     cluster: "tech_clusters"
     compute_contextual_features: "clusters_tech_contextual_info"
   decision_tree_buildings_dataset: "buildings_most_suitable_tech"
+  # The `layer` value carrying the clusters in the multi-layer front-end
+  # geojson; the cluster checks filter to it. Versions without a `layer`
+  # column (pre-August-2026 outputs) are treated as all-clusters.
+  cluster_layer: "clusters_with_contextual_features"
   # Columns whose distributions the report compares per stage (Q1/Q3, min,
   # max, mean, old vs new). Real output columns only: derived metrics such
   # as cluster area are computed from geometry in code and fed through the

--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -405,6 +405,14 @@ compare_versions:
     cluster: "tech_clusters"
     compute_contextual_features: "clusters_tech_contextual_info"
   decision_tree_buildings_dataset: "buildings_most_suitable_tech"
+  # Columns whose distributions the report compares per stage (Q1/Q3, min,
+  # max, mean, old vs new). Real output columns only: derived metrics such
+  # as cluster area are computed from geometry in code and fed through the
+  # same shared helper.
+  distribution_columns:
+    cluster: []
+    compute_contextual_features:
+      - "n_UPRNs"
   # Repo paths counted as each stage's module when scoping the commit log
   # between two versions' recorded commits: the stage entrypoint plus the
   # pipeline modules it directly drives. Cross-cutting code (getters/, utils/,

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -47,10 +47,14 @@ TECH_COL = "assigned_tech"
 NULL_TECH_LABEL = "(null)"
 CLUSTER_ID_COL = "cluster_id"
 AREA_COL = "area_m2"
+# Multi-layer front-end outputs (August 2026 onwards) tag every row with
+# the layer it belongs to; earlier outputs have no such column.
+LAYER_COL = "layer"
 # Stages whose outputs carry cluster geometry, and so get the cluster
 # count, area and distribution sections.
 GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
 
+CLUSTER_LAYER = config["compare_versions"]["cluster_layer"]
 STAGE_MODULE_PATHS = config["compare_versions"]["stage_module_paths"]
 STAGE_OUTPUT_DATASETS = config["compare_versions"]["stage_output_datasets"]
 BUILDINGS_DATASET = config["compare_versions"]["decision_tree_buildings_dataset"]
@@ -132,6 +136,27 @@ def generate_dict_cluster_count_delta(
     }
 
 
+def filter_df_clusters_layer(df: pl.DataFrame) -> pl.DataFrame:
+    """
+    Keep only a frame's clusters-layer rows.
+
+    Multi-layer front-end outputs bundle non-cluster layers (ward
+    boundaries, anchor loads) with the clusters in one file; the cluster
+    checks must not aggregate over them. A frame without a `layer` column
+    (a pre-layers output) is all clusters and passes through unchanged.
+
+    Args:
+        df: one version of a geometry-stage output (tabular or per-row areas)
+
+    Returns:
+        pl.DataFrame: the rows whose layer is the configured clusters layer,
+            or the frame itself when it has no `layer` column
+    """
+    if LAYER_COL not in df.columns:
+        return df
+    return df.filter(pl.col(LAYER_COL) == CLUSTER_LAYER)
+
+
 def generate_dict_total_area_delta(
     df_areas_old: pl.DataFrame, df_areas_new: pl.DataFrame
 ) -> dict:
@@ -196,23 +221,32 @@ def get_dict_distribution_frames(
 
     The derived cluster area reads the geometry-derived frames (when
     loaded); the stage's configured `DISTRIBUTION_COLUMNS` read the tabular
-    outputs.
+    outputs. Every frame is filtered to the clusters layer here, so the
+    stats tables and the plots fed from this mapping cannot diverge on
+    which rows they cover.
 
     Args:
         stage: pipeline stage the outputs belong to
         df_old: older version of the tabular stage output
         df_new: newer version of the tabular stage output
-        df_areas_old: older version's per-cluster areas, or None
-        df_areas_new: newer version's per-cluster areas, or None
+        df_areas_old: older version's per-row areas, or None
+        df_areas_new: newer version's per-row areas, or None
 
     Returns:
-        dict: column name to (old, new) frame pair, plot/report order
+        dict: column name to (old, new) clusters-layer frame pair,
+            plot/report order
     """
     frames = {}
     if df_areas_old is not None and df_areas_new is not None:
-        frames[AREA_COL] = (df_areas_old, df_areas_new)
+        frames[AREA_COL] = (
+            filter_df_clusters_layer(df_areas_old),
+            filter_df_clusters_layer(df_areas_new),
+        )
     for column in DISTRIBUTION_COLUMNS.get(stage, []):
-        frames[column] = (df_old, df_new)
+        frames[column] = (
+            filter_df_clusters_layer(df_old),
+            filter_df_clusters_layer(df_new),
+        )
     return frames
 
 
@@ -748,25 +782,31 @@ def load_transform_df_stage_output(path: str) -> pl.DataFrame:
 
 def load_df_cluster_areas(path: str) -> pl.DataFrame:
     """
-    Load a geometry-bearing stage output as per-cluster areas in m².
+    Load a geometry-bearing stage output as per-row areas in m².
 
     Areas are measured in EPSG:27700 (metres); an output saved in another
     CRS — the contextual-features geojson is EPSG:4326, with simplified
     geometry — is reprojected first. A zero-feature geojson degrades to an
-    empty frame.
+    empty frame. A multi-layer output's `layer` column rides along with the
+    areas, so the checks can filter to the clusters layer and the per-layer
+    table can tally the rest.
 
     Args:
         path: S3 path of the stage output (.parquet or .geojson)
 
     Returns:
         pl.DataFrame: one `area_m2` row per feature row (not deduplicated on
-            cluster id, so a duplicated cluster contributes each of its rows)
+            cluster id, so a duplicated cluster contributes each of its
+            rows), plus the source's `layer` column when it has one
 
     Raises:
         ValueError: for file types the comparison cannot read geometry from
     """
     if path.endswith(".parquet"):
-        gdf = gpd.read_parquet(path, columns=["geometry"])
+        columns = ["geometry"]
+        if LAYER_COL in pq.read_schema(path).names:
+            columns.append(LAYER_COL)
+        gdf = gpd.read_parquet(path, columns=columns)
     elif path.endswith(".geojson"):
         try:
             gdf = base_getters.load_gdf_from_s3_geojson(path, crs="EPSG:4326")
@@ -776,7 +816,10 @@ def load_df_cluster_areas(path: str) -> pl.DataFrame:
     else:
         raise ValueError(f"Cannot read geometry of {path}; expected parquet/geojson.")
     gdf = geo_utils.verify_gdf_crs(gdf)
-    return pl.DataFrame({AREA_COL: gdf.area.to_numpy()})
+    areas = {AREA_COL: gdf.area.to_numpy()}
+    if LAYER_COL in gdf.columns:
+        areas[LAYER_COL] = gdf[LAYER_COL].to_numpy()
+    return pl.DataFrame(areas)
 
 
 def load_df_buildings_tech(path: str) -> pl.DataFrame:
@@ -922,11 +965,15 @@ def _format_stat(value: float | int) -> str:
 
 
 def _generate_str_cluster_geometry_section(
-    count_delta: dict | None, area_delta: dict | None, stage: str
+    count_delta: dict | None,
+    area_delta: dict | None,
+    stage: str,
+    layer_filtered: bool = False,
 ) -> str:
     """Render cluster count and total area deltas as a markdown section,
-    with the CRS/units stated and the simplified-geometry caveat for the
-    contextual-features stage."""
+    with the CRS/units stated, the clusters-layer scope named when a
+    multi-layer output was filtered, and the simplified-geometry caveat
+    for the contextual-features stage."""
     lines = [
         "| Metric | Old | New | Delta |",
         "| --- | --- | --- | --- |",
@@ -942,6 +989,16 @@ def _generate_str_cluster_geometry_section(
             f"| Total area (m²) | {area_delta['area_m2_old']:,.1f} "
             f"| {area_delta['area_m2_new']:,.1f} "
             f"| {area_delta['area_m2_delta']:+,.1f} |"
+        )
+    if layer_filtered:
+        lines.extend(
+            [
+                "",
+                "This output bundles multiple front-end layers; the cluster "
+                f"checks and distributions cover the `{CLUSTER_LAYER}` layer "
+                f"only. A version without a `{LAYER_COL}` column predates "
+                "layered outputs and counts entirely as clusters.",
+            ]
         )
     if count_delta is None:
         lines.extend(
@@ -1172,13 +1229,26 @@ def generate_str_report(
     ]
     if stage in GEOMETRY_STAGES:
         area_delta = (
-            generate_dict_total_area_delta(df_areas_old, df_areas_new)
+            generate_dict_total_area_delta(
+                filter_df_clusters_layer(df_areas_old),
+                filter_df_clusters_layer(df_areas_new),
+            )
             if df_areas_old is not None and df_areas_new is not None
             else None
         )
+        layer_filtered = any(
+            LAYER_COL in frame.columns
+            for frame in (df_old, df_new, df_areas_old, df_areas_new)
+            if frame is not None
+        )
         sections.append(
             _generate_str_cluster_geometry_section(
-                generate_dict_cluster_count_delta(df_old, df_new), area_delta, stage
+                generate_dict_cluster_count_delta(
+                    filter_df_clusters_layer(df_old), filter_df_clusters_layer(df_new)
+                ),
+                area_delta,
+                stage,
+                layer_filtered,
             )
         )
         frames = get_dict_distribution_frames(

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -2,11 +2,13 @@
 Compare two dated versions of a pipeline stage output for one local authority.
 
 Reports row/UPRN count deltas, schema diff, UPRN churn, per-tech counts and
-the tech-assignment transition matrix (decision-tree stage), and a
-module-scoped commit log between the two versions' recorded commits. With a
---trigger, checks are read against that rubric's tolerances; without one, the
-report presents raw numbers only. Writes a local markdown report and logs a
-console summary.
+the tech-assignment transition matrix (decision-tree stage), cluster
+count/area deltas and distribution comparisons with overlaid plots (cluster
+and contextual-features stages), and a module-scoped commit log between the
+two versions' recorded commits. With a --trigger, checks are read against
+that rubric's tolerances; without one, the report presents raw numbers only.
+Writes a local markdown report (plus distribution plot PNGs next to it) and
+logs a console summary.
 
 Usage (compare the latest two versions, raw numbers only):
 python -m asf_heat_pump_suitability.pipeline.validate.compare_versions \
@@ -913,6 +915,86 @@ def _generate_str_churn_section(
     return _render_section("UPRN churn", *lines)
 
 
+def _format_stat(value: float | int) -> str:
+    """Format a statistic for a report table (floats to one decimal place)."""
+    return f"{value:,.1f}" if isinstance(value, float) else f"{value:,}"
+
+
+def _generate_str_cluster_geometry_section(
+    count_delta: dict | None, area_delta: dict | None, stage: str
+) -> str:
+    """Render cluster count and total area deltas as a markdown section,
+    with the CRS/units stated and the simplified-geometry caveat for the
+    contextual-features stage."""
+    lines = [
+        "| Metric | Old | New | Delta |",
+        "| --- | --- | --- | --- |",
+    ]
+    if count_delta is not None:
+        lines.append(
+            f"| Clusters | {count_delta['clusters_old']} "
+            f"| {count_delta['clusters_new']} "
+            f"| {count_delta['clusters_delta']:+d} |"
+        )
+    if area_delta is not None:
+        lines.append(
+            f"| Total area (m²) | {area_delta['area_m2_old']:,.1f} "
+            f"| {area_delta['area_m2_new']:,.1f} "
+            f"| {area_delta['area_m2_delta']:+,.1f} |"
+        )
+    if count_delta is None:
+        lines.extend(
+            [
+                "",
+                f"Cluster count skipped: no `{CLUSTER_ID_COL}` column in one or "
+                "both versions (see schema diff).",
+            ]
+        )
+    if area_delta is None:
+        lines.extend(["", "Total area skipped: geometry unavailable."])
+    else:
+        lines.extend(
+            ["", "Areas are computed in EPSG:27700 (British National Grid), in m²."]
+        )
+        if stage == "compute_contextual_features":
+            lines.append(
+                "Note: this stage's areas are measured on simplified geometry "
+                "(reprojected from EPSG:4326); small differences from the "
+                "cluster stage are simplification artefacts, not drift."
+            )
+    return _render_section("Cluster geometry", *lines)
+
+
+def _generate_str_distribution_section(
+    column: str,
+    frame_old: pl.DataFrame,
+    frame_new: pl.DataFrame,
+    plot_file: str | None,
+) -> str:
+    """Render one distribution's per-version statistics as a markdown
+    section, with its overlaid plot embedded when one was saved."""
+    title = f"Distribution: {column}"
+    stats_old = generate_dict_distribution_stats(frame_old, column)
+    stats_new = generate_dict_distribution_stats(frame_new, column)
+    if stats_old is None or stats_new is None:
+        return _render_section(
+            title, f"Skipped: no `{column}` values in one or both versions."
+        )
+    lines = [
+        "| Statistic | Old | New |",
+        "| --- | --- | --- |",
+    ]
+    labels = {"min": "Min", "q1": "Q1", "mean": "Mean", "q3": "Q3", "max": "Max"}
+    for key, label in labels.items():
+        lines.append(
+            f"| {label} | {_format_stat(stats_old[key])} "
+            f"| {_format_stat(stats_new[key])} |"
+        )
+    if plot_file is not None:
+        lines.extend(["", f"![Distribution of {column}: old vs new]({plot_file})"])
+    return _render_section(title, *lines)
+
+
 def _generate_str_tech_counts_section(
     df_old: pl.DataFrame | None, df_new: pl.DataFrame | None, level: str
 ) -> str:
@@ -1030,6 +1112,9 @@ def generate_str_report(
     path_new: str,
     df_buildings_old: pl.DataFrame | None = None,
     df_buildings_new: pl.DataFrame | None = None,
+    df_areas_old: pl.DataFrame | None = None,
+    df_areas_new: pl.DataFrame | None = None,
+    plot_files: dict[str, str] | None = None,
 ) -> str:
     """
     Assemble the full markdown comparison report.
@@ -1050,6 +1135,11 @@ def generate_str_report(
         df_buildings_old: older building-level decision-tree output, or None
             when missing (its per-tech counts section is then skipped)
         df_buildings_new: newer building-level output, or None when missing
+        df_areas_old: older version's per-cluster areas (geometry stages), or
+            None (the total-area check is then skipped)
+        df_areas_new: newer version's per-cluster areas, or None
+        plot_files: distribution column to saved plot filename, embedded as
+            image links; None embeds no plots
 
     Returns:
         str: markdown report; lineage sections are replaced by a note when a
@@ -1079,6 +1169,26 @@ def generate_str_report(
             tolerances["max_removed_uprn_share"] if tolerances is not None else None,
         ),
     ]
+    if stage in GEOMETRY_STAGES:
+        area_delta = (
+            generate_dict_total_area_delta(df_areas_old, df_areas_new)
+            if df_areas_old is not None and df_areas_new is not None
+            else None
+        )
+        sections.append(
+            _generate_str_cluster_geometry_section(
+                generate_dict_cluster_count_delta(df_old, df_new), area_delta, stage
+            )
+        )
+        frames = get_dict_distribution_frames(
+            stage, df_old, df_new, df_areas_old, df_areas_new
+        )
+        sections.extend(
+            _generate_str_distribution_section(
+                column, frame_old, frame_new, (plot_files or {}).get(column)
+            )
+            for column, (frame_old, frame_new) in frames.items()
+        )
     if stage == "decision_tree":
         sections.append(_generate_str_tech_counts_section(df_old, df_new, "UPRN-level"))
         sections.append(
@@ -1184,6 +1294,22 @@ if __name__ == "__main__":
         df_buildings_old, df_buildings_new = load_tuple_df_buildings(
             local_authority, release_date_old, release_date_new
         )
+    report_dir = Path(args.report_dir)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_stem = (
+        f"{args.stage}_{local_authority}_{release_date_old}_vs_{release_date_new}"
+    )
+    df_areas_old = df_areas_new = plot_files = None
+    if args.stage in GEOMETRY_STAGES:
+        df_areas_old = load_df_cluster_areas(path_old)
+        df_areas_new = load_df_cluster_areas(path_new)
+        plot_files = generate_dict_distribution_plots(
+            get_dict_distribution_frames(
+                args.stage, df_old, df_new, df_areas_old, df_areas_new
+            ),
+            report_dir,
+            report_stem,
+        )
     report = generate_str_report(
         df_old,
         df_new,
@@ -1198,12 +1324,11 @@ if __name__ == "__main__":
         path_new=path_new,
         df_buildings_old=df_buildings_old,
         df_buildings_new=df_buildings_new,
+        df_areas_old=df_areas_old,
+        df_areas_new=df_areas_new,
+        plot_files=plot_files,
     )
-    report_dir = Path(args.report_dir)
-    report_dir.mkdir(parents=True, exist_ok=True)
-    report_path = report_dir / (
-        f"{args.stage}_{local_authority}_{release_date_old}_vs_{release_date_new}.md"
-    )
+    report_path = report_dir / f"{report_stem}.md"
     report_path.write_text(report)
 
     counts = generate_dict_count_delta(df_old, df_new)

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -50,8 +50,6 @@ AREA_COL = "area_m2"
 # Multi-layer front-end outputs (August 2026 onwards) tag every row with
 # the layer it belongs to; earlier outputs have no such column.
 LAYER_COL = "layer"
-# Row label for a version without a layer column in the per-layer table.
-PRE_LAYERS_LABEL = "(pre-layers output)"
 # Stages whose outputs carry cluster geometry, and so get the cluster
 # count, area and distribution sections.
 GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
@@ -179,49 +177,6 @@ def generate_dict_total_area_delta(
         "area_m2_new": total_new,
         "area_m2_delta": total_new - total_old,
     }
-
-
-def generate_df_layer_summary(
-    df_areas_old: pl.DataFrame, df_areas_new: pl.DataFrame
-) -> pl.DataFrame | None:
-    """
-    Tally row counts and total area per layer, over both versions' layers.
-
-    Keeps the layers the cluster checks filter out (ward boundaries, anchor
-    loads) visible instead of silently excluded. A version without a
-    `layer` column tallies as a single pre-layers row; a layer absent from
-    one version stays null on that side rather than reading as zero
-    features.
-
-    Args:
-        df_areas_old: older version's per-row areas, with `layer` when the
-            source has it
-        df_areas_new: newer version's per-row areas, likewise
-
-    Returns:
-        pl.DataFrame: one row per layer with rows_old/new and
-            area_m2_old/new, sorted by layer, or None when neither version
-            has a `layer` column (nothing was filtered)
-    """
-    if LAYER_COL not in df_areas_old.columns and LAYER_COL not in df_areas_new.columns:
-        return None
-
-    def tally(df_areas: pl.DataFrame, suffix: str) -> pl.DataFrame:
-        layer = (
-            pl.col(LAYER_COL)
-            if LAYER_COL in df_areas.columns
-            else pl.lit(PRE_LAYERS_LABEL)
-        )
-        return df_areas.group_by(layer.alias(LAYER_COL)).agg(
-            pl.len().cast(pl.Int64).alias(f"rows_{suffix}"),
-            pl.col(AREA_COL).sum().alias(f"area_m2_{suffix}"),
-        )
-
-    return (
-        tally(df_areas_old, "old")
-        .join(tally(df_areas_new, "new"), on=LAYER_COL, how="full", coalesce=True)
-        .sort(LAYER_COL)
-    )
 
 
 def generate_dict_distribution_stats(df: pl.DataFrame, column: str) -> dict | None:
@@ -833,8 +788,7 @@ def load_df_cluster_areas(path: str) -> pl.DataFrame:
     CRS — the contextual-features geojson is EPSG:4326, with simplified
     geometry — is reprojected first. A zero-feature geojson degrades to an
     empty frame. A multi-layer output's `layer` column rides along with the
-    areas, so the checks can filter to the clusters layer and the per-layer
-    table can tally the rest.
+    areas, so the checks can filter to the clusters layer.
 
     Args:
         path: S3 path of the stage output (.parquet or .geojson)
@@ -1013,44 +967,16 @@ def _format_stat(value: float | int) -> str:
     return f"{value:,.0f}"
 
 
-def _format_layer_cell(value: int | float | None) -> str:
-    """Format one per-layer table cell; a side lacking the layer shows an
-    em dash rather than a misleading zero."""
-    if value is None:
-        return "—"
-    return f"{value:,.1f}" if isinstance(value, float) else f"{value:,}"
-
-
-def _generate_list_layer_table_lines(layer_summary: pl.DataFrame) -> list[str]:
-    """Render the per-layer rows/area summary as markdown table lines."""
-    lines = [
-        "",
-        "Rows and total area per layer, across all of the file's layers:",
-        "",
-        "| Layer | Rows (old) | Rows (new) "
-        "| Total area m² (old) | Total area m² (new) |",
-        "| --- | --- | --- | --- | --- |",
-    ]
-    for row in layer_summary.iter_rows(named=True):
-        cells = " | ".join(
-            _format_layer_cell(row[field])
-            for field in ("rows_old", "rows_new", "area_m2_old", "area_m2_new")
-        )
-        lines.append(f"| {row[LAYER_COL]} | {cells} |")
-    return lines
-
-
 def _generate_str_cluster_geometry_section(
     count_delta: dict | None,
     area_delta: dict | None,
     stage: str,
     layer_filtered: bool = False,
-    layer_summary: pl.DataFrame | None = None,
 ) -> str:
     """Render cluster count and total area deltas as a markdown section,
-    with the CRS/units stated, the clusters-layer scope named and the
-    per-layer summary tabulated when a multi-layer output was filtered,
-    and the simplified-geometry caveat for the contextual-features stage."""
+    with the CRS/units stated, the clusters-layer scope named when a
+    multi-layer output was filtered, and the simplified-geometry caveat
+    for the contextual-features stage."""
     lines = [
         "| Metric | Old | New | Delta |",
         "| --- | --- | --- | --- |",
@@ -1077,8 +1003,6 @@ def _generate_str_cluster_geometry_section(
                 "layered outputs and counts entirely as clusters.",
             ]
         )
-    if layer_summary is not None:
-        lines.extend(_generate_list_layer_table_lines(layer_summary))
     if count_delta is None:
         lines.extend(
             [
@@ -1320,11 +1244,6 @@ def generate_str_report(
             for frame in (df_old, df_new, df_areas_old, df_areas_new)
             if frame is not None
         )
-        layer_summary = (
-            generate_df_layer_summary(df_areas_old, df_areas_new)
-            if df_areas_old is not None and df_areas_new is not None
-            else None
-        )
         sections.append(
             _generate_str_cluster_geometry_section(
                 generate_dict_cluster_count_delta(
@@ -1333,7 +1252,6 @@ def generate_str_report(
                 area_delta,
                 stage,
                 layer_filtered,
-                layer_summary,
             )
         )
         frames = get_dict_distribution_frames(

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -50,6 +50,7 @@ GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
 STAGE_MODULE_PATHS = config["compare_versions"]["stage_module_paths"]
 STAGE_OUTPUT_DATASETS = config["compare_versions"]["stage_output_datasets"]
 BUILDINGS_DATASET = config["compare_versions"]["decision_tree_buildings_dataset"]
+DISTRIBUTION_COLUMNS = config["compare_versions"]["distribution_columns"]
 TOLERANCES = config["compare_versions"]["tolerances"]
 
 
@@ -147,6 +148,68 @@ def generate_dict_total_area_delta(
         "area_m2_new": total_new,
         "area_m2_delta": total_new - total_old,
     }
+
+
+def generate_dict_distribution_stats(df: pl.DataFrame, column: str) -> dict | None:
+    """
+    Summarise one column's distribution: both quartiles, min, max and mean.
+
+    Q1 and Q3 are reported separately (linear interpolation) so a shifted
+    distribution and a widened one stay distinguishable. Nulls are excluded.
+
+    Args:
+        df: one version of a stage output
+        column: column to summarise
+
+    Returns:
+        dict: min/q1/mean/q3/max, or None when the column is missing or has
+            no non-null values
+    """
+    if column not in df.columns:
+        return None
+    values = df[column].drop_nulls()
+    if values.is_empty():
+        return None
+    return {
+        "min": values.min(),
+        "q1": values.quantile(0.25, "linear"),
+        "mean": values.mean(),
+        "q3": values.quantile(0.75, "linear"),
+        "max": values.max(),
+    }
+
+
+def get_dict_distribution_frames(
+    stage: str,
+    df_old: pl.DataFrame,
+    df_new: pl.DataFrame,
+    df_areas_old: pl.DataFrame | None,
+    df_areas_new: pl.DataFrame | None,
+) -> dict[str, tuple[pl.DataFrame, pl.DataFrame]]:
+    """
+    Map each of a stage's distribution columns to the (old, new) frames
+    that carry it.
+
+    The derived cluster area reads the geometry-derived frames (when
+    loaded); the stage's configured `DISTRIBUTION_COLUMNS` read the tabular
+    outputs.
+
+    Args:
+        stage: pipeline stage the outputs belong to
+        df_old: older version of the tabular stage output
+        df_new: newer version of the tabular stage output
+        df_areas_old: older version's per-cluster areas, or None
+        df_areas_new: newer version's per-cluster areas, or None
+
+    Returns:
+        dict: column name to (old, new) frame pair, plot/report order
+    """
+    frames = {}
+    if df_areas_old is not None and df_areas_new is not None:
+        frames[AREA_COL] = (df_areas_old, df_areas_new)
+    for column in DISTRIBUTION_COLUMNS.get(stage, []):
+        frames[column] = (df_old, df_new)
+    return frames
 
 
 def generate_dict_schema_diff(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dict:

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -29,17 +29,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import fsspec
+import geopandas as gpd
 import polars as pl
 import pyarrow.parquet as pq
 import s3fs
 
 from asf_heat_pump_suitability import PROJECT_DIR, config
 from asf_heat_pump_suitability.getters import base_getters
-from asf_heat_pump_suitability.utils import manifest_utils, save_utils
+from asf_heat_pump_suitability.utils import geo_utils, manifest_utils, save_utils
 
 UPRN_COL = "UPRN"
 TECH_COL = "assigned_tech"
 NULL_TECH_LABEL = "(null)"
+CLUSTER_ID_COL = "cluster_id"
+AREA_COL = "area_m2"
+# Stages whose outputs carry cluster geometry, and so get the cluster
+# count, area and distribution sections.
+GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
 
 STAGE_MODULE_PATHS = config["compare_versions"]["stage_module_paths"]
 STAGE_OUTPUT_DATASETS = config["compare_versions"]["stage_output_datasets"]
@@ -94,6 +100,53 @@ def generate_dict_count_delta(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dic
         counts["uprns_new"] = df_new[UPRN_COL].n_unique()
         counts["uprns_delta"] = counts["uprns_new"] - counts["uprns_old"]
     return counts
+
+
+def generate_dict_cluster_count_delta(
+    df_old: pl.DataFrame, df_new: pl.DataFrame
+) -> dict | None:
+    """
+    Compare distinct-cluster counts between two versions of an output.
+
+    Args:
+        df_old: older version of a cluster-bearing stage output
+        df_new: newer version of a cluster-bearing stage output
+
+    Returns:
+        dict: old/new/delta distinct-cluster counts, or None when either
+            version has no cluster-id column
+    """
+    if CLUSTER_ID_COL not in df_old.columns or CLUSTER_ID_COL not in df_new.columns:
+        return None
+    n_old = df_old[CLUSTER_ID_COL].n_unique()
+    n_new = df_new[CLUSTER_ID_COL].n_unique()
+    return {
+        "clusters_old": n_old,
+        "clusters_new": n_new,
+        "clusters_delta": n_new - n_old,
+    }
+
+
+def generate_dict_total_area_delta(
+    df_areas_old: pl.DataFrame, df_areas_new: pl.DataFrame
+) -> dict:
+    """
+    Compare total cluster area between two versions, in m² (EPSG:27700).
+
+    Args:
+        df_areas_old: older version's per-cluster areas
+        df_areas_new: newer version's per-cluster areas
+
+    Returns:
+        dict: old/new/delta total areas; a version with no clusters totals 0
+    """
+    total_old = df_areas_old[AREA_COL].sum()
+    total_new = df_areas_new[AREA_COL].sum()
+    return {
+        "area_m2_old": total_old,
+        "area_m2_new": total_new,
+        "area_m2_delta": total_new - total_old,
+    }
 
 
 def generate_dict_schema_diff(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dict:
@@ -559,6 +612,38 @@ def load_transform_df_stage_output(path: str) -> pl.DataFrame:
             return pl.DataFrame()
         return pl.from_pandas(gdf.drop(columns="geometry"))
     raise ValueError(f"Cannot compare file type of {path}; expected parquet/geojson.")
+
+
+def load_df_cluster_areas(path: str) -> pl.DataFrame:
+    """
+    Load a geometry-bearing stage output as per-cluster areas in m².
+
+    Areas are measured in EPSG:27700 (metres); an output saved in another
+    CRS — the contextual-features geojson is EPSG:4326, with simplified
+    geometry — is reprojected first. A zero-feature geojson degrades to an
+    empty frame.
+
+    Args:
+        path: S3 path of the stage output (.parquet or .geojson)
+
+    Returns:
+        pl.DataFrame: one `area_m2` row per cluster
+
+    Raises:
+        ValueError: for file types the comparison cannot read geometry from
+    """
+    if path.endswith(".parquet"):
+        gdf = gpd.read_parquet(path, columns=["geometry"])
+    elif path.endswith(".geojson"):
+        try:
+            gdf = base_getters.load_gdf_from_s3_geojson(path, crs="EPSG:4326")
+        except ValueError:
+            logging.warning("No features in geojson at %s; no areas to load.", path)
+            return pl.DataFrame(schema={AREA_COL: pl.Float64})
+    else:
+        raise ValueError(f"Cannot read geometry of {path}; expected parquet/geojson.")
+    gdf = geo_utils.verify_gdf_crs(gdf)
+    return pl.DataFrame({AREA_COL: gdf.area.to_numpy()})
 
 
 def load_df_buildings_tech(path: str) -> pl.DataFrame:

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -50,6 +50,8 @@ AREA_COL = "area_m2"
 # Multi-layer front-end outputs (August 2026 onwards) tag every row with
 # the layer it belongs to; earlier outputs have no such column.
 LAYER_COL = "layer"
+# Row label for a version without a layer column in the per-layer table.
+PRE_LAYERS_LABEL = "(pre-layers output)"
 # Stages whose outputs carry cluster geometry, and so get the cluster
 # count, area and distribution sections.
 GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
@@ -177,6 +179,49 @@ def generate_dict_total_area_delta(
         "area_m2_new": total_new,
         "area_m2_delta": total_new - total_old,
     }
+
+
+def generate_df_layer_summary(
+    df_areas_old: pl.DataFrame, df_areas_new: pl.DataFrame
+) -> pl.DataFrame | None:
+    """
+    Tally row counts and total area per layer, over both versions' layers.
+
+    Keeps the layers the cluster checks filter out (ward boundaries, anchor
+    loads) visible instead of silently excluded. A version without a
+    `layer` column tallies as a single pre-layers row; a layer absent from
+    one version stays null on that side rather than reading as zero
+    features.
+
+    Args:
+        df_areas_old: older version's per-row areas, with `layer` when the
+            source has it
+        df_areas_new: newer version's per-row areas, likewise
+
+    Returns:
+        pl.DataFrame: one row per layer with rows_old/new and
+            area_m2_old/new, sorted by layer, or None when neither version
+            has a `layer` column (nothing was filtered)
+    """
+    if LAYER_COL not in df_areas_old.columns and LAYER_COL not in df_areas_new.columns:
+        return None
+
+    def tally(df_areas: pl.DataFrame, suffix: str) -> pl.DataFrame:
+        layer = (
+            pl.col(LAYER_COL)
+            if LAYER_COL in df_areas.columns
+            else pl.lit(PRE_LAYERS_LABEL)
+        )
+        return df_areas.group_by(layer.alias(LAYER_COL)).agg(
+            pl.len().cast(pl.Int64).alias(f"rows_{suffix}"),
+            pl.col(AREA_COL).sum().alias(f"area_m2_{suffix}"),
+        )
+
+    return (
+        tally(df_areas_old, "old")
+        .join(tally(df_areas_new, "new"), on=LAYER_COL, how="full", coalesce=True)
+        .sort(LAYER_COL)
+    )
 
 
 def generate_dict_distribution_stats(df: pl.DataFrame, column: str) -> dict | None:
@@ -964,16 +1009,44 @@ def _format_stat(value: float | int) -> str:
     return f"{value:,.1f}" if isinstance(value, float) else f"{value:,}"
 
 
+def _format_layer_cell(value: int | float | None) -> str:
+    """Format one per-layer table cell; a side lacking the layer shows an
+    em dash rather than a misleading zero."""
+    if value is None:
+        return "—"
+    return f"{value:,.1f}" if isinstance(value, float) else f"{value:,}"
+
+
+def _generate_list_layer_table_lines(layer_summary: pl.DataFrame) -> list[str]:
+    """Render the per-layer rows/area summary as markdown table lines."""
+    lines = [
+        "",
+        "Rows and total area per layer, across all of the file's layers:",
+        "",
+        "| Layer | Rows (old) | Rows (new) "
+        "| Total area m² (old) | Total area m² (new) |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in layer_summary.iter_rows(named=True):
+        cells = " | ".join(
+            _format_layer_cell(row[field])
+            for field in ("rows_old", "rows_new", "area_m2_old", "area_m2_new")
+        )
+        lines.append(f"| {row[LAYER_COL]} | {cells} |")
+    return lines
+
+
 def _generate_str_cluster_geometry_section(
     count_delta: dict | None,
     area_delta: dict | None,
     stage: str,
     layer_filtered: bool = False,
+    layer_summary: pl.DataFrame | None = None,
 ) -> str:
     """Render cluster count and total area deltas as a markdown section,
-    with the CRS/units stated, the clusters-layer scope named when a
-    multi-layer output was filtered, and the simplified-geometry caveat
-    for the contextual-features stage."""
+    with the CRS/units stated, the clusters-layer scope named and the
+    per-layer summary tabulated when a multi-layer output was filtered,
+    and the simplified-geometry caveat for the contextual-features stage."""
     lines = [
         "| Metric | Old | New | Delta |",
         "| --- | --- | --- | --- |",
@@ -1000,6 +1073,8 @@ def _generate_str_cluster_geometry_section(
                 "layered outputs and counts entirely as clusters.",
             ]
         )
+    if layer_summary is not None:
+        lines.extend(_generate_list_layer_table_lines(layer_summary))
     if count_delta is None:
         lines.extend(
             [
@@ -1241,6 +1316,11 @@ def generate_str_report(
             for frame in (df_old, df_new, df_areas_old, df_areas_new)
             if frame is not None
         )
+        layer_summary = (
+            generate_df_layer_summary(df_areas_old, df_areas_new)
+            if df_areas_old is not None and df_areas_new is not None
+            else None
+        )
         sections.append(
             _generate_str_cluster_geometry_section(
                 generate_dict_cluster_count_delta(
@@ -1249,6 +1329,7 @@ def generate_str_report(
                 area_delta,
                 stage,
                 layer_filtered,
+                layer_summary,
             )
         )
         frames = get_dict_distribution_frames(

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -996,7 +996,7 @@ def _generate_str_cluster_geometry_section(
     count_delta: dict | None,
     area_delta: dict | None,
     stage: str,
-    layer_filtered: bool = False,
+    layer_filtered: bool,
 ) -> str:
     """Render cluster count and total area deltas as a markdown section,
     with the CRS/units stated, the clusters-layer scope named when a

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -1005,8 +1005,12 @@ def _generate_str_churn_section(
 
 
 def _format_stat(value: float | int) -> str:
-    """Format a statistic for a report table (floats to one decimal place)."""
-    return f"{value:,.1f}" if isinstance(value, float) else f"{value:,}"
+    """Format a statistic for a report table. An integral float renders like
+    an int (1738.0 -> "1,738"), so a version whose column loaded as Float64
+    lines up with an Int64 one; non-integral floats keep one decimal place."""
+    if isinstance(value, float) and not value.is_integer():
+        return f"{value:,.1f}"
+    return f"{value:,.0f}"
 
 
 def _format_layer_cell(value: int | float | None) -> str:

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import fsspec
 import geopandas as gpd
+import matplotlib.pyplot as plt
+import numpy as np
 import polars as pl
 import pyarrow.parquet as pq
 import s3fs
@@ -210,6 +212,71 @@ def get_dict_distribution_frames(
     for column in DISTRIBUTION_COLUMNS.get(stage, []):
         frames[column] = (df_old, df_new)
     return frames
+
+
+def plot_distribution_overlay(
+    values_old: pl.Series, values_new: pl.Series, label: str, path: Path
+) -> None:
+    """
+    Save an overlaid old-vs-new histogram of one distribution as a PNG.
+
+    Both versions share the same bins so the shapes are comparable.
+
+    Args:
+        values_old: older version's values
+        values_new: newer version's values
+        label: distribution name, used for the x-axis and title
+        path: file path the PNG is saved to
+    """
+    old, new = values_old.to_numpy(), values_new.to_numpy()
+    bins = np.histogram_bin_edges(np.concatenate([old, new]), bins=40)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.hist(old, bins=bins, alpha=0.6, label="Old", color="tab:blue")
+    ax.hist(new, bins=bins, alpha=0.6, label="New", color="tab:orange")
+    ax.set_xlabel(label)
+    ax.set_ylabel("Count")
+    ax.set_title(f"Distribution of {label}: old vs new")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def generate_dict_distribution_plots(
+    frames: dict[str, tuple[pl.DataFrame, pl.DataFrame]],
+    plot_dir: Path,
+    file_stem: str,
+) -> dict[str, str]:
+    """
+    Save an overlaid old-vs-new histogram for each of a stage's distributions.
+
+    A distribution with a missing column or no values on either side is
+    skipped with a warning — its stats section already notes the gap.
+
+    Args:
+        frames: column to (old, new) frame pair, as built by
+            `get_dict_distribution_frames`
+        plot_dir: directory the PNGs are saved to
+        file_stem: filename prefix, shared with the markdown report
+
+    Returns:
+        dict: column to saved PNG filename (relative to `plot_dir`, so the
+            report next to the PNGs can link them relatively)
+    """
+    plot_files = {}
+    for column, (frame_old, frame_new) in frames.items():
+        if column not in frame_old.columns or column not in frame_new.columns:
+            logging.warning("Column %s missing from one version; plot skipped.", column)
+            continue
+        values_old = frame_old[column].drop_nulls()
+        values_new = frame_new[column].drop_nulls()
+        if values_old.is_empty() or values_new.is_empty():
+            logging.warning("No %s values in one version; plot skipped.", column)
+            continue
+        filename = f"{file_stem}_{column}.png"
+        plot_distribution_overlay(values_old, values_new, column, plot_dir / filename)
+        plot_files[column] = filename
+    return plot_files
 
 
 def generate_dict_schema_diff(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dict:

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -759,7 +759,8 @@ def load_df_cluster_areas(path: str) -> pl.DataFrame:
         path: S3 path of the stage output (.parquet or .geojson)
 
     Returns:
-        pl.DataFrame: one `area_m2` row per cluster
+        pl.DataFrame: one `area_m2` row per feature row (not deduplicated on
+            cluster id, so a duplicated cluster contributes each of its rows)
 
     Raises:
         ValueError: for file types the comparison cannot read geometry from

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1129,6 +1129,52 @@ class TestGenerateStrReportGeometrySections:
             f"`{compare_versions.CLUSTER_LAYER}` layer only" in report
         ), "the report must state the headline checks cover the clusters layer only"
 
+    def test_per_layer_table_keeps_non_cluster_layers_visible(
+        self, df_clusters_old, df_areas_old
+    ):
+        """Filtered-out layers must not vanish silently: the geometry
+        section tabulates rows and total area per layer over both versions,
+        with the pre-layers old version shown as a single labelled row."""
+        df_new = pl.DataFrame(
+            {
+                "cluster_id": ["HP_1", "DHN_1", None],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                ],
+            }
+        )
+        df_areas_new = pl.DataFrame(
+            {
+                "area_m2": [210.0, 100.0, 5_000_000.0],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                ],
+            }
+        )
+        report = generate_report(
+            df_clusters_old,
+            df_new,
+            None,
+            None,
+            stage="compute_contextual_features",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_new,
+        )
+        assert (
+            "| ward_boundaries | — | 1 | — | 5,000,000.0 |" in report
+        ), "the excluded ward layer must stay visible with its rows and area"
+        assert (
+            f"| {compare_versions.PRE_LAYERS_LABEL} | 3 | — | 300.0 | — |" in report
+        ), "the pre-layers old version must appear as its own labelled row"
+        assert (
+            f"| {compare_versions.CLUSTER_LAYER} | — | 2 | — | 310.0 |" in report
+        ), "the clusters layer's own tallies must appear in the table"
+
     def test_unlayered_versions_carry_no_layer_filtering_note(
         self, df_clusters_old, df_areas_old
     ):
@@ -1147,6 +1193,9 @@ class TestGenerateStrReportGeometrySections:
         assert (
             "layer only" not in report
         ), "no layer column anywhere means no filtering note may appear"
+        assert (
+            "per layer" not in report
+        ), "no layer column anywhere means no per-layer table may appear"
 
     def test_geometry_sections_only_for_geometry_stages(
         self, df_old, df_new_identical, manifests, mocker
@@ -1404,6 +1453,80 @@ class TestGenerateDictTotalAreaDelta:
         assert (
             totals["area_m2_new"] == 0.0 and totals["area_m2_delta"] == -300.0
         ), "a version with no clusters must total zero area, not crash"
+
+
+class TestGenerateDfLayerSummary:
+    """Tests for `generate_df_layer_summary`."""
+
+    def test_tallies_rows_and_area_per_layer_over_the_union(self):
+        """Each layer of either version gets one row with per-version row
+        counts and total areas; a layer absent from one side stays null
+        there rather than reading as zero features."""
+        old = pl.DataFrame(
+            {
+                "area_m2": [1.0, 2.0, 30.0],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "anchor_loads",
+                ],
+            }
+        )
+        new = pl.DataFrame(
+            {
+                "area_m2": [3.0, 400.0],
+                "layer": [compare_versions.CLUSTER_LAYER, "ward_boundaries"],
+            }
+        )
+        summary = compare_versions.generate_df_layer_summary(old, new)
+        by_layer = {row["layer"]: row for row in summary.iter_rows(named=True)}
+        assert set(by_layer) == {
+            compare_versions.CLUSTER_LAYER,
+            "anchor_loads",
+            "ward_boundaries",
+        }, "the table must cover the union of both versions' layers"
+        clusters = by_layer[compare_versions.CLUSTER_LAYER]
+        assert (
+            clusters["rows_old"] == 2 and clusters["area_m2_old"] == 3.0
+        ), "the old clusters layer must tally its two rows and 3 m²"
+        assert (
+            clusters["rows_new"] == 1 and clusters["area_m2_new"] == 3.0
+        ), "the new clusters layer must tally its one row and 3 m²"
+        assert (
+            by_layer["ward_boundaries"]["rows_old"] is None
+        ), "a layer absent from the old version must stay null, not zero"
+        assert (
+            by_layer["anchor_loads"]["rows_new"] is None
+        ), "a layer absent from the new version must stay null, not zero"
+
+    def test_pre_layers_version_appears_as_a_single_row(self, df_areas_old):
+        """A version without a `layer` column is one pre-layers output; it
+        gets a single labelled row so the table still shows both versions."""
+        new = pl.DataFrame(
+            {
+                "area_m2": [3.0, 400.0],
+                "layer": [compare_versions.CLUSTER_LAYER, "ward_boundaries"],
+            }
+        )
+        summary = compare_versions.generate_df_layer_summary(df_areas_old, new)
+        by_layer = {row["layer"]: row for row in summary.iter_rows(named=True)}
+        pre_layers = by_layer[compare_versions.PRE_LAYERS_LABEL]
+        assert (
+            pre_layers["rows_old"] == 3 and pre_layers["area_m2_old"] == 300.0
+        ), "the pre-layers version must appear as one row tallying all its features"
+        assert (
+            pre_layers["rows_new"] is None
+        ), "the layered version has no pre-layers row, so its side stays null"
+
+    def test_returns_none_when_neither_version_is_layered(self, df_areas_old):
+        """Two pre-layers versions have no layers to tabulate; the section
+        must get None so no table is rendered."""
+        assert (
+            compare_versions.generate_df_layer_summary(
+                df_areas_old, df_areas_old.clone()
+            )
+            is None
+        ), "no layer column on either side means no per-layer table"
 
 
 class TestLoadDfClusterAreas:

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1039,8 +1039,48 @@ class TestGenerateStrReportGeometrySections:
                 f"| {statistic} |" in report
             ), f"each distribution must report {statistic} per version"
         assert (
-            "| Mean | 5.0 | 8.0 |" in report
+            "| Mean | 5 | 8 |" in report
         ), "the n_UPRNs shift must appear as old and new means"
+
+    def test_stats_render_consistently_across_int_and_float_dtypes(self):
+        """One version's n_UPRNs loading as Float64 (a geojson round-trip
+        upcast) must not render "1,738.0" against the other's "1,738":
+        integral floats render like ints."""
+        df_old = pl.DataFrame({"cluster_id": ["a", "b"], "n_UPRNs": [1165, 2311]})
+        df_new = df_old.with_columns(pl.col("n_UPRNs").cast(pl.Float64))
+        report = generate_report(
+            df_old,
+            df_new,
+            None,
+            None,
+            stage="compute_contextual_features",
+            trigger=None,
+        )
+        assert (
+            "| Min | 1,165 | 1,165 |" in report
+        ), "an Int64 and a Float64 version must render the same min"
+        assert (
+            "| Mean | 1,738 | 1,738 |" in report
+        ), "integral float means must render like ints, with no trailing .0"
+        assert (
+            "1,738.0" not in report
+        ), "no integral statistic may keep a trailing .0 in either column"
+
+    def test_non_integral_stats_keep_one_decimal_place(self):
+        """A genuinely fractional statistic still renders to one decimal
+        place, so real precision is not rounded away."""
+        df = pl.DataFrame({"cluster_id": ["a", "b"], "n_UPRNs": [2, 3]})
+        report = generate_report(
+            df,
+            df.clone(),
+            None,
+            None,
+            stage="compute_contextual_features",
+            trigger=None,
+        )
+        assert (
+            "| Mean | 2.5 | 2.5 |" in report
+        ), "a fractional mean must keep its one decimal place"
 
     def test_plots_are_embedded_as_image_links(
         self, df_clusters_old, df_areas_old, df_areas_merged

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1082,6 +1082,72 @@ class TestGenerateStrReportGeometrySections:
             "cluster_id" in report and "Cluster geometry" in report
         ), "the missing cluster_id must be noted inside the geometry section"
 
+    def test_layered_output_scopes_headline_checks_to_the_clusters_layer(
+        self, df_clusters_old, df_areas_old
+    ):
+        """A new-format multi-layer output (ward boundaries bundled with the
+        clusters) must not swamp the cluster count and total area: the
+        headline checks cover the clusters layer only, the pre-layers old
+        version counts entirely as clusters, and the report says so."""
+        df_new = pl.DataFrame(
+            {
+                "cluster_id": ["HP_1", "DHN_1", None],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                ],
+            }
+        )
+        df_areas_new = pl.DataFrame(
+            {
+                "area_m2": [210.0, 100.0, 5_000_000.0],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                ],
+            }
+        )
+        report = generate_report(
+            df_clusters_old,
+            df_new,
+            None,
+            None,
+            stage="compute_contextual_features",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_new,
+        )
+        assert (
+            "| Clusters | 3 | 2 | -1 |" in report
+        ), "the ward row (null cluster_id) must not count as a cluster"
+        assert (
+            "| Total area (m²) | 300.0 | 310.0 | +10.0 |" in report
+        ), "the 5M m² ward polygon must not enter the total-area check"
+        assert (
+            f"`{compare_versions.CLUSTER_LAYER}` layer only" in report
+        ), "the report must state the headline checks cover the clusters layer only"
+
+    def test_unlayered_versions_carry_no_layer_filtering_note(
+        self, df_clusters_old, df_areas_old
+    ):
+        """Two pre-layers versions have nothing filtered, so the report
+        must not claim a layer scope that was never applied."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_old.clone(),
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        assert (
+            "layer only" not in report
+        ), "no layer column anywhere means no filtering note may appear"
+
     def test_geometry_sections_only_for_geometry_stages(
         self, df_old, df_new_identical, manifests, mocker
     ):
@@ -1418,6 +1484,87 @@ class TestLoadDfClusterAreas:
         with pytest.raises(ValueError, match="csv"):
             compare_versions.load_df_cluster_areas("s3://bucket/dir/output.csv")
 
+    def test_geojson_layer_column_is_carried_alongside_areas(self, mocker):
+        """A multi-layer front-end geojson's areas must keep each feature's
+        layer, so the checks can filter to clusters and the per-layer table
+        can tally the rest."""
+        gdf = self.gdf_two_squares("EPSG:4326")
+        gdf["layer"] = [compare_versions.CLUSTER_LAYER, "ward_boundaries"]
+        mocker.patch(
+            "asf_heat_pump_suitability.getters.base_getters.load_gdf_from_s3_geojson",
+            return_value=gdf,
+        )
+        df = compare_versions.load_df_cluster_areas("s3://bucket/dir/output.geojson")
+        assert df.columns == [
+            "area_m2",
+            "layer",
+        ], "a layered source must yield areas alongside their layer"
+        assert df["layer"].to_list() == [
+            compare_versions.CLUSTER_LAYER,
+            "ward_boundaries",
+        ], "each area row must keep its feature's layer"
+
+    def test_geoparquet_layer_column_is_carried_alongside_areas(self, tmp_path):
+        """The loader carries `layer` from geoparquet too, so a future
+        layered parquet output filters the same way as the geojson."""
+        path = tmp_path / "clusters.parquet"
+        gdf = self.gdf_two_squares("EPSG:27700")
+        gdf["layer"] = [compare_versions.CLUSTER_LAYER, "anchor_loads"]
+        gdf.to_parquet(path)
+        df = compare_versions.load_df_cluster_areas(str(path))
+        assert df["layer"].to_list() == [
+            compare_versions.CLUSTER_LAYER,
+            "anchor_loads",
+        ], "geoparquet area rows must keep their feature's layer too"
+
+
+class TestFilterDfClustersLayer:
+    """Tests for `filter_df_clusters_layer`."""
+
+    def test_keeps_only_the_configured_clusters_layer(self):
+        """A multi-layer front-end output bundles whole-county ward polygons
+        with the clusters; the filter must keep clusters-layer rows only so
+        the wards cannot swamp the cluster checks."""
+        df = pl.DataFrame(
+            {
+                "cluster_id": ["HP_1", None, "HP_2"],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                    compare_versions.CLUSTER_LAYER,
+                ],
+            }
+        )
+        filtered = compare_versions.filter_df_clusters_layer(df)
+        assert filtered.height == 2, "only the two clusters-layer rows may survive"
+        assert filtered["layer"].unique().to_list() == [
+            compare_versions.CLUSTER_LAYER
+        ], "no other layer's rows may survive the filter"
+
+    def test_frame_without_a_layer_column_passes_through_unchanged(
+        self, df_clusters_old
+    ):
+        """Pre-layers outputs have no `layer` column and are treated as
+        all-clusters, so old-vs-new comparisons across the format change
+        keep working."""
+        assert (
+            compare_versions.filter_df_clusters_layer(df_clusters_old)
+            is df_clusters_old
+        ), "a frame without a layer column must pass through as the same frame"
+
+    def test_clusters_layer_name_comes_from_config(self):
+        """The clusters layer name is config, not code, and must match the
+        front-end file's real layer value (verified against the 20260806
+        East Lothian output)."""
+        assert (
+            config["compare_versions"]["cluster_layer"]
+            == "clusters_with_contextual_features"
+        ), "base.yaml must name the front-end file's real clusters layer"
+        assert (
+            compare_versions.CLUSTER_LAYER
+            == config["compare_versions"]["cluster_layer"]
+        ), "the module must read the clusters layer name from config"
+
 
 class TestGenerateDictDistributionStats:
     """Tests for `generate_dict_distribution_stats`."""
@@ -1527,6 +1674,46 @@ class TestGetDictDistributionFrames:
             "decision_tree", df_old, df_old, None, None
         )
         assert frames == {}, "a stage without geometry or configured columns gets none"
+
+    def test_layered_frames_are_filtered_to_the_clusters_layer(self):
+        """Multi-layer outputs bundle ward polygons and anchor loads with
+        the clusters; every distribution (and so every plot fed from here)
+        must cover the clusters layer only."""
+        df_tabular = pl.DataFrame(
+            {
+                "n_UPRNs": [5, 8, None],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                ],
+            }
+        )
+        df_areas = pl.DataFrame(
+            {
+                "area_m2": [100.0, 200.0, 5_000_000.0],
+                "layer": [
+                    compare_versions.CLUSTER_LAYER,
+                    compare_versions.CLUSTER_LAYER,
+                    "ward_boundaries",
+                ],
+            }
+        )
+        frames = compare_versions.get_dict_distribution_frames(
+            "compute_contextual_features",
+            df_tabular,
+            df_tabular,
+            df_areas,
+            df_areas,
+        )
+        assert frames["n_UPRNs"][0]["n_UPRNs"].drop_nulls().to_list() == [
+            5,
+            8,
+        ], "ward rows must not enter the n_UPRNs distribution"
+        assert frames["area_m2"][1]["area_m2"].to_list() == [
+            100.0,
+            200.0,
+        ], "whole-county ward polygons must not enter the area distribution"
 
 
 class TestPlotDistributionOverlay:

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1054,6 +1054,208 @@ class TestLoadTupleDfBuildings:
         load.assert_not_called()
 
 
+@pytest.fixture(scope="module")
+def df_clusters_old():
+    """Old-version cluster-level output: three clusters across two techs."""
+    return pl.DataFrame(
+        {
+            "cluster_id": ["HP_1", "HP_2", "DHN_1"],
+            "assigned_tech": [
+                "Networked heat pump",
+                "Networked heat pump",
+                "District heat network",
+            ],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def df_clusters_merged(df_clusters_old):
+    """New-version cluster-level output with genuine geometry drift: the two
+    heat-pump clusters merged into one."""
+    return pl.DataFrame(
+        {
+            "cluster_id": ["HP_1", "DHN_1"],
+            "assigned_tech": ["Networked heat pump", "District heat network"],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def df_areas_old():
+    """Old-version per-cluster areas: three 100 m² clusters."""
+    return pl.DataFrame({"area_m2": [100.0, 100.0, 100.0]})
+
+
+@pytest.fixture(scope="module")
+def df_areas_merged():
+    """New-version per-cluster areas after the merge: the merged cluster
+    absorbed the 10 m² gap between its parents (100 + 100 + 10)."""
+    return pl.DataFrame({"area_m2": [210.0, 100.0]})
+
+
+class TestGenerateDictClusterCountDelta:
+    """Tests for `generate_dict_cluster_count_delta`."""
+
+    def test_identical_versions_have_zero_delta(self, df_clusters_old):
+        """No drift means no change in the distinct-cluster count."""
+        counts = compare_versions.generate_dict_cluster_count_delta(
+            df_clusters_old, df_clusters_old.clone()
+        )
+        assert counts == {
+            "clusters_old": 3,
+            "clusters_new": 3,
+            "clusters_delta": 0,
+        }, "identical versions must show no cluster count change"
+
+    def test_merged_clusters_show_a_negative_delta(
+        self, df_clusters_old, df_clusters_merged
+    ):
+        """Two clusters merging into one is genuine geometry drift the
+        tabular checks cannot see; the count delta must surface it."""
+        counts = compare_versions.generate_dict_cluster_count_delta(
+            df_clusters_old, df_clusters_merged
+        )
+        assert counts == {
+            "clusters_old": 3,
+            "clusters_new": 2,
+            "clusters_delta": -1,
+        }, "a cluster merge must appear as a negative cluster count delta"
+
+    def test_counts_distinct_cluster_ids_not_rows(self, df_clusters_old):
+        """A cluster-id column with repeated values (e.g. a UPRN-level frame)
+        must count distinct clusters, not rows."""
+        repeated = pl.concat([df_clusters_old, df_clusters_old])
+        counts = compare_versions.generate_dict_cluster_count_delta(
+            repeated, df_clusters_old
+        )
+        assert (
+            counts["clusters_old"] == 3
+        ), "repeated cluster ids must count as one cluster each"
+
+    def test_returns_none_without_cluster_id_column(self, df_old):
+        """Outputs without a cluster_id column (e.g. UPRN-stage outputs)
+        cannot be cluster-counted."""
+        assert (
+            compare_versions.generate_dict_cluster_count_delta(df_old, df_old) is None
+        ), "no cluster_id column means no cluster count, so None is expected"
+
+
+class TestGenerateDictTotalAreaDelta:
+    """Tests for `generate_dict_total_area_delta`."""
+
+    def test_identical_versions_have_zero_delta(self, df_areas_old):
+        """No drift means no total-area change."""
+        totals = compare_versions.generate_dict_total_area_delta(
+            df_areas_old, df_areas_old.clone()
+        )
+        assert totals == {
+            "area_m2_old": 300.0,
+            "area_m2_new": 300.0,
+            "area_m2_delta": 0.0,
+        }, "identical versions must show no total-area change"
+
+    def test_reports_the_total_area_delta_in_m2(self, df_areas_old, df_areas_merged):
+        """The cluster merge grew the total area by the 10 m² gap it
+        absorbed; the delta must surface it in m²."""
+        totals = compare_versions.generate_dict_total_area_delta(
+            df_areas_old, df_areas_merged
+        )
+        assert totals == {
+            "area_m2_old": 300.0,
+            "area_m2_new": 310.0,
+            "area_m2_delta": 10.0,
+        }, "the total-area delta must be new minus old, in m²"
+
+    def test_a_version_with_no_clusters_totals_zero(self, df_areas_old):
+        """An empty areas frame (zero-feature geojson) totals 0 m² rather
+        than crashing the delta."""
+        empty = pl.DataFrame(schema={"area_m2": pl.Float64})
+        totals = compare_versions.generate_dict_total_area_delta(df_areas_old, empty)
+        assert (
+            totals["area_m2_new"] == 0.0 and totals["area_m2_delta"] == -300.0
+        ), "a version with no clusters must total zero area, not crash"
+
+
+class TestLoadDfClusterAreas:
+    """Tests for `load_df_cluster_areas`."""
+
+    @staticmethod
+    def gdf_two_squares(crs: str):
+        """Two axis-aligned squares of 100 and 400 m², built in EPSG:27700
+        near Plymouth and converted to the requested CRS."""
+        import geopandas as gpd
+        from shapely.geometry import box
+
+        gdf = gpd.GeoDataFrame(
+            {"cluster_id": ["HP_1", "HP_2"]},
+            geometry=[
+                box(250000, 55000, 250010, 55010),
+                box(250100, 55100, 250120, 55120),
+            ],
+            crs="EPSG:27700",
+        )
+        return gdf.to_crs(crs)
+
+    def test_geoparquet_areas_measured_in_m2(self, tmp_path):
+        """The cluster stage's geoparquet carries exact EPSG:27700 geometry;
+        areas come back in m², one row per cluster."""
+        path = tmp_path / "clusters.parquet"
+        self.gdf_two_squares("EPSG:27700").to_parquet(path)
+        df = compare_versions.load_df_cluster_areas(str(path))
+        assert df.columns == ["area_m2"], "only the derived area column is returned"
+        assert df["area_m2"].to_list() == [
+            100.0,
+            400.0,
+        ], "areas must be measured in m² on the saved EPSG:27700 geometry"
+
+    def test_geoparquet_in_another_crs_is_reprojected_before_measuring(self, tmp_path):
+        """A geoparquet not in the target CRS must be reprojected to
+        EPSG:27700 first — measuring in EPSG:4326 would return degrees²."""
+        path = tmp_path / "clusters.parquet"
+        self.gdf_two_squares("EPSG:4326").to_parquet(path)
+        df = compare_versions.load_df_cluster_areas(str(path))
+        assert df["area_m2"].to_list() == pytest.approx(
+            [100.0, 400.0], rel=1e-3
+        ), "areas must be measured in metres after reprojection, not degrees"
+
+    def test_geojson_is_reprojected_to_the_target_crs_before_measuring(self, mocker):
+        """The contextual-features geojson is saved in EPSG:4326; its areas
+        must be measured after reprojecting back to EPSG:27700."""
+        load = mocker.patch(
+            "asf_heat_pump_suitability.getters.base_getters.load_gdf_from_s3_geojson",
+            return_value=self.gdf_two_squares("EPSG:4326"),
+        )
+        df = compare_versions.load_df_cluster_areas("s3://bucket/dir/output.geojson")
+        assert load.call_args.kwargs.get("crs") == "EPSG:4326" or (
+            "EPSG:4326" in load.call_args.args
+        ), "the geojson must be loaded as the EPSG:4326 it is saved in"
+        assert df["area_m2"].to_list() == pytest.approx(
+            [100.0, 400.0], rel=1e-3
+        ), "geojson areas must be measured in m² after reprojection"
+
+    def test_zero_feature_geojson_degrades_to_an_empty_frame(self, mocker):
+        """A geojson with every feature filtered out must degrade to an
+        empty areas frame, matching the tabular loader's behaviour."""
+        mocker.patch(
+            "asf_heat_pump_suitability.getters.base_getters.load_gdf_from_s3_geojson",
+            side_effect=ValueError(
+                "Assigning CRS to a GeoDataFrame without a geometry column "
+                "is not supported"
+            ),
+        )
+        df = compare_versions.load_df_cluster_areas("s3://bucket/dir/output.geojson")
+        assert df.is_empty(), "a zero-feature geojson must degrade to an empty frame"
+        assert df.columns == [
+            "area_m2"
+        ], "the empty frame must still carry the area column for downstream sums"
+
+    def test_unreadable_file_type_raises(self):
+        """File types the comparison cannot read geometry from fail loudly."""
+        with pytest.raises(ValueError, match="csv"):
+            compare_versions.load_df_cluster_areas("s3://bucket/dir/output.csv")
+
+
 class TestParseArguments:
     """Tests for `parse_arguments`."""
 

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1340,7 +1340,7 @@ def df_clusters_old():
 
 
 @pytest.fixture(scope="module")
-def df_clusters_merged(df_clusters_old):
+def df_clusters_merged():
     """New-version cluster-level output with genuine geometry drift: the two
     heat-pump clusters merged into one."""
     return pl.DataFrame(

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1256,6 +1256,116 @@ class TestLoadDfClusterAreas:
             compare_versions.load_df_cluster_areas("s3://bucket/dir/output.csv")
 
 
+class TestGenerateDictDistributionStats:
+    """Tests for `generate_dict_distribution_stats`."""
+
+    def test_reports_quartiles_min_max_and_mean(self):
+        """The shared helper reports Q1 and Q3 (both quartiles, so a shift
+        and a widening stay distinguishable) plus min, max and mean."""
+        df = pl.DataFrame({"n_UPRNs": [1, 2, 3, 4, 5]})
+        stats = compare_versions.generate_dict_distribution_stats(df, "n_UPRNs")
+        assert stats == {
+            "min": 1,
+            "q1": 2.0,
+            "mean": 3.0,
+            "q3": 4.0,
+            "max": 5,
+        }, "the helper must report Q1, Q3, min, max and mean for the column"
+
+    def test_nulls_are_excluded_from_the_statistics(self):
+        """Null values must not drag the statistics; they are dropped."""
+        df = pl.DataFrame({"n_UPRNs": [1, 2, 3, 4, 5, None]})
+        stats = compare_versions.generate_dict_distribution_stats(df, "n_UPRNs")
+        assert stats["mean"] == 3.0, "nulls must be excluded, not counted as zeros"
+
+    def test_missing_column_returns_none(self, df_clusters_old):
+        """A version without the target column cannot be summarised."""
+        assert (
+            compare_versions.generate_dict_distribution_stats(
+                df_clusters_old, "n_UPRNs"
+            )
+            is None
+        ), "a missing column must degrade to None, not raise"
+
+    def test_all_null_column_returns_none(self):
+        """A column with no values has no distribution to report."""
+        df = pl.DataFrame({"n_UPRNs": [None, None]}, schema={"n_UPRNs": pl.Int64})
+        assert (
+            compare_versions.generate_dict_distribution_stats(df, "n_UPRNs") is None
+        ), "an all-null column must degrade to None, not report null statistics"
+
+
+class TestDistributionColumns:
+    """Tests for the configured `DISTRIBUTION_COLUMNS` per-stage lists."""
+
+    def test_every_configured_stage_is_a_known_stage(self):
+        """Distribution columns are keyed by real pipeline stages."""
+        assert set(compare_versions.DISTRIBUTION_COLUMNS) <= set(
+            compare_versions.STAGE_OUTPUT_DATASETS
+        ), "distribution columns must be configured under known stage names"
+
+    def test_uprns_per_cluster_is_configured_at_the_contextual_stage(self):
+        """n_UPRNs is computed at the contextual-features stage, so its
+        distribution is configured there — config lists real columns only."""
+        assert (
+            "n_UPRNs"
+            in compare_versions.DISTRIBUTION_COLUMNS["compute_contextual_features"]
+        ), "the UPRNs-per-cluster distribution must target the real n_UPRNs column"
+
+
+class TestGetDictDistributionFrames:
+    """Tests for `get_dict_distribution_frames`."""
+
+    def test_cluster_stage_gets_the_derived_area_distribution_only(
+        self, df_clusters_old, df_areas_old, df_areas_merged
+    ):
+        """The cluster stage output has no configured distribution columns;
+        its only distribution is the geometry-derived area."""
+        frames = compare_versions.get_dict_distribution_frames(
+            "cluster",
+            df_clusters_old,
+            df_clusters_old,
+            df_areas_old,
+            df_areas_merged,
+        )
+        assert list(frames) == [
+            "area_m2"
+        ], "the cluster stage must get exactly the derived area distribution"
+        assert frames["area_m2"] == (
+            df_areas_old,
+            df_areas_merged,
+        ), "the area distribution must read the geometry-derived frames"
+
+    def test_contextual_stage_adds_the_configured_columns(
+        self, df_clusters_old, df_areas_old
+    ):
+        """The contextual-features stage gets the derived area plus its
+        configured columns (n_UPRNs), read from the tabular output."""
+        frames = compare_versions.get_dict_distribution_frames(
+            "compute_contextual_features",
+            df_clusters_old,
+            df_clusters_old,
+            df_areas_old,
+            df_areas_old,
+        )
+        assert set(frames) == {
+            "area_m2",
+            "n_UPRNs",
+        }, "the contextual stage must get the area and n_UPRNs distributions"
+        assert frames["n_UPRNs"] == (
+            df_clusters_old,
+            df_clusters_old,
+        ), "configured columns must read the tabular stage output"
+
+    def test_stage_without_geometry_gets_no_distributions(self, df_old):
+        """Non-geometry stages have no areas and no configured columns yet,
+        so no distribution sections are added."""
+        frames = compare_versions.get_dict_distribution_frames(
+            "decision_tree", df_old, df_old, None, None
+        )
+        assert frames == {}, "a stage without geometry or configured columns gets none"
+
+
 class TestParseArguments:
     """Tests for `parse_arguments`."""
 

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1169,52 +1169,6 @@ class TestGenerateStrReportGeometrySections:
             f"`{compare_versions.CLUSTER_LAYER}` layer only" in report
         ), "the report must state the headline checks cover the clusters layer only"
 
-    def test_per_layer_table_keeps_non_cluster_layers_visible(
-        self, df_clusters_old, df_areas_old
-    ):
-        """Filtered-out layers must not vanish silently: the geometry
-        section tabulates rows and total area per layer over both versions,
-        with the pre-layers old version shown as a single labelled row."""
-        df_new = pl.DataFrame(
-            {
-                "cluster_id": ["HP_1", "DHN_1", None],
-                "layer": [
-                    compare_versions.CLUSTER_LAYER,
-                    compare_versions.CLUSTER_LAYER,
-                    "ward_boundaries",
-                ],
-            }
-        )
-        df_areas_new = pl.DataFrame(
-            {
-                "area_m2": [210.0, 100.0, 5_000_000.0],
-                "layer": [
-                    compare_versions.CLUSTER_LAYER,
-                    compare_versions.CLUSTER_LAYER,
-                    "ward_boundaries",
-                ],
-            }
-        )
-        report = generate_report(
-            df_clusters_old,
-            df_new,
-            None,
-            None,
-            stage="compute_contextual_features",
-            trigger=None,
-            df_areas_old=df_areas_old,
-            df_areas_new=df_areas_new,
-        )
-        assert (
-            "| ward_boundaries | — | 1 | — | 5,000,000.0 |" in report
-        ), "the excluded ward layer must stay visible with its rows and area"
-        assert (
-            f"| {compare_versions.PRE_LAYERS_LABEL} | 3 | — | 300.0 | — |" in report
-        ), "the pre-layers old version must appear as its own labelled row"
-        assert (
-            f"| {compare_versions.CLUSTER_LAYER} | — | 2 | — | 310.0 |" in report
-        ), "the clusters layer's own tallies must appear in the table"
-
     def test_unlayered_versions_carry_no_layer_filtering_note(
         self, df_clusters_old, df_areas_old
     ):
@@ -1233,9 +1187,6 @@ class TestGenerateStrReportGeometrySections:
         assert (
             "layer only" not in report
         ), "no layer column anywhere means no filtering note may appear"
-        assert (
-            "per layer" not in report
-        ), "no layer column anywhere means no per-layer table may appear"
 
     def test_geometry_sections_only_for_geometry_stages(
         self, df_old, df_new_identical, manifests, mocker
@@ -1495,80 +1446,6 @@ class TestGenerateDictTotalAreaDelta:
         ), "a version with no clusters must total zero area, not crash"
 
 
-class TestGenerateDfLayerSummary:
-    """Tests for `generate_df_layer_summary`."""
-
-    def test_tallies_rows_and_area_per_layer_over_the_union(self):
-        """Each layer of either version gets one row with per-version row
-        counts and total areas; a layer absent from one side stays null
-        there rather than reading as zero features."""
-        old = pl.DataFrame(
-            {
-                "area_m2": [1.0, 2.0, 30.0],
-                "layer": [
-                    compare_versions.CLUSTER_LAYER,
-                    compare_versions.CLUSTER_LAYER,
-                    "anchor_loads",
-                ],
-            }
-        )
-        new = pl.DataFrame(
-            {
-                "area_m2": [3.0, 400.0],
-                "layer": [compare_versions.CLUSTER_LAYER, "ward_boundaries"],
-            }
-        )
-        summary = compare_versions.generate_df_layer_summary(old, new)
-        by_layer = {row["layer"]: row for row in summary.iter_rows(named=True)}
-        assert set(by_layer) == {
-            compare_versions.CLUSTER_LAYER,
-            "anchor_loads",
-            "ward_boundaries",
-        }, "the table must cover the union of both versions' layers"
-        clusters = by_layer[compare_versions.CLUSTER_LAYER]
-        assert (
-            clusters["rows_old"] == 2 and clusters["area_m2_old"] == 3.0
-        ), "the old clusters layer must tally its two rows and 3 m²"
-        assert (
-            clusters["rows_new"] == 1 and clusters["area_m2_new"] == 3.0
-        ), "the new clusters layer must tally its one row and 3 m²"
-        assert (
-            by_layer["ward_boundaries"]["rows_old"] is None
-        ), "a layer absent from the old version must stay null, not zero"
-        assert (
-            by_layer["anchor_loads"]["rows_new"] is None
-        ), "a layer absent from the new version must stay null, not zero"
-
-    def test_pre_layers_version_appears_as_a_single_row(self, df_areas_old):
-        """A version without a `layer` column is one pre-layers output; it
-        gets a single labelled row so the table still shows both versions."""
-        new = pl.DataFrame(
-            {
-                "area_m2": [3.0, 400.0],
-                "layer": [compare_versions.CLUSTER_LAYER, "ward_boundaries"],
-            }
-        )
-        summary = compare_versions.generate_df_layer_summary(df_areas_old, new)
-        by_layer = {row["layer"]: row for row in summary.iter_rows(named=True)}
-        pre_layers = by_layer[compare_versions.PRE_LAYERS_LABEL]
-        assert (
-            pre_layers["rows_old"] == 3 and pre_layers["area_m2_old"] == 300.0
-        ), "the pre-layers version must appear as one row tallying all its features"
-        assert (
-            pre_layers["rows_new"] is None
-        ), "the layered version has no pre-layers row, so its side stays null"
-
-    def test_returns_none_when_neither_version_is_layered(self, df_areas_old):
-        """Two pre-layers versions have no layers to tabulate; the section
-        must get None so no table is rendered."""
-        assert (
-            compare_versions.generate_df_layer_summary(
-                df_areas_old, df_areas_old.clone()
-            )
-            is None
-        ), "no layer column on either side means no per-layer table"
-
-
 class TestLoadDfClusterAreas:
     """Tests for `load_df_cluster_areas`."""
 
@@ -1649,8 +1526,7 @@ class TestLoadDfClusterAreas:
 
     def test_geojson_layer_column_is_carried_alongside_areas(self, mocker):
         """A multi-layer front-end geojson's areas must keep each feature's
-        layer, so the checks can filter to clusters and the per-layer table
-        can tally the rest."""
+        layer, so the checks can filter to clusters."""
         gdf = self.gdf_two_squares("EPSG:4326")
         gdf["layer"] = [compare_versions.CLUSTER_LAYER, "ward_boundaries"]
         mocker.patch(

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -933,6 +933,169 @@ class TestGenerateStrReport:
         ), "non-decision-tree stages must not carry per-tech count sections"
 
 
+class TestGenerateStrReportGeometrySections:
+    """Tests for `generate_str_report`'s cluster geometry sections."""
+
+    def test_geometry_drift_surfaces_in_counts_and_area(
+        self, df_clusters_old, df_clusters_merged, df_areas_old, df_areas_merged
+    ):
+        """A cluster merge (genuine geometry drift invisible to the tabular
+        checks) must surface as a cluster count delta and an area delta,
+        with the CRS and units stated."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_merged,
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_merged,
+        )
+        assert "Cluster geometry" in report, "the geometry section must appear"
+        assert (
+            "| Clusters | 3 | 2 | -1 |" in report
+        ), "the cluster merge must appear as a -1 cluster count delta"
+        assert (
+            "| Total area (m²) | 300.0 | 310.0 | +10.0 |" in report
+        ), "the absorbed 10 m² gap must appear as the total-area delta"
+        assert "EPSG:27700" in report, "the report must state the CRS areas use"
+
+    def test_stable_versions_show_zero_geometry_deltas(
+        self, df_clusters_old, df_areas_old
+    ):
+        """No geometry drift means zero cluster and area deltas."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_old.clone(),
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        assert (
+            "| Clusters | 3 | 3 | +0 |" in report
+        ), "stable versions must show a zero cluster count delta"
+        assert (
+            "| Total area (m²) | 300.0 | 300.0 | +0.0 |" in report
+        ), "stable versions must show a zero total-area delta"
+
+    def test_simplified_geometry_caveat_only_at_the_contextual_stage(
+        self, df_clusters_old, df_areas_old
+    ):
+        """The contextual-features geojson carries simplified geometry, so
+        its report warns that area differences may be simplification
+        artefacts; the cluster stage's exact geometry needs no caveat."""
+        kwargs = dict(
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        contextual = generate_report(
+            df_clusters_old,
+            df_clusters_old,
+            None,
+            None,
+            stage="compute_contextual_features",
+            **kwargs,
+        )
+        cluster = generate_report(
+            df_clusters_old, df_clusters_old, None, None, stage="cluster", **kwargs
+        )
+        assert (
+            "simplified geometry" in contextual
+        ), "the contextual-features report must carry the simplified-geometry caveat"
+        assert (
+            "simplified geometry" not in cluster
+        ), "the cluster stage's exact geometry must not carry the caveat"
+
+    def test_distribution_sections_report_the_statistics_per_version(
+        self, df_clusters_old, df_areas_old, df_areas_merged
+    ):
+        """Each distribution gets a section with Q1, Q3, min, max and mean
+        for both versions; the contextual stage also covers n_UPRNs."""
+        df_old = df_clusters_old.with_columns(pl.lit(5).alias("n_UPRNs"))
+        df_new = df_old.with_columns(pl.lit(8).alias("n_UPRNs"))
+        report = generate_report(
+            df_old,
+            df_new,
+            None,
+            None,
+            stage="compute_contextual_features",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_merged,
+        )
+        assert (
+            "Distribution: area_m2" in report
+        ), "the cluster-area distribution section must appear"
+        assert (
+            "Distribution: n_UPRNs" in report
+        ), "the UPRNs-per-cluster distribution section must appear"
+        for statistic in ("Min", "Q1", "Mean", "Q3", "Max"):
+            assert (
+                f"| {statistic} |" in report
+            ), f"each distribution must report {statistic} per version"
+        assert (
+            "| Mean | 5.0 | 8.0 |" in report
+        ), "the n_UPRNs shift must appear as old and new means"
+
+    def test_plots_are_embedded_as_image_links(
+        self, df_clusters_old, df_areas_old, df_areas_merged
+    ):
+        """Saved distribution plots are embedded in the report via image
+        links, next to their distribution's statistics."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_old,
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_merged,
+            plot_files={"area_m2": "cluster_plymouth_area_m2.png"},
+        )
+        assert (
+            "![Distribution of area_m2: old vs new](cluster_plymouth_area_m2.png)"
+            in report
+        ), "the saved plot must be embedded via a markdown image link"
+
+    def test_missing_cluster_id_degrades_the_count_to_a_note(
+        self, df_old, df_areas_old
+    ):
+        """A geometry-stage version without a cluster_id column (schema
+        change) must degrade the count to a note, not crash the report."""
+        report = generate_report(
+            df_old,
+            df_old,
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        assert (
+            "cluster_id" in report and "Cluster geometry" in report
+        ), "the missing cluster_id must be noted inside the geometry section"
+
+    def test_geometry_sections_only_for_geometry_stages(
+        self, df_old, df_new_identical, manifests, mocker
+    ):
+        """Stages without cluster geometry must not carry geometry or
+        distribution sections."""
+        mocker.patch.object(
+            compare_versions, "generate_list_commit_log", return_value=[]
+        )
+        report = generate_report(df_old, df_new_identical, *manifests)
+        assert (
+            "Cluster geometry" not in report and "Distribution:" not in report
+        ), "non-geometry stages must not carry geometry sections"
+
+
 class TestLoadTransformDfStageOutput:
     """Tests for `load_transform_df_stage_output`."""
 

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1366,6 +1366,69 @@ class TestGetDictDistributionFrames:
         assert frames == {}, "a stage without geometry or configured columns gets none"
 
 
+class TestPlotDistributionOverlay:
+    """Tests for `plot_distribution_overlay`."""
+
+    def test_saves_a_png_at_the_given_path(self, tmp_path):
+        """The overlaid old-vs-new histogram is saved as a PNG file."""
+        path = tmp_path / "cluster_plymouth_area_m2.png"
+        compare_versions.plot_distribution_overlay(
+            pl.Series("area_m2", [100.0, 100.0, 100.0]),
+            pl.Series("area_m2", [210.0, 100.0]),
+            "area_m2",
+            path,
+        )
+        assert path.exists(), "the plot must be saved at the given path"
+        assert path.stat().st_size > 0, "the saved plot must not be an empty file"
+
+
+class TestGenerateDictDistributionPlots:
+    """Tests for `generate_dict_distribution_plots`."""
+
+    def test_saves_one_plot_per_distribution(
+        self, tmp_path, df_areas_old, df_areas_merged, df_clusters_old
+    ):
+        """Each distribution with values on both sides gets one PNG, named
+        after the report stem, and the mapping points the report at it."""
+        df_uprns = df_clusters_old.with_columns(pl.lit(5).alias("n_UPRNs"))
+        frames = {
+            "area_m2": (df_areas_old, df_areas_merged),
+            "n_UPRNs": (df_uprns, df_uprns),
+        }
+        plot_files = compare_versions.generate_dict_distribution_plots(
+            frames, tmp_path, "cluster_plymouth_20260601_vs_20260722"
+        )
+        assert plot_files == {
+            "area_m2": "cluster_plymouth_20260601_vs_20260722_area_m2.png",
+            "n_UPRNs": "cluster_plymouth_20260601_vs_20260722_n_UPRNs.png",
+        }, "each distribution must map to its stem-named PNG"
+        for filename in plot_files.values():
+            assert (tmp_path / filename).exists(), "every mapped PNG must be saved"
+
+    def test_skips_a_distribution_with_no_values_on_one_side(
+        self, tmp_path, df_areas_old
+    ):
+        """A distribution empty on one side (e.g. zero-feature geojson) has
+        nothing to overlay: no file, no mapping entry, no crash."""
+        empty = pl.DataFrame(schema={"area_m2": pl.Float64})
+        plot_files = compare_versions.generate_dict_distribution_plots(
+            {"area_m2": (df_areas_old, empty)}, tmp_path, "stem"
+        )
+        assert plot_files == {}, "an empty side must skip the plot, not crash"
+        assert list(tmp_path.iterdir()) == [], "no file may be written for a skip"
+
+    def test_skips_a_distribution_whose_column_is_missing(
+        self, tmp_path, df_clusters_old
+    ):
+        """A configured column missing from one version (schema change) is
+        skipped; the report's stats section already notes the gap."""
+        with_col = df_clusters_old.with_columns(pl.lit(5).alias("n_UPRNs"))
+        plot_files = compare_versions.generate_dict_distribution_plots(
+            {"n_UPRNs": (with_col, df_clusters_old)}, tmp_path, "stem"
+        )
+        assert plot_files == {}, "a missing column must skip the plot, not raise"
+
+
 class TestParseArguments:
     """Tests for `parse_arguments`."""
 

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -1,8 +1,8 @@
 ---
 title: Cross-version comparison script — cluster geometry checks
-status: draft
+status: in-review
 github_issue: https://github.com/nestauk/asf_heat_pump_suitability/issues/472
-pr:
+pr: https://github.com/nestauk/asf_heat_pump_suitability/pull/475
 asana: https://app.asana.com/1/5571817120120/project/1214222223606748/task/1216704619895657
 created: 2026-08-13
 ---

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -151,6 +151,12 @@ Implementation decisions from the first acceptance run on real data
   like an int in `_format_stat` (1738.0 → "1,738"), so a version whose
   column round-trips to Float64 no longer renders "1,738.0" beside the
   other version's "1,165"; non-integral floats keep one decimal place.
+- **Plots switch to log-spaced bins for heavily skewed distributions.**
+  Real cluster areas span orders of magnitude, so linear bins collapsed
+  almost every cluster into one bar. When values are all positive and
+  max/median exceeds 50 (`LOG_BINS_SKEW_RATIO`), bins are log-spaced and
+  the x-axis is log-scaled, labelled "(log scale)"; compact distributions
+  keep linear bins. Both versions still share the same bins.
 
 ## Verification
 

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -2,7 +2,9 @@
 title: Cross-version comparison script — cluster geometry checks
 status: in-review
 github_issue: https://github.com/nestauk/asf_heat_pump_suitability/issues/472
-pr: https://github.com/nestauk/asf_heat_pump_suitability/pull/475
+pr: https://github.com/nestauk/asf_heat_pump_suitability/pull/486 (1/3),
+  https://github.com/nestauk/asf_heat_pump_suitability/pull/487 (2/3),
+  https://github.com/nestauk/asf_heat_pump_suitability/pull/475 (3/3)
 asana: https://app.asana.com/1/5571817120120/project/1214222223606748/task/1216704619895657
 created: 2026-08-13
 ---

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -91,16 +91,37 @@ Decisions settled during kickoff interview (2026-08-13):
   space…) are "important" enough to plot — this issue builds the plotting
   mechanism; the follow-on decides where else to apply it.
 
+Implementation decisions within the spec's frame (2026-08-13):
+
+- **Target columns live in `compare_versions.distribution_columns`** in
+  `base.yaml`, keyed by stage (`cluster: []`,
+  `compute_contextual_features: [n_UPRNs]`); a test pins the keys to known
+  stages. The geometry-bearing stages themselves are a module constant
+  (`GEOMETRY_STAGES`) — which outputs carry geometry is code behaviour,
+  not a tunable.
+- **The shared helper is `generate_dict_distribution_stats(df, column)`**
+  (min/Q1/mean/Q3/max, linear-interpolated quartiles, nulls dropped);
+  `get_dict_distribution_frames` pairs each distribution with the frames
+  carrying it — derived `area_m2` from the geometry loader
+  (`load_df_cluster_areas`, which reprojects non-EPSG:27700 outputs before
+  measuring), configured columns from the tabular outputs.
+- **Plots share the report's filename stem**
+  (`{stage}_{la}_{old}_vs_{new}_{column}.png`, saved next to the report);
+  both versions share histogram bins so the shapes are comparable. A
+  distribution with a missing column or no values on one side skips its
+  plot with a warning — its stats section already notes the gap.
+
 ## Verification
 
-- [ ] Cluster count delta reported for both stages
-- [ ] Total area delta reported for both stages with CRS/units stated;
+- [x] Cluster count delta reported for both stages
+- [x] Total area delta reported for both stages with CRS/units stated;
       simplified-geometry caveat in the contextual-features section
-- [ ] Cluster-area distribution reported: Q1, Q3, min, max, mean per version
-- [ ] UPRNs-per-cluster distribution reported with the same statistics
-- [ ] One shared column-parameterized distribution function; target columns
+- [x] Cluster-area distribution reported: Q1, Q3, min, max, mean per version
+- [x] UPRNs-per-cluster distribution reported with the same statistics
+- [x] One shared column-parameterized distribution function; target columns
       per stage in `base.yaml`
-- [ ] Overlaid old-vs-new plots for cluster area and UPRNs per cluster,
+- [x] Overlaid old-vs-new plots for cluster area and UPRNs per cluster,
       embedded in the report
-- [ ] Unit tests cover at least one genuine geometry-drift case and one
-      stable case
+- [x] Unit tests cover at least one genuine geometry-drift case and one
+      stable case (a cluster merge vs identical versions; acceptance runs
+      against Plymouth 20260806 vs 20260812 exercised both stages on S3)

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -79,6 +79,13 @@ Decisions settled during kickoff interview (2026-08-13):
   them as an open question only** — rejected; the helper would be
   retrofitted just as distributions multiply, and the geometry
   distributions would get plots retroactively.
+- **A per-layer rows/area summary table in the geometry section** —
+  implemented alongside the layer filtering, then removed (2026-08-26):
+  on real output it mostly paired numbers with dashes, duplicated the
+  headline comparison, and its accounting value (where did the
+  non-cluster rows go) is already covered by the scope note and the
+  whole-file row counts. If layer-presence drift ever needs flagging,
+  the thresholding follow-on can add it as a check rather than a table.
 
 ## Out of scope
 
@@ -131,14 +138,15 @@ Implementation decisions from the first acceptance run on real data
 - **The clusters layer name is config, not code:**
   `compare_versions.cluster_layer` in `base.yaml`, verified against the
   20260806 East Lothian output — a front-end rename is a config change.
-- **A per-layer summary table keeps excluded layers visible.** The
-  geometry section tabulates rows and total area (m²) per layer over the
-  union of both versions' layers, so non-cluster layers are surfaced
-  rather than silently dropped; a version without a `layer` column shows
-  as a single `(pre-layers output)` row, and a side lacking a layer
-  renders as a dash, not a misleading zero. When filtering was applied,
-  the section states that the headline checks cover the clusters layer
-  only.
+- **No per-layer summary table** (removed 2026-08-26, Aidan's call, after
+  reading it on real output). The report's job is to compare clusters
+  between versions, and that comparison is the headline table. During the
+  format transition the per-layer table was a grid of dashes pairing each
+  number with nothing, and its useful content is carried elsewhere: the
+  scope note says filtering happened and names the clusters layer, and the
+  whole-file row counts at the top already reveal that non-cluster rows
+  exist. When filtering was applied, the section states that the headline
+  checks cover the clusters layer only.
 - **Stats render consistently across dtypes:** an integral float renders
   like an int in `_format_stat` (1738.0 → "1,738"), so a version whose
   column round-trips to Float64 no longer renders "1,738.0" beside the
@@ -162,11 +170,8 @@ Implementation decisions from the first acceptance run on real data
       and plots cover the config-named clusters layer only
       (`compare_versions.cluster_layer`), with the scope stated in the
       report
-- [x] Per-layer summary table reports rows and total area (m²) per layer,
-      old vs new, over the union of both versions' layers
 - [x] A version without a `layer` column is treated as all-clusters
-      (back-compat across the format change) and shown as a single
-      pre-layers row in the per-layer table
+      (back-compat across the format change)
 - [x] Statistics render consistently across versions: integral floats
       render like ints, non-integral floats keep one decimal place
       (acceptance re-run against East Lothian 20260708 vs 20260806

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -111,6 +111,37 @@ Implementation decisions within the spec's frame (2026-08-13):
   distribution with a missing column or no values on one side skips its
   plot with a warning — its stats section already notes the gap.
 
+Implementation decisions from the first acceptance run on real data
+(2026-08-26):
+
+- **The geometry checks filter to the clusters layer.** As of ~August 2026
+  the contextual-features geojson is a multi-layer front-end file: a
+  `layer` column tags each row (`clusters_with_contextual_features`,
+  `ward_boundaries`, `anchor_loads`,
+  `areas_of_district_heat_network_potential`). Aggregating all layers let
+  six whole-county ward polygons swamp the cluster signal (+679.5M m²
+  total-area delta on East Lothian 20260708 vs 20260806). Cluster count,
+  total area, distribution stats and plots now cover the clusters layer
+  only — one shared filter (`filter_df_clusters_layer`) applied to both
+  the tabular and geometry-derived frames. A version without a `layer`
+  column (pre-August outputs) is treated as all-clusters, so comparisons
+  across the format change keep working.
+- **The clusters layer name is config, not code:**
+  `compare_versions.cluster_layer` in `base.yaml`, verified against the
+  20260806 East Lothian output — a front-end rename is a config change.
+- **A per-layer summary table keeps excluded layers visible.** The
+  geometry section tabulates rows and total area (m²) per layer over the
+  union of both versions' layers, so non-cluster layers are surfaced
+  rather than silently dropped; a version without a `layer` column shows
+  as a single `(pre-layers output)` row, and a side lacking a layer
+  renders as a dash, not a misleading zero. When filtering was applied,
+  the section states that the headline checks cover the clusters layer
+  only.
+- **Stats render consistently across dtypes:** an integral float renders
+  like an int in `_format_stat` (1738.0 → "1,738"), so a version whose
+  column round-trips to Float64 no longer renders "1,738.0" beside the
+  other version's "1,165"; non-integral floats keep one decimal place.
+
 ## Verification
 
 - [x] Cluster count delta reported for both stages
@@ -125,3 +156,16 @@ Implementation decisions within the spec's frame (2026-08-13):
 - [x] Unit tests cover at least one genuine geometry-drift case and one
       stable case (a cluster merge vs identical versions; acceptance runs
       against Plymouth 20260806 vs 20260812 exercised both stages on S3)
+- [x] Multi-layer outputs: cluster count, total area, distribution stats
+      and plots cover the config-named clusters layer only
+      (`compare_versions.cluster_layer`), with the scope stated in the
+      report
+- [x] Per-layer summary table reports rows and total area (m²) per layer,
+      old vs new, over the union of both versions' layers
+- [x] A version without a `layer` column is treated as all-clusters
+      (back-compat across the format change) and shown as a single
+      pre-layers row in the per-layer table
+- [x] Statistics render consistently across versions: integral floats
+      render like ints, non-integral floats keep one decimal place
+      (acceptance re-run against East Lothian 20260708 vs 20260806
+      exercised the multi-layer path on S3)

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -1,0 +1,106 @@
+---
+title: Cross-version comparison script — cluster geometry checks
+status: draft
+github_issue: https://github.com/nestauk/asf_heat_pump_suitability/issues/472
+pr:
+asana: https://app.asana.com/1/5571817120120/project/1214222223606748/task/1216704619895657
+created: 2026-08-13
+---
+
+## Problem
+
+The comparison script's tabular checks (#447, PR #451) can't see
+geometry-level drift — a clustering change could alter cluster count, total
+area, or size distribution while every tabular check still passes. This is
+by design in the base checks: `load_transform_df_stage_output` drops
+geoarrow geometry columns because polars cannot read them, so nothing
+downstream of the loader ever sees a polygon.
+
+Third issue in the comparison-script stack (see
+`docs/specs/447_addCompareVersionsScript.md` and the stack's drafts doc):
+stacks on `447_addCompareVersionsScript`, and the shared distribution
+helper introduced here is reused by the distribution-checks follow-on
+(issue 5 in the stack).
+
+## Proposal
+
+Extend the report, for the clustering and contextual-features stages, with:
+
+- cluster count delta (`n_unique(cluster_id)` per version)
+- total area delta, in m² (EPSG:27700), with CRS and units stated
+- cluster-area distribution comparison: Q1, Q3, min, max, mean per version
+- UPRNs-per-cluster distribution comparison with the same statistics
+  (the `n_UPRNs` count computed at the contextual-features stage)
+- an old-vs-new overlaid plot per distribution, saved as a PNG next to the
+  markdown report and embedded in it via an image link (matplotlib is
+  already a main dependency)
+
+Decisions settled during kickoff interview (2026-08-13):
+
+- **Area is reported at both stages, with a caveat at the
+  contextual-features stage.** The cluster stage's geoparquet carries exact
+  EPSG:27700 geometry; the contextual-features geojson carries the same
+  clusters reprojected to EPSG:4326 and simplified
+  (`compute_contextual_features.py` simplifies before saving). Both stages
+  get area checks — the contextual-features output is what the front-end
+  tool consumes, so leaving it blind to area drift defeats the check — but
+  its geometries are reprojected back to EPSG:27700 before measuring and
+  the report states that its areas are computed on simplified geometry, so
+  a reader doesn't chase simplification artefacts as drift.
+- **`base.yaml` lists real columns only.** The per-stage target-column
+  lists for the shared distribution helper (settled 2026-08-10 for the
+  stack) name columns that exist in the stage output (e.g. `n_UPRNs` for
+  the contextual-features stage), so config stays verifiable by test. The
+  derived `area_m2` is computed from geometry in code for geometry-bearing
+  stages and fed through the same shared helper — code owns derived
+  metrics, config owns stored columns.
+- **IQR is reported as the Q1 and Q3 quartiles**, old vs new, not as a
+  single width. Both quartiles show whether a distribution shifted or
+  widened; a lone width hides a shift where both quartiles move together.
+- **Overlaid distribution plots land in this issue**, for its two
+  distributions (cluster area, UPRNs per cluster). Building the plotting
+  arm now, while there are only two distributions, means the
+  distribution-checks follow-on inherits it rather than retrofitting it.
+
+## Alternatives considered
+
+- **Area checks at the cluster stage only** — rejected; avoids approximate
+  areas but leaves the final, tool-facing stage blind to area drift.
+- **Both stages with no simplified-geometry caveat** — rejected; a reader
+  could chase reprojection/simplification artefacts as drift.
+- **Listing `area_m2` as a pseudo-column in `base.yaml`** — rejected;
+  config would name a column no output contains, and the follow-on issue's
+  config inherits that ambiguity.
+- **Single IQR width (Q3 − Q1)** — rejected; cannot distinguish a shifted
+  distribution from a stable one.
+- **Deferring plots to the distribution-checks follow-on, or recording
+  them as an open question only** — rejected; the helper would be
+  retrofitted just as distributions multiply, and the geometry
+  distributions would get plots retroactively.
+
+## Out of scope
+
+- Categorical mix deltas, numeric drift (stacked follow-on issue 5)
+- Turning deltas into an automatic expected/suspicious flag (stacked
+  follow-on issue 6)
+- PSI or other distribution-drift scalars
+
+## Open questions
+
+- Which of the follow-on issue's distributions (tenure, EPC, outdoor
+  space…) are "important" enough to plot — this issue builds the plotting
+  mechanism; the follow-on decides where else to apply it.
+
+## Verification
+
+- [ ] Cluster count delta reported for both stages
+- [ ] Total area delta reported for both stages with CRS/units stated;
+      simplified-geometry caveat in the contextual-features section
+- [ ] Cluster-area distribution reported: Q1, Q3, min, max, mean per version
+- [ ] UPRNs-per-cluster distribution reported with the same statistics
+- [ ] One shared column-parameterized distribution function; target columns
+      per stage in `base.yaml`
+- [ ] Overlaid old-vs-new plots for cluster area and UPRNs per cluster,
+      embedded in the report
+- [ ] Unit tests cover at least one genuine geometry-drift case and one
+      stable case


### PR DESCRIPTION
> **Stacked PR, 3 of 3.** Base is `472_addGeometryReportSections` (PR #487, 2/3), not `dev`. Please review only this PR's 5 commits.

# Description

The contextual-features outputs are now multi-layer front-end files: one `layer` column holding `clusters`, `ward_boundaries`, `anchor_loads` and DHN areas. The geometry checks from 1/3 and 2/3 counted every layer, so six whole-county ward polygons swamped the totals...East Lothian showed a +679.5M m² area delta that was entirely wards, not clusters.

- Checks, distributions and plots now cover the clusters layer only, named by `compare_versions.cluster_layer` in `base.yaml`.
- Outputs from before layers existed have no `layer` column, so they count entirely as clusters.

The decomposition follow-on (#474) stacks on this branch.

Closes #472.

# Instructions for Reviewer

## Please pay special attention to

- **The pre-layers fallback** — treating a missing `layer` column as all-clusters. It is the assumption that makes old-vs-new comparisons work across the format change, and it is wrong if any pre-layers output was ever multi-layer.

## How to test

```bash
uv run python -m pytest asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py -v
```

Expect **175 passed**; 14 test functions are new here.

Acceptance run, East Lothian

```bash
uv run python -m asf_heat_pump_suitability.pipeline.validate.compare_versions \
   --stage cluster --local_authority east_lothian

uv run python -m asf_heat_pump_suitability.pipeline.validate.compare_versions \
   --stage compute_contextual_features --local_authority east_lothian
```

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
- [x] I have explained this PR above
- [ ] I have requested a code review — draft while the branches underneath are still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
