### PR TITLE
472 Add cluster count, area and distribution-stats checks (1/3)

### DIFF
--- a/asf_heat_pump_suitability/config/base.yaml
+++ b/asf_heat_pump_suitability/config/base.yaml
@@ -405,6 +405,14 @@ compare_versions:
     cluster: "tech_clusters"
     compute_contextual_features: "clusters_tech_contextual_info"
   decision_tree_buildings_dataset: "buildings_most_suitable_tech"
+  # Columns whose distributions the report compares per stage (Q1/Q3, min,
+  # max, mean, old vs new). Real output columns only: derived metrics such
+  # as cluster area are computed from geometry in code and fed through the
+  # same shared helper.
+  distribution_columns:
+    cluster: []
+    compute_contextual_features:
+      - "n_UPRNs"
   # Repo paths counted as each stage's module when scoping the commit log
   # between two versions' recorded commits: the stage entrypoint plus the
   # pipeline modules it directly drives. Cross-cutting code (getters/, utils/,

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -50,6 +50,7 @@ GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
 STAGE_MODULE_PATHS = config["compare_versions"]["stage_module_paths"]
 STAGE_OUTPUT_DATASETS = config["compare_versions"]["stage_output_datasets"]
 BUILDINGS_DATASET = config["compare_versions"]["decision_tree_buildings_dataset"]
+DISTRIBUTION_COLUMNS = config["compare_versions"]["distribution_columns"]
 TOLERANCES = config["compare_versions"]["tolerances"]
 
 
@@ -147,6 +148,68 @@ def generate_dict_total_area_delta(
         "area_m2_new": total_new,
         "area_m2_delta": total_new - total_old,
     }
+
+
+def generate_dict_distribution_stats(df: pl.DataFrame, column: str) -> dict | None:
+    """
+    Summarise one column's distribution: both quartiles, min, max and mean.
+
+    Q1 and Q3 are reported separately (linear interpolation) so a shifted
+    distribution and a widened one stay distinguishable. Nulls are excluded.
+
+    Args:
+        df: one version of a stage output
+        column: column to summarise
+
+    Returns:
+        dict: min/q1/mean/q3/max, or None when the column is missing or has
+            no non-null values
+    """
+    if column not in df.columns:
+        return None
+    values = df[column].drop_nulls()
+    if values.is_empty():
+        return None
+    return {
+        "min": values.min(),
+        "q1": values.quantile(0.25, "linear"),
+        "mean": values.mean(),
+        "q3": values.quantile(0.75, "linear"),
+        "max": values.max(),
+    }
+
+
+def get_dict_distribution_frames(
+    stage: str,
+    df_old: pl.DataFrame,
+    df_new: pl.DataFrame,
+    df_areas_old: pl.DataFrame | None,
+    df_areas_new: pl.DataFrame | None,
+) -> dict[str, tuple[pl.DataFrame, pl.DataFrame]]:
+    """
+    Map each of a stage's distribution columns to the (old, new) frames
+    that carry it.
+
+    The derived cluster area reads the geometry-derived frames (when
+    loaded); the stage's configured `DISTRIBUTION_COLUMNS` read the tabular
+    outputs.
+
+    Args:
+        stage: pipeline stage the outputs belong to
+        df_old: older version of the tabular stage output
+        df_new: newer version of the tabular stage output
+        df_areas_old: older version's per-cluster areas, or None
+        df_areas_new: newer version's per-cluster areas, or None
+
+    Returns:
+        dict: column name to (old, new) frame pair, plot/report order
+    """
+    frames = {}
+    if df_areas_old is not None and df_areas_new is not None:
+        frames[AREA_COL] = (df_areas_old, df_areas_new)
+    for column in DISTRIBUTION_COLUMNS.get(stage, []):
+        frames[column] = (df_old, df_new)
+    return frames
 
 
 def generate_dict_schema_diff(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dict:

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -29,17 +29,23 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import fsspec
+import geopandas as gpd
 import polars as pl
 import pyarrow.parquet as pq
 import s3fs
 
 from asf_heat_pump_suitability import PROJECT_DIR, config
 from asf_heat_pump_suitability.getters import base_getters
-from asf_heat_pump_suitability.utils import manifest_utils, save_utils
+from asf_heat_pump_suitability.utils import geo_utils, manifest_utils, save_utils
 
 UPRN_COL = "UPRN"
 TECH_COL = "assigned_tech"
 NULL_TECH_LABEL = "(null)"
+CLUSTER_ID_COL = "cluster_id"
+AREA_COL = "area_m2"
+# Stages whose outputs carry cluster geometry, and so get the cluster
+# count, area and distribution sections.
+GEOMETRY_STAGES = ("cluster", "compute_contextual_features")
 
 STAGE_MODULE_PATHS = config["compare_versions"]["stage_module_paths"]
 STAGE_OUTPUT_DATASETS = config["compare_versions"]["stage_output_datasets"]
@@ -94,6 +100,53 @@ def generate_dict_count_delta(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dic
         counts["uprns_new"] = df_new[UPRN_COL].n_unique()
         counts["uprns_delta"] = counts["uprns_new"] - counts["uprns_old"]
     return counts
+
+
+def generate_dict_cluster_count_delta(
+    df_old: pl.DataFrame, df_new: pl.DataFrame
+) -> dict | None:
+    """
+    Compare distinct-cluster counts between two versions of an output.
+
+    Args:
+        df_old: older version of a cluster-bearing stage output
+        df_new: newer version of a cluster-bearing stage output
+
+    Returns:
+        dict: old/new/delta distinct-cluster counts, or None when either
+            version has no cluster-id column
+    """
+    if CLUSTER_ID_COL not in df_old.columns or CLUSTER_ID_COL not in df_new.columns:
+        return None
+    n_old = df_old[CLUSTER_ID_COL].n_unique()
+    n_new = df_new[CLUSTER_ID_COL].n_unique()
+    return {
+        "clusters_old": n_old,
+        "clusters_new": n_new,
+        "clusters_delta": n_new - n_old,
+    }
+
+
+def generate_dict_total_area_delta(
+    df_areas_old: pl.DataFrame, df_areas_new: pl.DataFrame
+) -> dict:
+    """
+    Compare total cluster area between two versions, in m² (EPSG:27700).
+
+    Args:
+        df_areas_old: older version's per-cluster areas
+        df_areas_new: newer version's per-cluster areas
+
+    Returns:
+        dict: old/new/delta total areas; a version with no clusters totals 0
+    """
+    total_old = df_areas_old[AREA_COL].sum()
+    total_new = df_areas_new[AREA_COL].sum()
+    return {
+        "area_m2_old": total_old,
+        "area_m2_new": total_new,
+        "area_m2_delta": total_new - total_old,
+    }
 
 
 def generate_dict_schema_diff(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dict:
@@ -559,6 +612,38 @@ def load_transform_df_stage_output(path: str) -> pl.DataFrame:
             return pl.DataFrame()
         return pl.from_pandas(gdf.drop(columns="geometry"))
     raise ValueError(f"Cannot compare file type of {path}; expected parquet/geojson.")
+
+
+def load_df_cluster_areas(path: str) -> pl.DataFrame:
+    """
+    Load a geometry-bearing stage output as per-cluster areas in m².
+
+    Areas are measured in EPSG:27700 (metres); an output saved in another
+    CRS — the contextual-features geojson is EPSG:4326, with simplified
+    geometry — is reprojected first. A zero-feature geojson degrades to an
+    empty frame.
+
+    Args:
+        path: S3 path of the stage output (.parquet or .geojson)
+
+    Returns:
+        pl.DataFrame: one `area_m2` row per cluster
+
+    Raises:
+        ValueError: for file types the comparison cannot read geometry from
+    """
+    if path.endswith(".parquet"):
+        gdf = gpd.read_parquet(path, columns=["geometry"])
+    elif path.endswith(".geojson"):
+        try:
+            gdf = base_getters.load_gdf_from_s3_geojson(path, crs="EPSG:4326")
+        except ValueError:
+            logging.warning("No features in geojson at %s; no areas to load.", path)
+            return pl.DataFrame(schema={AREA_COL: pl.Float64})
+    else:
+        raise ValueError(f"Cannot read geometry of {path}; expected parquet/geojson.")
+    gdf = geo_utils.verify_gdf_crs(gdf)
+    return pl.DataFrame({AREA_COL: gdf.area.to_numpy()})
 
 
 def load_df_buildings_tech(path: str) -> pl.DataFrame:

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1054,6 +1054,208 @@ class TestLoadTupleDfBuildings:
         load.assert_not_called()
 
 
+@pytest.fixture(scope="module")
+def df_clusters_old():
+    """Old-version cluster-level output: three clusters across two techs."""
+    return pl.DataFrame(
+        {
+            "cluster_id": ["HP_1", "HP_2", "DHN_1"],
+            "assigned_tech": [
+                "Networked heat pump",
+                "Networked heat pump",
+                "District heat network",
+            ],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def df_clusters_merged(df_clusters_old):
+    """New-version cluster-level output with genuine geometry drift: the two
+    heat-pump clusters merged into one."""
+    return pl.DataFrame(
+        {
+            "cluster_id": ["HP_1", "DHN_1"],
+            "assigned_tech": ["Networked heat pump", "District heat network"],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def df_areas_old():
+    """Old-version per-cluster areas: three 100 m² clusters."""
+    return pl.DataFrame({"area_m2": [100.0, 100.0, 100.0]})
+
+
+@pytest.fixture(scope="module")
+def df_areas_merged():
+    """New-version per-cluster areas after the merge: the merged cluster
+    absorbed the 10 m² gap between its parents (100 + 100 + 10)."""
+    return pl.DataFrame({"area_m2": [210.0, 100.0]})
+
+
+class TestGenerateDictClusterCountDelta:
+    """Tests for `generate_dict_cluster_count_delta`."""
+
+    def test_identical_versions_have_zero_delta(self, df_clusters_old):
+        """No drift means no change in the distinct-cluster count."""
+        counts = compare_versions.generate_dict_cluster_count_delta(
+            df_clusters_old, df_clusters_old.clone()
+        )
+        assert counts == {
+            "clusters_old": 3,
+            "clusters_new": 3,
+            "clusters_delta": 0,
+        }, "identical versions must show no cluster count change"
+
+    def test_merged_clusters_show_a_negative_delta(
+        self, df_clusters_old, df_clusters_merged
+    ):
+        """Two clusters merging into one is genuine geometry drift the
+        tabular checks cannot see; the count delta must surface it."""
+        counts = compare_versions.generate_dict_cluster_count_delta(
+            df_clusters_old, df_clusters_merged
+        )
+        assert counts == {
+            "clusters_old": 3,
+            "clusters_new": 2,
+            "clusters_delta": -1,
+        }, "a cluster merge must appear as a negative cluster count delta"
+
+    def test_counts_distinct_cluster_ids_not_rows(self, df_clusters_old):
+        """A cluster-id column with repeated values (e.g. a UPRN-level frame)
+        must count distinct clusters, not rows."""
+        repeated = pl.concat([df_clusters_old, df_clusters_old])
+        counts = compare_versions.generate_dict_cluster_count_delta(
+            repeated, df_clusters_old
+        )
+        assert (
+            counts["clusters_old"] == 3
+        ), "repeated cluster ids must count as one cluster each"
+
+    def test_returns_none_without_cluster_id_column(self, df_old):
+        """Outputs without a cluster_id column (e.g. UPRN-stage outputs)
+        cannot be cluster-counted."""
+        assert (
+            compare_versions.generate_dict_cluster_count_delta(df_old, df_old) is None
+        ), "no cluster_id column means no cluster count, so None is expected"
+
+
+class TestGenerateDictTotalAreaDelta:
+    """Tests for `generate_dict_total_area_delta`."""
+
+    def test_identical_versions_have_zero_delta(self, df_areas_old):
+        """No drift means no total-area change."""
+        totals = compare_versions.generate_dict_total_area_delta(
+            df_areas_old, df_areas_old.clone()
+        )
+        assert totals == {
+            "area_m2_old": 300.0,
+            "area_m2_new": 300.0,
+            "area_m2_delta": 0.0,
+        }, "identical versions must show no total-area change"
+
+    def test_reports_the_total_area_delta_in_m2(self, df_areas_old, df_areas_merged):
+        """The cluster merge grew the total area by the 10 m² gap it
+        absorbed; the delta must surface it in m²."""
+        totals = compare_versions.generate_dict_total_area_delta(
+            df_areas_old, df_areas_merged
+        )
+        assert totals == {
+            "area_m2_old": 300.0,
+            "area_m2_new": 310.0,
+            "area_m2_delta": 10.0,
+        }, "the total-area delta must be new minus old, in m²"
+
+    def test_a_version_with_no_clusters_totals_zero(self, df_areas_old):
+        """An empty areas frame (zero-feature geojson) totals 0 m² rather
+        than crashing the delta."""
+        empty = pl.DataFrame(schema={"area_m2": pl.Float64})
+        totals = compare_versions.generate_dict_total_area_delta(df_areas_old, empty)
+        assert (
+            totals["area_m2_new"] == 0.0 and totals["area_m2_delta"] == -300.0
+        ), "a version with no clusters must total zero area, not crash"
+
+
+class TestLoadDfClusterAreas:
+    """Tests for `load_df_cluster_areas`."""
+
+    @staticmethod
+    def gdf_two_squares(crs: str):
+        """Two axis-aligned squares of 100 and 400 m², built in EPSG:27700
+        near Plymouth and converted to the requested CRS."""
+        import geopandas as gpd
+        from shapely.geometry import box
+
+        gdf = gpd.GeoDataFrame(
+            {"cluster_id": ["HP_1", "HP_2"]},
+            geometry=[
+                box(250000, 55000, 250010, 55010),
+                box(250100, 55100, 250120, 55120),
+            ],
+            crs="EPSG:27700",
+        )
+        return gdf.to_crs(crs)
+
+    def test_geoparquet_areas_measured_in_m2(self, tmp_path):
+        """The cluster stage's geoparquet carries exact EPSG:27700 geometry;
+        areas come back in m², one row per cluster."""
+        path = tmp_path / "clusters.parquet"
+        self.gdf_two_squares("EPSG:27700").to_parquet(path)
+        df = compare_versions.load_df_cluster_areas(str(path))
+        assert df.columns == ["area_m2"], "only the derived area column is returned"
+        assert df["area_m2"].to_list() == [
+            100.0,
+            400.0,
+        ], "areas must be measured in m² on the saved EPSG:27700 geometry"
+
+    def test_geoparquet_in_another_crs_is_reprojected_before_measuring(self, tmp_path):
+        """A geoparquet not in the target CRS must be reprojected to
+        EPSG:27700 first — measuring in EPSG:4326 would return degrees²."""
+        path = tmp_path / "clusters.parquet"
+        self.gdf_two_squares("EPSG:4326").to_parquet(path)
+        df = compare_versions.load_df_cluster_areas(str(path))
+        assert df["area_m2"].to_list() == pytest.approx(
+            [100.0, 400.0], rel=1e-3
+        ), "areas must be measured in metres after reprojection, not degrees"
+
+    def test_geojson_is_reprojected_to_the_target_crs_before_measuring(self, mocker):
+        """The contextual-features geojson is saved in EPSG:4326; its areas
+        must be measured after reprojecting back to EPSG:27700."""
+        load = mocker.patch(
+            "asf_heat_pump_suitability.getters.base_getters.load_gdf_from_s3_geojson",
+            return_value=self.gdf_two_squares("EPSG:4326"),
+        )
+        df = compare_versions.load_df_cluster_areas("s3://bucket/dir/output.geojson")
+        assert load.call_args.kwargs.get("crs") == "EPSG:4326" or (
+            "EPSG:4326" in load.call_args.args
+        ), "the geojson must be loaded as the EPSG:4326 it is saved in"
+        assert df["area_m2"].to_list() == pytest.approx(
+            [100.0, 400.0], rel=1e-3
+        ), "geojson areas must be measured in m² after reprojection"
+
+    def test_zero_feature_geojson_degrades_to_an_empty_frame(self, mocker):
+        """A geojson with every feature filtered out must degrade to an
+        empty areas frame, matching the tabular loader's behaviour."""
+        mocker.patch(
+            "asf_heat_pump_suitability.getters.base_getters.load_gdf_from_s3_geojson",
+            side_effect=ValueError(
+                "Assigning CRS to a GeoDataFrame without a geometry column "
+                "is not supported"
+            ),
+        )
+        df = compare_versions.load_df_cluster_areas("s3://bucket/dir/output.geojson")
+        assert df.is_empty(), "a zero-feature geojson must degrade to an empty frame"
+        assert df.columns == [
+            "area_m2"
+        ], "the empty frame must still carry the area column for downstream sums"
+
+    def test_unreadable_file_type_raises(self):
+        """File types the comparison cannot read geometry from fail loudly."""
+        with pytest.raises(ValueError, match="csv"):
+            compare_versions.load_df_cluster_areas("s3://bucket/dir/output.csv")
+
+
 class TestParseArguments:
     """Tests for `parse_arguments`."""
 

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1256,6 +1256,116 @@ class TestLoadDfClusterAreas:
             compare_versions.load_df_cluster_areas("s3://bucket/dir/output.csv")
 
 
+class TestGenerateDictDistributionStats:
+    """Tests for `generate_dict_distribution_stats`."""
+
+    def test_reports_quartiles_min_max_and_mean(self):
+        """The shared helper reports Q1 and Q3 (both quartiles, so a shift
+        and a widening stay distinguishable) plus min, max and mean."""
+        df = pl.DataFrame({"n_UPRNs": [1, 2, 3, 4, 5]})
+        stats = compare_versions.generate_dict_distribution_stats(df, "n_UPRNs")
+        assert stats == {
+            "min": 1,
+            "q1": 2.0,
+            "mean": 3.0,
+            "q3": 4.0,
+            "max": 5,
+        }, "the helper must report Q1, Q3, min, max and mean for the column"
+
+    def test_nulls_are_excluded_from_the_statistics(self):
+        """Null values must not drag the statistics; they are dropped."""
+        df = pl.DataFrame({"n_UPRNs": [1, 2, 3, 4, 5, None]})
+        stats = compare_versions.generate_dict_distribution_stats(df, "n_UPRNs")
+        assert stats["mean"] == 3.0, "nulls must be excluded, not counted as zeros"
+
+    def test_missing_column_returns_none(self, df_clusters_old):
+        """A version without the target column cannot be summarised."""
+        assert (
+            compare_versions.generate_dict_distribution_stats(
+                df_clusters_old, "n_UPRNs"
+            )
+            is None
+        ), "a missing column must degrade to None, not raise"
+
+    def test_all_null_column_returns_none(self):
+        """A column with no values has no distribution to report."""
+        df = pl.DataFrame({"n_UPRNs": [None, None]}, schema={"n_UPRNs": pl.Int64})
+        assert (
+            compare_versions.generate_dict_distribution_stats(df, "n_UPRNs") is None
+        ), "an all-null column must degrade to None, not report null statistics"
+
+
+class TestDistributionColumns:
+    """Tests for the configured `DISTRIBUTION_COLUMNS` per-stage lists."""
+
+    def test_every_configured_stage_is_a_known_stage(self):
+        """Distribution columns are keyed by real pipeline stages."""
+        assert set(compare_versions.DISTRIBUTION_COLUMNS) <= set(
+            compare_versions.STAGE_OUTPUT_DATASETS
+        ), "distribution columns must be configured under known stage names"
+
+    def test_uprns_per_cluster_is_configured_at_the_contextual_stage(self):
+        """n_UPRNs is computed at the contextual-features stage, so its
+        distribution is configured there — config lists real columns only."""
+        assert (
+            "n_UPRNs"
+            in compare_versions.DISTRIBUTION_COLUMNS["compute_contextual_features"]
+        ), "the UPRNs-per-cluster distribution must target the real n_UPRNs column"
+
+
+class TestGetDictDistributionFrames:
+    """Tests for `get_dict_distribution_frames`."""
+
+    def test_cluster_stage_gets_the_derived_area_distribution_only(
+        self, df_clusters_old, df_areas_old, df_areas_merged
+    ):
+        """The cluster stage output has no configured distribution columns;
+        its only distribution is the geometry-derived area."""
+        frames = compare_versions.get_dict_distribution_frames(
+            "cluster",
+            df_clusters_old,
+            df_clusters_old,
+            df_areas_old,
+            df_areas_merged,
+        )
+        assert list(frames) == [
+            "area_m2"
+        ], "the cluster stage must get exactly the derived area distribution"
+        assert frames["area_m2"] == (
+            df_areas_old,
+            df_areas_merged,
+        ), "the area distribution must read the geometry-derived frames"
+
+    def test_contextual_stage_adds_the_configured_columns(
+        self, df_clusters_old, df_areas_old
+    ):
+        """The contextual-features stage gets the derived area plus its
+        configured columns (n_UPRNs), read from the tabular output."""
+        frames = compare_versions.get_dict_distribution_frames(
+            "compute_contextual_features",
+            df_clusters_old,
+            df_clusters_old,
+            df_areas_old,
+            df_areas_old,
+        )
+        assert set(frames) == {
+            "area_m2",
+            "n_UPRNs",
+        }, "the contextual stage must get the area and n_UPRNs distributions"
+        assert frames["n_UPRNs"] == (
+            df_clusters_old,
+            df_clusters_old,
+        ), "configured columns must read the tabular stage output"
+
+    def test_stage_without_geometry_gets_no_distributions(self, df_old):
+        """Non-geometry stages have no areas and no configured columns yet,
+        so no distribution sections are added."""
+        frames = compare_versions.get_dict_distribution_frames(
+            "decision_tree", df_old, df_old, None, None
+        )
+        assert frames == {}, "a stage without geometry or configured columns gets none"
+
+
 class TestParseArguments:
     """Tests for `parse_arguments`."""
 

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -1,0 +1,106 @@
+---
+title: Cross-version comparison script — cluster geometry checks
+status: draft
+github_issue: https://github.com/nestauk/asf_heat_pump_suitability/issues/472
+pr:
+asana: https://app.asana.com/1/5571817120120/project/1214222223606748/task/1216704619895657
+created: 2026-08-13
+---
+
+## Problem
+
+The comparison script's tabular checks (#447, PR #451) can't see
+geometry-level drift — a clustering change could alter cluster count, total
+area, or size distribution while every tabular check still passes. This is
+by design in the base checks: `load_transform_df_stage_output` drops
+geoarrow geometry columns because polars cannot read them, so nothing
+downstream of the loader ever sees a polygon.
+
+Third issue in the comparison-script stack (see
+`docs/specs/447_addCompareVersionsScript.md` and the stack's drafts doc):
+stacks on `447_addCompareVersionsScript`, and the shared distribution
+helper introduced here is reused by the distribution-checks follow-on
+(issue 5 in the stack).
+
+## Proposal
+
+Extend the report, for the clustering and contextual-features stages, with:
+
+- cluster count delta (`n_unique(cluster_id)` per version)
+- total area delta, in m² (EPSG:27700), with CRS and units stated
+- cluster-area distribution comparison: Q1, Q3, min, max, mean per version
+- UPRNs-per-cluster distribution comparison with the same statistics
+  (the `n_UPRNs` count computed at the contextual-features stage)
+- an old-vs-new overlaid plot per distribution, saved as a PNG next to the
+  markdown report and embedded in it via an image link (matplotlib is
+  already a main dependency)
+
+Decisions settled during kickoff interview (2026-08-13):
+
+- **Area is reported at both stages, with a caveat at the
+  contextual-features stage.** The cluster stage's geoparquet carries exact
+  EPSG:27700 geometry; the contextual-features geojson carries the same
+  clusters reprojected to EPSG:4326 and simplified
+  (`compute_contextual_features.py` simplifies before saving). Both stages
+  get area checks — the contextual-features output is what the front-end
+  tool consumes, so leaving it blind to area drift defeats the check — but
+  its geometries are reprojected back to EPSG:27700 before measuring and
+  the report states that its areas are computed on simplified geometry, so
+  a reader doesn't chase simplification artefacts as drift.
+- **`base.yaml` lists real columns only.** The per-stage target-column
+  lists for the shared distribution helper (settled 2026-08-10 for the
+  stack) name columns that exist in the stage output (e.g. `n_UPRNs` for
+  the contextual-features stage), so config stays verifiable by test. The
+  derived `area_m2` is computed from geometry in code for geometry-bearing
+  stages and fed through the same shared helper — code owns derived
+  metrics, config owns stored columns.
+- **IQR is reported as the Q1 and Q3 quartiles**, old vs new, not as a
+  single width. Both quartiles show whether a distribution shifted or
+  widened; a lone width hides a shift where both quartiles move together.
+- **Overlaid distribution plots land in this issue**, for its two
+  distributions (cluster area, UPRNs per cluster). Building the plotting
+  arm now, while there are only two distributions, means the
+  distribution-checks follow-on inherits it rather than retrofitting it.
+
+## Alternatives considered
+
+- **Area checks at the cluster stage only** — rejected; avoids approximate
+  areas but leaves the final, tool-facing stage blind to area drift.
+- **Both stages with no simplified-geometry caveat** — rejected; a reader
+  could chase reprojection/simplification artefacts as drift.
+- **Listing `area_m2` as a pseudo-column in `base.yaml`** — rejected;
+  config would name a column no output contains, and the follow-on issue's
+  config inherits that ambiguity.
+- **Single IQR width (Q3 − Q1)** — rejected; cannot distinguish a shifted
+  distribution from a stable one.
+- **Deferring plots to the distribution-checks follow-on, or recording
+  them as an open question only** — rejected; the helper would be
+  retrofitted just as distributions multiply, and the geometry
+  distributions would get plots retroactively.
+
+## Out of scope
+
+- Categorical mix deltas, numeric drift (stacked follow-on issue 5)
+- Turning deltas into an automatic expected/suspicious flag (stacked
+  follow-on issue 6)
+- PSI or other distribution-drift scalars
+
+## Open questions
+
+- Which of the follow-on issue's distributions (tenure, EPC, outdoor
+  space…) are "important" enough to plot — this issue builds the plotting
+  mechanism; the follow-on decides where else to apply it.
+
+## Verification
+
+- [ ] Cluster count delta reported for both stages
+- [ ] Total area delta reported for both stages with CRS/units stated;
+      simplified-geometry caveat in the contextual-features section
+- [ ] Cluster-area distribution reported: Q1, Q3, min, max, mean per version
+- [ ] UPRNs-per-cluster distribution reported with the same statistics
+- [ ] One shared column-parameterized distribution function; target columns
+      per stage in `base.yaml`
+- [ ] Overlaid old-vs-new plots for cluster area and UPRNs per cluster,
+      embedded in the report
+- [ ] Unit tests cover at least one genuine geometry-drift case and one
+      stable case


### PR DESCRIPTION
> **Stacked PR, 1 of 3.** Base is `447_addCompareVersionsScript`, not `dev`. Please review only this PR's 3 commits.

# Description

The comparison report from PR #451 is blind to cluster geometry: its loader drops geometry columns, so a clustering change could merge, split or reshape clusters and every existing check would still pass. This slice adds the checks that close that gap. Rendering them into the report happens in 2/3.

- `load_df_cluster_areas` reads a stage output's geometry (geoparquet or geojson) and returns **one area per row**, reprojecting to EPSG:27700 first so areas are always in m².
- `generate_dict_cluster_count_delta` and `generate_dict_total_area_delta` produce the two headline numbers: clusters per version, and total area per version, each with the difference.
- `generate_dict_distribution_stats(df, column)` turns any one column into min/Q1/mean/Q3/max. It is shared: both this issue's distributions and the follow-on issue's go through it.
- `base.yaml` gains `compare_versions.distribution_columns`, keyed by stage. It names columns that really exist in the output; the derived `area_m2` is computed in code rather than listed as a pseudo-column.

Spec (with the reasoning behind each decision): `docs/specs/472_addClusterGeometryChecksToCompareVersions.md`, in this diff.

Part of #472.

# Instructions for Reviewer

## Please pay special attention to

- **`load_df_cluster_areas`** — the reprojection logic, and that it really is per-row rather than a single total. This is the one genuinely geospatial function here, so it is where a CRS mistake would hide.
- **The config/code split**: config owns stored columns, code owns derived ones. Is `distribution_columns` the right shape to grow into, given the follow-on issue adds more distributions to it?
- **Q1 and Q3 reported separately**, not as one IQR width. A lone width cannot tell a shifted distribution from a stable one when both quartiles move together.

## How to test

```bash
uv run python -m pytest asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py -v
```

Green, no credentials or network needed. 21 new test functions here, including a genuine geometry-drift case (clusters merging between versions) and a stable case (identical versions, where every delta should be zero).

# Checklist:

- [ ] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
- [x] I have explained this PR above
- [ ] I have requested a code review — draft while the base PR (#451) is still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
