### PR TITLE
472 Add distribution plots and geometry report sections (2/3)

### DIFF
--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -2,11 +2,13 @@
 Compare two dated versions of a pipeline stage output for one local authority.
 
 Reports row/UPRN count deltas, schema diff, UPRN churn, per-tech counts and
-the tech-assignment transition matrix (decision-tree stage), and a
-module-scoped commit log between the two versions' recorded commits. With a
---trigger, checks are read against that rubric's tolerances; without one, the
-report presents raw numbers only. Writes a local markdown report and logs a
-console summary.
+the tech-assignment transition matrix (decision-tree stage), cluster
+count/area deltas and distribution comparisons with overlaid plots (cluster
+and contextual-features stages), and a module-scoped commit log between the
+two versions' recorded commits. With a --trigger, checks are read against
+that rubric's tolerances; without one, the report presents raw numbers only.
+Writes a local markdown report (plus distribution plot PNGs next to it) and
+logs a console summary.
 
 Usage (compare the latest two versions, raw numbers only):
 python -m asf_heat_pump_suitability.pipeline.validate.compare_versions \
@@ -913,6 +915,86 @@ def _generate_str_churn_section(
     return _render_section("UPRN churn", *lines)
 
 
+def _format_stat(value: float | int) -> str:
+    """Format a statistic for a report table (floats to one decimal place)."""
+    return f"{value:,.1f}" if isinstance(value, float) else f"{value:,}"
+
+
+def _generate_str_cluster_geometry_section(
+    count_delta: dict | None, area_delta: dict | None, stage: str
+) -> str:
+    """Render cluster count and total area deltas as a markdown section,
+    with the CRS/units stated and the simplified-geometry caveat for the
+    contextual-features stage."""
+    lines = [
+        "| Metric | Old | New | Delta |",
+        "| --- | --- | --- | --- |",
+    ]
+    if count_delta is not None:
+        lines.append(
+            f"| Clusters | {count_delta['clusters_old']} "
+            f"| {count_delta['clusters_new']} "
+            f"| {count_delta['clusters_delta']:+d} |"
+        )
+    if area_delta is not None:
+        lines.append(
+            f"| Total area (m²) | {area_delta['area_m2_old']:,.1f} "
+            f"| {area_delta['area_m2_new']:,.1f} "
+            f"| {area_delta['area_m2_delta']:+,.1f} |"
+        )
+    if count_delta is None:
+        lines.extend(
+            [
+                "",
+                f"Cluster count skipped: no `{CLUSTER_ID_COL}` column in one or "
+                "both versions (see schema diff).",
+            ]
+        )
+    if area_delta is None:
+        lines.extend(["", "Total area skipped: geometry unavailable."])
+    else:
+        lines.extend(
+            ["", "Areas are computed in EPSG:27700 (British National Grid), in m²."]
+        )
+        if stage == "compute_contextual_features":
+            lines.append(
+                "Note: this stage's areas are measured on simplified geometry "
+                "(reprojected from EPSG:4326); small differences from the "
+                "cluster stage are simplification artefacts, not drift."
+            )
+    return _render_section("Cluster geometry", *lines)
+
+
+def _generate_str_distribution_section(
+    column: str,
+    frame_old: pl.DataFrame,
+    frame_new: pl.DataFrame,
+    plot_file: str | None,
+) -> str:
+    """Render one distribution's per-version statistics as a markdown
+    section, with its overlaid plot embedded when one was saved."""
+    title = f"Distribution: {column}"
+    stats_old = generate_dict_distribution_stats(frame_old, column)
+    stats_new = generate_dict_distribution_stats(frame_new, column)
+    if stats_old is None or stats_new is None:
+        return _render_section(
+            title, f"Skipped: no `{column}` values in one or both versions."
+        )
+    lines = [
+        "| Statistic | Old | New |",
+        "| --- | --- | --- |",
+    ]
+    labels = {"min": "Min", "q1": "Q1", "mean": "Mean", "q3": "Q3", "max": "Max"}
+    for key, label in labels.items():
+        lines.append(
+            f"| {label} | {_format_stat(stats_old[key])} "
+            f"| {_format_stat(stats_new[key])} |"
+        )
+    if plot_file is not None:
+        lines.extend(["", f"![Distribution of {column}: old vs new]({plot_file})"])
+    return _render_section(title, *lines)
+
+
 def _generate_str_tech_counts_section(
     df_old: pl.DataFrame | None, df_new: pl.DataFrame | None, level: str
 ) -> str:
@@ -1030,6 +1112,9 @@ def generate_str_report(
     path_new: str,
     df_buildings_old: pl.DataFrame | None = None,
     df_buildings_new: pl.DataFrame | None = None,
+    df_areas_old: pl.DataFrame | None = None,
+    df_areas_new: pl.DataFrame | None = None,
+    plot_files: dict[str, str] | None = None,
 ) -> str:
     """
     Assemble the full markdown comparison report.
@@ -1050,6 +1135,11 @@ def generate_str_report(
         df_buildings_old: older building-level decision-tree output, or None
             when missing (its per-tech counts section is then skipped)
         df_buildings_new: newer building-level output, or None when missing
+        df_areas_old: older version's per-cluster areas (geometry stages), or
+            None (the total-area check is then skipped)
+        df_areas_new: newer version's per-cluster areas, or None
+        plot_files: distribution column to saved plot filename, embedded as
+            image links; None embeds no plots
 
     Returns:
         str: markdown report; lineage sections are replaced by a note when a
@@ -1079,6 +1169,26 @@ def generate_str_report(
             tolerances["max_removed_uprn_share"] if tolerances is not None else None,
         ),
     ]
+    if stage in GEOMETRY_STAGES:
+        area_delta = (
+            generate_dict_total_area_delta(df_areas_old, df_areas_new)
+            if df_areas_old is not None and df_areas_new is not None
+            else None
+        )
+        sections.append(
+            _generate_str_cluster_geometry_section(
+                generate_dict_cluster_count_delta(df_old, df_new), area_delta, stage
+            )
+        )
+        frames = get_dict_distribution_frames(
+            stage, df_old, df_new, df_areas_old, df_areas_new
+        )
+        sections.extend(
+            _generate_str_distribution_section(
+                column, frame_old, frame_new, (plot_files or {}).get(column)
+            )
+            for column, (frame_old, frame_new) in frames.items()
+        )
     if stage == "decision_tree":
         sections.append(_generate_str_tech_counts_section(df_old, df_new, "UPRN-level"))
         sections.append(
@@ -1184,6 +1294,22 @@ if __name__ == "__main__":
         df_buildings_old, df_buildings_new = load_tuple_df_buildings(
             local_authority, release_date_old, release_date_new
         )
+    report_dir = Path(args.report_dir)
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_stem = (
+        f"{args.stage}_{local_authority}_{release_date_old}_vs_{release_date_new}"
+    )
+    df_areas_old = df_areas_new = plot_files = None
+    if args.stage in GEOMETRY_STAGES:
+        df_areas_old = load_df_cluster_areas(path_old)
+        df_areas_new = load_df_cluster_areas(path_new)
+        plot_files = generate_dict_distribution_plots(
+            get_dict_distribution_frames(
+                args.stage, df_old, df_new, df_areas_old, df_areas_new
+            ),
+            report_dir,
+            report_stem,
+        )
     report = generate_str_report(
         df_old,
         df_new,
@@ -1198,12 +1324,11 @@ if __name__ == "__main__":
         path_new=path_new,
         df_buildings_old=df_buildings_old,
         df_buildings_new=df_buildings_new,
+        df_areas_old=df_areas_old,
+        df_areas_new=df_areas_new,
+        plot_files=plot_files,
     )
-    report_dir = Path(args.report_dir)
-    report_dir.mkdir(parents=True, exist_ok=True)
-    report_path = report_dir / (
-        f"{args.stage}_{local_authority}_{release_date_old}_vs_{release_date_new}.md"
-    )
+    report_path = report_dir / f"{report_stem}.md"
     report_path.write_text(report)
 
     counts = generate_dict_count_delta(df_old, df_new)

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -216,13 +216,31 @@ def get_dict_distribution_frames(
     return frames
 
 
+# Max-to-median ratio above which a distribution is drawn on log-spaced
+# bins: cluster areas and UPRNs-per-cluster are heavily right-skewed, and
+# linear bins collapse almost every value into one bar.
+LOG_BINS_SKEW_RATIO = 50
+
+
+def _use_log_bins(values: np.ndarray) -> bool:
+    """Log-spaced bins suit a heavily right-skewed, all-positive
+    distribution; anything else keeps linear bins."""
+    if values.min() <= 0:
+        return False
+    return values.max() / np.median(values) > LOG_BINS_SKEW_RATIO
+
+
 def plot_distribution_overlay(
     values_old: pl.Series, values_new: pl.Series, label: str, path: Path
 ) -> None:
     """
     Save an overlaid old-vs-new histogram of one distribution as a PNG.
 
-    Both versions share the same bins so the shapes are comparable.
+    Both versions share the same bins so the shapes are comparable. A
+    heavily right-skewed distribution (see `_use_log_bins`) is drawn on
+    log-spaced bins with a log x-axis, so the bulk of the values stays
+    readable instead of collapsing into one bar next to the extremes; the
+    x-axis label says when this applied.
 
     Args:
         values_old: older version's values
@@ -231,11 +249,18 @@ def plot_distribution_overlay(
         path: file path the PNG is saved to
     """
     old, new = values_old.to_numpy(), values_new.to_numpy()
-    bins = np.histogram_bin_edges(np.concatenate([old, new]), bins=40)
+    combined = np.concatenate([old, new])
+    log_bins = _use_log_bins(combined)
+    if log_bins:
+        bins = np.logspace(np.log10(combined.min()), np.log10(combined.max()), num=41)
+    else:
+        bins = np.histogram_bin_edges(combined, bins=40)
     fig, ax = plt.subplots(figsize=(8, 5))
     ax.hist(old, bins=bins, alpha=0.6, label="Old", color="tab:blue")
     ax.hist(new, bins=bins, alpha=0.6, label="New", color="tab:orange")
-    ax.set_xlabel(label)
+    if log_bins:
+        ax.set_xscale("log")
+    ax.set_xlabel(f"{label} (log scale)" if log_bins else label)
     ax.set_ylabel("Count")
     ax.set_title(f"Distribution of {label}: old vs new")
     ax.legend()

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import fsspec
 import geopandas as gpd
+import matplotlib.pyplot as plt
+import numpy as np
 import polars as pl
 import pyarrow.parquet as pq
 import s3fs
@@ -210,6 +212,71 @@ def get_dict_distribution_frames(
     for column in DISTRIBUTION_COLUMNS.get(stage, []):
         frames[column] = (df_old, df_new)
     return frames
+
+
+def plot_distribution_overlay(
+    values_old: pl.Series, values_new: pl.Series, label: str, path: Path
+) -> None:
+    """
+    Save an overlaid old-vs-new histogram of one distribution as a PNG.
+
+    Both versions share the same bins so the shapes are comparable.
+
+    Args:
+        values_old: older version's values
+        values_new: newer version's values
+        label: distribution name, used for the x-axis and title
+        path: file path the PNG is saved to
+    """
+    old, new = values_old.to_numpy(), values_new.to_numpy()
+    bins = np.histogram_bin_edges(np.concatenate([old, new]), bins=40)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.hist(old, bins=bins, alpha=0.6, label="Old", color="tab:blue")
+    ax.hist(new, bins=bins, alpha=0.6, label="New", color="tab:orange")
+    ax.set_xlabel(label)
+    ax.set_ylabel("Count")
+    ax.set_title(f"Distribution of {label}: old vs new")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def generate_dict_distribution_plots(
+    frames: dict[str, tuple[pl.DataFrame, pl.DataFrame]],
+    plot_dir: Path,
+    file_stem: str,
+) -> dict[str, str]:
+    """
+    Save an overlaid old-vs-new histogram for each of a stage's distributions.
+
+    A distribution with a missing column or no values on either side is
+    skipped with a warning — its stats section already notes the gap.
+
+    Args:
+        frames: column to (old, new) frame pair, as built by
+            `get_dict_distribution_frames`
+        plot_dir: directory the PNGs are saved to
+        file_stem: filename prefix, shared with the markdown report
+
+    Returns:
+        dict: column to saved PNG filename (relative to `plot_dir`, so the
+            report next to the PNGs can link them relatively)
+    """
+    plot_files = {}
+    for column, (frame_old, frame_new) in frames.items():
+        if column not in frame_old.columns or column not in frame_new.columns:
+            logging.warning("Column %s missing from one version; plot skipped.", column)
+            continue
+        values_old = frame_old[column].drop_nulls()
+        values_new = frame_new[column].drop_nulls()
+        if values_old.is_empty() or values_new.is_empty():
+            logging.warning("No %s values in one version; plot skipped.", column)
+            continue
+        filename = f"{file_stem}_{column}.png"
+        plot_distribution_overlay(values_old, values_new, column, plot_dir / filename)
+        plot_files[column] = filename
+    return plot_files
 
 
 def generate_dict_schema_diff(df_old: pl.DataFrame, df_new: pl.DataFrame) -> dict:

--- a/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/compare_versions.py
@@ -759,7 +759,8 @@ def load_df_cluster_areas(path: str) -> pl.DataFrame:
         path: S3 path of the stage output (.parquet or .geojson)
 
     Returns:
-        pl.DataFrame: one `area_m2` row per cluster
+        pl.DataFrame: one `area_m2` row per feature row (not deduplicated on
+            cluster id, so a duplicated cluster contributes each of its rows)
 
     Raises:
         ValueError: for file types the comparison cannot read geometry from

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -8,6 +8,7 @@ pytest asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.p
 import json
 import subprocess
 
+import numpy as np
 import polars as pl
 import pytest
 
@@ -1529,6 +1530,35 @@ class TestGetDictDistributionFrames:
         assert frames == {}, "a stage without geometry or configured columns gets none"
 
 
+class TestUseLogBins:
+    """Tests for `_use_log_bins`."""
+
+    def test_heavily_right_skewed_positive_values_use_log_bins(self):
+        """Cluster areas span orders of magnitude (a few huge clusters, a
+        bulk of small ones); linear bins would collapse the bulk into one
+        bar, so log bins apply."""
+        values = np.array([10.0] * 99 + [1_000_000.0])
+        assert compare_versions._use_log_bins(
+            values
+        ), "a max thousands of times the median must switch to log bins"
+
+    def test_compact_values_keep_linear_bins(self):
+        """A distribution without an extreme tail reads best on the familiar
+        linear axis."""
+        values = np.array([80.0, 100.0, 120.0, 150.0])
+        assert not compare_versions._use_log_bins(
+            values
+        ), "values within one order of magnitude must keep linear bins"
+
+    def test_nonpositive_values_keep_linear_bins(self):
+        """Log bins cannot represent zero or negative values, so any such
+        value forces linear bins."""
+        values = np.array([0.0, 10.0, 1_000_000.0])
+        assert not compare_versions._use_log_bins(
+            values
+        ), "a zero value must force linear bins - log10(0) is undefined"
+
+
 class TestPlotDistributionOverlay:
     """Tests for `plot_distribution_overlay`."""
 
@@ -1542,6 +1572,18 @@ class TestPlotDistributionOverlay:
             path,
         )
         assert path.exists(), "the plot must be saved at the given path"
+
+    def test_skewed_distribution_saves_a_log_binned_png(self, tmp_path):
+        """A heavily right-skewed distribution (real cluster areas) still
+        plots cleanly on the log-spaced bins."""
+        path = tmp_path / "cluster_plymouth_area_m2.png"
+        compare_versions.plot_distribution_overlay(
+            pl.Series("area_m2", [20.0] * 50 + [3_000.0] * 10 + [400_000.0]),
+            pl.Series("area_m2", [25.0] * 60 + [300_000_000.0]),
+            "area_m2",
+            path,
+        )
+        assert path.exists(), "the log-binned plot must be saved at the given path"
         assert path.stat().st_size > 0, "the saved plot must not be an empty file"
 
 

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1572,6 +1572,7 @@ class TestPlotDistributionOverlay:
             path,
         )
         assert path.exists(), "the plot must be saved at the given path"
+        assert path.stat().st_size > 0, "the saved plot must not be an empty file"
 
     def test_skewed_distribution_saves_a_log_binned_png(self, tmp_path):
         """A heavily right-skewed distribution (real cluster areas) still
@@ -1584,7 +1585,6 @@ class TestPlotDistributionOverlay:
             path,
         )
         assert path.exists(), "the log-binned plot must be saved at the given path"
-        assert path.stat().st_size > 0, "the saved plot must not be an empty file"
 
 
 class TestGenerateDictDistributionPlots:

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -933,6 +933,169 @@ class TestGenerateStrReport:
         ), "non-decision-tree stages must not carry per-tech count sections"
 
 
+class TestGenerateStrReportGeometrySections:
+    """Tests for `generate_str_report`'s cluster geometry sections."""
+
+    def test_geometry_drift_surfaces_in_counts_and_area(
+        self, df_clusters_old, df_clusters_merged, df_areas_old, df_areas_merged
+    ):
+        """A cluster merge (genuine geometry drift invisible to the tabular
+        checks) must surface as a cluster count delta and an area delta,
+        with the CRS and units stated."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_merged,
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_merged,
+        )
+        assert "Cluster geometry" in report, "the geometry section must appear"
+        assert (
+            "| Clusters | 3 | 2 | -1 |" in report
+        ), "the cluster merge must appear as a -1 cluster count delta"
+        assert (
+            "| Total area (m²) | 300.0 | 310.0 | +10.0 |" in report
+        ), "the absorbed 10 m² gap must appear as the total-area delta"
+        assert "EPSG:27700" in report, "the report must state the CRS areas use"
+
+    def test_stable_versions_show_zero_geometry_deltas(
+        self, df_clusters_old, df_areas_old
+    ):
+        """No geometry drift means zero cluster and area deltas."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_old.clone(),
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        assert (
+            "| Clusters | 3 | 3 | +0 |" in report
+        ), "stable versions must show a zero cluster count delta"
+        assert (
+            "| Total area (m²) | 300.0 | 300.0 | +0.0 |" in report
+        ), "stable versions must show a zero total-area delta"
+
+    def test_simplified_geometry_caveat_only_at_the_contextual_stage(
+        self, df_clusters_old, df_areas_old
+    ):
+        """The contextual-features geojson carries simplified geometry, so
+        its report warns that area differences may be simplification
+        artefacts; the cluster stage's exact geometry needs no caveat."""
+        kwargs = dict(
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        contextual = generate_report(
+            df_clusters_old,
+            df_clusters_old,
+            None,
+            None,
+            stage="compute_contextual_features",
+            **kwargs,
+        )
+        cluster = generate_report(
+            df_clusters_old, df_clusters_old, None, None, stage="cluster", **kwargs
+        )
+        assert (
+            "simplified geometry" in contextual
+        ), "the contextual-features report must carry the simplified-geometry caveat"
+        assert (
+            "simplified geometry" not in cluster
+        ), "the cluster stage's exact geometry must not carry the caveat"
+
+    def test_distribution_sections_report_the_statistics_per_version(
+        self, df_clusters_old, df_areas_old, df_areas_merged
+    ):
+        """Each distribution gets a section with Q1, Q3, min, max and mean
+        for both versions; the contextual stage also covers n_UPRNs."""
+        df_old = df_clusters_old.with_columns(pl.lit(5).alias("n_UPRNs"))
+        df_new = df_old.with_columns(pl.lit(8).alias("n_UPRNs"))
+        report = generate_report(
+            df_old,
+            df_new,
+            None,
+            None,
+            stage="compute_contextual_features",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_merged,
+        )
+        assert (
+            "Distribution: area_m2" in report
+        ), "the cluster-area distribution section must appear"
+        assert (
+            "Distribution: n_UPRNs" in report
+        ), "the UPRNs-per-cluster distribution section must appear"
+        for statistic in ("Min", "Q1", "Mean", "Q3", "Max"):
+            assert (
+                f"| {statistic} |" in report
+            ), f"each distribution must report {statistic} per version"
+        assert (
+            "| Mean | 5.0 | 8.0 |" in report
+        ), "the n_UPRNs shift must appear as old and new means"
+
+    def test_plots_are_embedded_as_image_links(
+        self, df_clusters_old, df_areas_old, df_areas_merged
+    ):
+        """Saved distribution plots are embedded in the report via image
+        links, next to their distribution's statistics."""
+        report = generate_report(
+            df_clusters_old,
+            df_clusters_old,
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_merged,
+            plot_files={"area_m2": "cluster_plymouth_area_m2.png"},
+        )
+        assert (
+            "![Distribution of area_m2: old vs new](cluster_plymouth_area_m2.png)"
+            in report
+        ), "the saved plot must be embedded via a markdown image link"
+
+    def test_missing_cluster_id_degrades_the_count_to_a_note(
+        self, df_old, df_areas_old
+    ):
+        """A geometry-stage version without a cluster_id column (schema
+        change) must degrade the count to a note, not crash the report."""
+        report = generate_report(
+            df_old,
+            df_old,
+            None,
+            None,
+            stage="cluster",
+            trigger=None,
+            df_areas_old=df_areas_old,
+            df_areas_new=df_areas_old.clone(),
+        )
+        assert (
+            "cluster_id" in report and "Cluster geometry" in report
+        ), "the missing cluster_id must be noted inside the geometry section"
+
+    def test_geometry_sections_only_for_geometry_stages(
+        self, df_old, df_new_identical, manifests, mocker
+    ):
+        """Stages without cluster geometry must not carry geometry or
+        distribution sections."""
+        mocker.patch.object(
+            compare_versions, "generate_list_commit_log", return_value=[]
+        )
+        report = generate_report(df_old, df_new_identical, *manifests)
+        assert (
+            "Cluster geometry" not in report and "Distribution:" not in report
+        ), "non-geometry stages must not carry geometry sections"
+
+
 class TestLoadTransformDfStageOutput:
     """Tests for `load_transform_df_stage_output`."""
 

--- a/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
+++ b/asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py
@@ -1366,6 +1366,69 @@ class TestGetDictDistributionFrames:
         assert frames == {}, "a stage without geometry or configured columns gets none"
 
 
+class TestPlotDistributionOverlay:
+    """Tests for `plot_distribution_overlay`."""
+
+    def test_saves_a_png_at_the_given_path(self, tmp_path):
+        """The overlaid old-vs-new histogram is saved as a PNG file."""
+        path = tmp_path / "cluster_plymouth_area_m2.png"
+        compare_versions.plot_distribution_overlay(
+            pl.Series("area_m2", [100.0, 100.0, 100.0]),
+            pl.Series("area_m2", [210.0, 100.0]),
+            "area_m2",
+            path,
+        )
+        assert path.exists(), "the plot must be saved at the given path"
+        assert path.stat().st_size > 0, "the saved plot must not be an empty file"
+
+
+class TestGenerateDictDistributionPlots:
+    """Tests for `generate_dict_distribution_plots`."""
+
+    def test_saves_one_plot_per_distribution(
+        self, tmp_path, df_areas_old, df_areas_merged, df_clusters_old
+    ):
+        """Each distribution with values on both sides gets one PNG, named
+        after the report stem, and the mapping points the report at it."""
+        df_uprns = df_clusters_old.with_columns(pl.lit(5).alias("n_UPRNs"))
+        frames = {
+            "area_m2": (df_areas_old, df_areas_merged),
+            "n_UPRNs": (df_uprns, df_uprns),
+        }
+        plot_files = compare_versions.generate_dict_distribution_plots(
+            frames, tmp_path, "cluster_plymouth_20260601_vs_20260722"
+        )
+        assert plot_files == {
+            "area_m2": "cluster_plymouth_20260601_vs_20260722_area_m2.png",
+            "n_UPRNs": "cluster_plymouth_20260601_vs_20260722_n_UPRNs.png",
+        }, "each distribution must map to its stem-named PNG"
+        for filename in plot_files.values():
+            assert (tmp_path / filename).exists(), "every mapped PNG must be saved"
+
+    def test_skips_a_distribution_with_no_values_on_one_side(
+        self, tmp_path, df_areas_old
+    ):
+        """A distribution empty on one side (e.g. zero-feature geojson) has
+        nothing to overlay: no file, no mapping entry, no crash."""
+        empty = pl.DataFrame(schema={"area_m2": pl.Float64})
+        plot_files = compare_versions.generate_dict_distribution_plots(
+            {"area_m2": (df_areas_old, empty)}, tmp_path, "stem"
+        )
+        assert plot_files == {}, "an empty side must skip the plot, not crash"
+        assert list(tmp_path.iterdir()) == [], "no file may be written for a skip"
+
+    def test_skips_a_distribution_whose_column_is_missing(
+        self, tmp_path, df_clusters_old
+    ):
+        """A configured column missing from one version (schema change) is
+        skipped; the report's stats section already notes the gap."""
+        with_col = df_clusters_old.with_columns(pl.lit(5).alias("n_UPRNs"))
+        plot_files = compare_versions.generate_dict_distribution_plots(
+            {"n_UPRNs": (with_col, df_clusters_old)}, tmp_path, "stem"
+        )
+        assert plot_files == {}, "a missing column must skip the plot, not raise"
+
+
 class TestParseArguments:
     """Tests for `parse_arguments`."""
 

--- a/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
+++ b/docs/specs/472_addClusterGeometryChecksToCompareVersions.md
@@ -91,16 +91,37 @@ Decisions settled during kickoff interview (2026-08-13):
   space…) are "important" enough to plot — this issue builds the plotting
   mechanism; the follow-on decides where else to apply it.
 
+Implementation decisions within the spec's frame (2026-08-13):
+
+- **Target columns live in `compare_versions.distribution_columns`** in
+  `base.yaml`, keyed by stage (`cluster: []`,
+  `compute_contextual_features: [n_UPRNs]`); a test pins the keys to known
+  stages. The geometry-bearing stages themselves are a module constant
+  (`GEOMETRY_STAGES`) — which outputs carry geometry is code behaviour,
+  not a tunable.
+- **The shared helper is `generate_dict_distribution_stats(df, column)`**
+  (min/Q1/mean/Q3/max, linear-interpolated quartiles, nulls dropped);
+  `get_dict_distribution_frames` pairs each distribution with the frames
+  carrying it — derived `area_m2` from the geometry loader
+  (`load_df_cluster_areas`, which reprojects non-EPSG:27700 outputs before
+  measuring), configured columns from the tabular outputs.
+- **Plots share the report's filename stem**
+  (`{stage}_{la}_{old}_vs_{new}_{column}.png`, saved next to the report);
+  both versions share histogram bins so the shapes are comparable. A
+  distribution with a missing column or no values on one side skips its
+  plot with a warning — its stats section already notes the gap.
+
 ## Verification
 
-- [ ] Cluster count delta reported for both stages
-- [ ] Total area delta reported for both stages with CRS/units stated;
+- [x] Cluster count delta reported for both stages
+- [x] Total area delta reported for both stages with CRS/units stated;
       simplified-geometry caveat in the contextual-features section
-- [ ] Cluster-area distribution reported: Q1, Q3, min, max, mean per version
-- [ ] UPRNs-per-cluster distribution reported with the same statistics
-- [ ] One shared column-parameterized distribution function; target columns
+- [x] Cluster-area distribution reported: Q1, Q3, min, max, mean per version
+- [x] UPRNs-per-cluster distribution reported with the same statistics
+- [x] One shared column-parameterized distribution function; target columns
       per stage in `base.yaml`
-- [ ] Overlaid old-vs-new plots for cluster area and UPRNs per cluster,
+- [x] Overlaid old-vs-new plots for cluster area and UPRNs per cluster,
       embedded in the report
-- [ ] Unit tests cover at least one genuine geometry-drift case and one
-      stable case
+- [x] Unit tests cover at least one genuine geometry-drift case and one
+      stable case (a cluster merge vs identical versions; acceptance runs
+      against Plymouth 20260806 vs 20260812 exercised both stages on S3)


### PR DESCRIPTION
> **Stacked PR, 2 of 3.** Base is `472_addGeometryDeltaChecks` (PR #486, 1/3), not `dev`. Please review only this PR's 4 commits.

# Description

1/3 added the geometry checks. This slice makes them visible in the report and plots them.

- **Overlaid old-vs-new histograms**, one PNG per distribution, saved next to the markdown report and embedded in it. Both versions share bins so the shapes are actually comparable. Filenames share the report's stem: `{stage}_{la}_{old}_vs_{new}_{column}.png`.
- **A "Cluster geometry" section** per geometry-bearing stage, stating the CRS (EPSG:27700) and units (m²), plus a section per distribution.
- **A simplified-geometry caveat** in the `compute_contextual_features` section. That stage's geojson holds the same clusters reprojected to EPSG:4326 *and* simplified; areas are measured after reprojecting back to EPSG:27700, so they are approximate. Without the caveat a reader would chase simplification artefacts as real drift.

Part of #472.

# Instructions for Reviewer

## Please pay special attention to

- **The caveat wording.** Is reporting an approximate area for the contextual-features stage the right call at all, and does the wording make the limitation clear to someone who has not read this PR?
- **Graceful degradation.** If a configured column is missing, or one version has no values, the plot is skipped with a warning and the stats section notes the gap. Is skipping right here, rather than failing loudly?

## How to test

```bash
uv run python -m pytest asf_heat_pump_suitability/pipeline/validate/tests/test_compare_versions.py -v
```

Green, no credentials needed. 11 new test functions here, covering section rendering and the plotting arm.

For a real report :

```bash
uv run python -m asf_heat_pump_suitability.pipeline.validate.compare_versions \
   --stage cluster --local_authority east_lothian

uv run python -m asf_heat_pump_suitability.pipeline.validate.compare_versions \
   --stage compute_contextual_features --local_authority east_lothian
```

Then open the markdown and check: a cluster geometry section for both the `cluster` and `compute_contextual_features` stages; CRS and units stated; the caveat line in the contextual-features section only; the PNGs present next to the report and rendering in preview.

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
- [x] I have explained this PR above
- [ ] I have requested a code review — draft while the branches underneath are still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
