### PR TITLE
493 `add_features.py`: bugfix remove `detail` from params

### DIFF
--- a/asf_heat_pump_suitability/pipeline/run/add_features.py
+++ b/asf_heat_pump_suitability/pipeline/run/add_features.py
@@ -350,6 +350,5 @@ if __name__ == "__main__":
             params={
                 "local_authorities": args.local_authorities,
                 "release_date": release_date,
-                "detail": args.detail,
             },
         )


### PR DESCRIPTION
---

# Description

`args.detail` was kept by mistake in `add_features.py`. This PR removes it.

Fixes #493 