### PR TITLE
499 fix bug due to lack of default in cluster.py's map_df_uprns_to_clusters()

### DIFF
--- a/asf_heat_pump_suitability/pipeline/cluster/cluster.py
+++ b/asf_heat_pump_suitability/pipeline/cluster/cluster.py
@@ -796,11 +796,12 @@ def map_df_uprns_to_clusters(
         "cluster_id"
     ].to_dict()
     uprns_df = uprns_df.with_columns(
-        pl.col(building_id).replace_strict(building_cluster_mapping).alias("cluster_id")
+        pl.col(building_id)
+        .replace_strict(building_cluster_mapping, default=None)
+        .alias("cluster_id")
     )
 
     return uprns_df
-
 
 
 def parse_arguments() -> argparse.Namespace:


### PR DESCRIPTION
---

# Description

Fix bug due to lack of default in cluster.py's `map_df_uprns_to_clusters()`

Fixes #499 

Question: is there a reason for this to be happening now and not have been a problem before? Is adding the default just masking an existing problem? The number of properties without mapping is low.